### PR TITLE
Unify time formatting with locale fallback across calendar views

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1001,7 +1001,9 @@ class SkylightCalendarCard extends HTMLElement {
       day_styles: normalizedDayStyles, // Per-day styling rules
       hide_times_for_calendars: config.hide_times_for_calendars || [], // Hide times in schedule view for specific calendars
       show_current_time_bar: config.show_current_time_bar || false, // Show a "now" indicator in schedule view
-      use_24hr_schedule: config.use_24hr_schedule ?? false, // Use 24-hour time notation in schedule view
+      use_24hr_schedule: Object.prototype.hasOwnProperty.call(config, 'use_24hr_schedule')
+        ? config.use_24hr_schedule
+        : undefined, // If set, force 12/24-hour notation; otherwise defer to locale defaults
       header_color: normalizedHeaderColor !== undefined ? normalizedHeaderColor : 'var(--primary-color)', // Custom header background color/gradient
       header_text_color: normalizedHeaderTextColor, // Optional custom header text color (auto contrast by default)
       header_background_transparent: normalizedHeaderBackgroundOpacity >= 100, // Legacy alias for full header transparency
@@ -6052,12 +6054,22 @@ class SkylightCalendarCard extends HTMLElement {
     return this.formatScheduleTime(date);
   }
 
-  formatScheduleTime(date) {
-    return new Intl.DateTimeFormat(this.getLocale(), {
+  getTimeFormatOptions() {
+    const formatOptions = {
       hour: 'numeric',
-      minute: '2-digit',
-      hour12: !this._config.use_24hr_schedule
-    }).format(date);
+      minute: '2-digit'
+    };
+
+    const config = this._config || {};
+    if (Object.prototype.hasOwnProperty.call(config, 'use_24hr_schedule')) {
+      formatOptions.hour12 = !config.use_24hr_schedule;
+    }
+
+    return formatOptions;
+  }
+
+  formatScheduleTime(date) {
+    return new Intl.DateTimeFormat(this.getLocale(), this.getTimeFormatOptions()).format(date);
   }
 
   getMonthWeekRowCount() {
@@ -9123,7 +9135,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   formatTime(date) {
-    return new Intl.DateTimeFormat(this.getLocale(), { hour: 'numeric', minute: '2-digit' }).format(date);
+    return new Intl.DateTimeFormat(this.getLocale(), this.getTimeFormatOptions()).format(date);
   }
 
   parseTimeValue(value) {

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1001,9 +1001,6 @@ class SkylightCalendarCard extends HTMLElement {
       day_styles: normalizedDayStyles, // Per-day styling rules
       hide_times_for_calendars: config.hide_times_for_calendars || [], // Hide times in schedule view for specific calendars
       show_current_time_bar: config.show_current_time_bar || false, // Show a "now" indicator in schedule view
-      use_24hr_schedule: Object.prototype.hasOwnProperty.call(config, 'use_24hr_schedule')
-        ? config.use_24hr_schedule
-        : undefined, // If set, force 12/24-hour notation; otherwise defer to locale defaults
       header_color: normalizedHeaderColor !== undefined ? normalizedHeaderColor : 'var(--primary-color)', // Custom header background color/gradient
       header_text_color: normalizedHeaderTextColor, // Optional custom header text color (auto contrast by default)
       header_background_transparent: normalizedHeaderBackgroundOpacity >= 100, // Legacy alias for full header transparency
@@ -1043,6 +1040,9 @@ class SkylightCalendarCard extends HTMLElement {
       event_styles: normalizedEventStyles,
       day_styles: normalizedDayStyles
     };
+    if (!Object.prototype.hasOwnProperty.call(config, 'use_24hr_schedule')) {
+      delete this._config.use_24hr_schedule; // Preserve locale-based hour cycle defaults when unset
+    }
     this._viewMode = this._config.default_view;
     this.applyThemeMode(this._config.color_scheme);
     this._hiddenCalendars = new Set(


### PR DESCRIPTION
### Motivation

- Time is rendered in many places (month/week/agenda/schedule views, modals, header sensor output) and formatting was inconsistent between schedule and non-schedule paths.
- The `use_24hr_schedule` config previously forced a behavior even when not explicitly provided, preventing proper locale-based defaults.
- The change centralizes time formatting so 12/24-hour behavior is applied consistently across all views and modals.

### Description

- Added a shared `getTimeFormatOptions()` helper to centralize time formatting options used across the card.
- Updated `formatScheduleTime()` and `formatTime()` to use `getTimeFormatOptions()` so all displayed times use the same logic.
- Changed config normalization for `use_24hr_schedule` to only force hour-cycle behavior when the key is explicitly present in the config, otherwise leaving it `undefined` so `Intl.DateTimeFormat` falls back to locale defaults.
- Preserves precedence: explicit `use_24hr_schedule` if provided, otherwise defer to `locale`/resolved language.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0253e11048331bffefbe04ce63ffd)