### PR TITLE
Support negated day_styles condition `!has_event`

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1327,10 +1327,18 @@ class SkylightCalendarCard extends HTMLElement {
       .map((rule) => {
         if (!rule || typeof rule !== 'object') return null;
 
-        const condition = String(rule.condition || '').trim().toLowerCase();
+        const rawCondition = String(rule.condition || '').trim().toLowerCase();
+        if (!rawCondition) return null;
+
+        const isNegatedCondition = rawCondition.startsWith('!');
+        const condition = isNegatedCondition ? rawCondition.slice(1) : rawCondition;
         if (!condition) return null;
 
         if (!['today', 'past', 'future', 'weekend', 'weekday', 'has_event'].includes(condition)) {
+          return null;
+        }
+
+        if (isNegatedCondition && condition !== 'has_event') {
           return null;
         }
 
@@ -1339,6 +1347,7 @@ class SkylightCalendarCard extends HTMLElement {
         }
 
         const normalized = { condition };
+        if (isNegatedCondition) normalized.negate = true;
 
         const normalizedBackground = String(rule.background || '').trim().toLowerCase() === 'auto'
           ? 'auto'
@@ -1627,6 +1636,10 @@ class SkylightCalendarCard extends HTMLElement {
       if (rule.condition === 'has_event') {
         matchedEvent = this.findMatchingDayStyleEvent(rule, dayEvents);
         matches = !!matchedEvent;
+        if (rule.negate) {
+          matches = !matches;
+          if (!matches) matchedEvent = null;
+        }
       }
 
       if (!matches) return;


### PR DESCRIPTION
### Motivation
- Allow day styling to target days where a specific calendar has no matching events (example: mark days off when `calendar.work` has no events).
- Keep existing `has_event` behavior but add a straightforward syntax (`!has_event`) for negation to improve configuration ergonomics.

### Description
- Parse `condition` values with a leading `!` in `normalizeDayStyles`, normalize to the base condition and set a `negate` flag on the rule when detected in `skylight-calendar-card.js`.
- Only allow negation for the `has_event` condition and validate that `calendar` is still required for `has_event` rules.
- Apply the negation during evaluation in `getDayStyleConfig` by flipping `matches` when `rule.negate` is present and clearing `matchedEvent` when the negated rule does not match.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f028f353c483319e78ee757ebede92)