### PR TITLE
Add configurable per-calendar header badge hiding

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1017,6 +1017,7 @@ class SkylightCalendarCard extends HTMLElement {
       combine_calendars_width: config.combine_calendars_width ?? 18, // Stripe width in pixels for combined calendar zebra styling
       enable_event_management: config.enable_event_management !== false, // Enable create/edit/delete
       readonly_calendars: config.readonly_calendars || [], // Calendars that should not allow modifications
+      hide_badge_calendars: config.hide_badge_calendars || [], // Calendars whose badges should be hidden from the header
       language: config.language || null, // Language code for translations (e.g., 'en', 'de', 'fr')
       locale: config.locale || null, // Locale override for date/time formatting (e.g., 'en-US')
       color_scheme: this.normalizeDefaultDarkMode(config.color_scheme), // Controls theme mode on initial load: auto, light, or dark
@@ -5042,10 +5043,13 @@ class SkylightCalendarCard extends HTMLElement {
   renderCalendarBadgesInline() {
     if (!this._config.entities || this._config.entities.length === 0) return '';
     const hideCalendarNames = !!this._config.hide_calendar_names;
+    const hiddenBadgeCalendars = new Set(this._config.hide_badge_calendars || []);
+    const visibleBadgeEntities = this._config.entities.filter((entityId) => !hiddenBadgeCalendars.has(entityId));
+    if (visibleBadgeEntities.length === 0) return '';
 
     return `
       <div class="calendar-badges-inline">
-        ${this._config.entities.map((entityId, index) => {
+        ${visibleBadgeEntities.map((entityId, index) => {
           const name = this.getCalendarName(entityId);
           const color = this.normalizeSingleColor(this._config.colors[entityId] || this.getDefaultColor(index));
           const isHidden = this._hiddenCalendars.has(entityId);
@@ -5585,11 +5589,14 @@ class SkylightCalendarCard extends HTMLElement {
   renderCalendarBadges() {
     if (!this._config.entities || this._config.entities.length === 0) return '';
     const hideCalendarNames = !!this._config.hide_calendar_names;
+    const hiddenBadgeCalendars = new Set(this._config.hide_badge_calendars || []);
+    const visibleBadgeEntities = this._config.entities.filter((entityId) => !hiddenBadgeCalendars.has(entityId));
+    if (visibleBadgeEntities.length === 0) return '';
 
     return `
       <div class="calendar-badges-container">
         <div class="calendar-badges">
-          ${this._config.entities.map((entityId, index) => {
+          ${visibleBadgeEntities.map((entityId, index) => {
             const name = this.getCalendarName(entityId);
             const color = this.normalizeSingleColor(this._config.colors[entityId] || this.getDefaultColor(index));
             const isHidden = this._hiddenCalendars.has(entityId);
@@ -10359,6 +10366,7 @@ class SkylightCalendarCardEditor extends HTMLElement {
         <label><input type="checkbox" data-field="enable_event_management" ${this._config.enable_event_management !== false ? 'checked' : ''}> Enable event management</label>
       </div>
       ${this.renderSubSection('Read-only calendars', `<div class="list-checkbox-grid">${this.renderCalendarListCheckboxes('readonly_calendars', { label: 'read-only calendars' })}</div>`)}
+      ${this.renderSubSection('Hide header badges for calendars', `<div class="list-checkbox-grid">${this.renderCalendarListCheckboxes('hide_badge_calendars', { label: 'hidden header badges calendars' })}</div>`)}
     `);
 
     const localeSection = this.renderSection('Localization & preferences', `

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -5044,14 +5044,16 @@ class SkylightCalendarCard extends HTMLElement {
     if (!this._config.entities || this._config.entities.length === 0) return '';
     const hideCalendarNames = !!this._config.hide_calendar_names;
     const hiddenBadgeCalendars = new Set(this._config.hide_badge_calendars || []);
-    const visibleBadgeEntities = this._config.entities.filter((entityId) => !hiddenBadgeCalendars.has(entityId));
+    const visibleBadgeEntities = this._config.entities
+      .map((entityId, originalIndex) => ({ entityId, originalIndex }))
+      .filter(({ entityId }) => !hiddenBadgeCalendars.has(entityId));
     if (visibleBadgeEntities.length === 0) return '';
 
     return `
       <div class="calendar-badges-inline">
-        ${visibleBadgeEntities.map((entityId, index) => {
+        ${visibleBadgeEntities.map(({ entityId, originalIndex }) => {
           const name = this.getCalendarName(entityId);
-          const color = this.normalizeSingleColor(this._config.colors[entityId] || this.getDefaultColor(index));
+          const color = this.normalizeSingleColor(this._config.colors[entityId] || this.getDefaultColor(originalIndex));
           const isHidden = this._hiddenCalendars.has(entityId);
 
           const badgeBackground = isHidden ? '#f3f4f6' : this.lightenColor(color, 0.85);
@@ -5590,15 +5592,17 @@ class SkylightCalendarCard extends HTMLElement {
     if (!this._config.entities || this._config.entities.length === 0) return '';
     const hideCalendarNames = !!this._config.hide_calendar_names;
     const hiddenBadgeCalendars = new Set(this._config.hide_badge_calendars || []);
-    const visibleBadgeEntities = this._config.entities.filter((entityId) => !hiddenBadgeCalendars.has(entityId));
+    const visibleBadgeEntities = this._config.entities
+      .map((entityId, originalIndex) => ({ entityId, originalIndex }))
+      .filter(({ entityId }) => !hiddenBadgeCalendars.has(entityId));
     if (visibleBadgeEntities.length === 0) return '';
 
     return `
       <div class="calendar-badges-container">
         <div class="calendar-badges">
-          ${visibleBadgeEntities.map((entityId, index) => {
+          ${visibleBadgeEntities.map(({ entityId, originalIndex }) => {
             const name = this.getCalendarName(entityId);
-            const color = this.normalizeSingleColor(this._config.colors[entityId] || this.getDefaultColor(index));
+            const color = this.normalizeSingleColor(this._config.colors[entityId] || this.getDefaultColor(originalIndex));
             const isHidden = this._hiddenCalendars.has(entityId);
 
             const badgeBackground = isHidden ? '#f3f4f6' : this.lightenColor(color, 0.85);


### PR DESCRIPTION
### Motivation
- Provide the ability to hide an individual calendar's header badge independently of global header badge visibility so users can suppress specific calendars from the header while keeping them available in views.
- Make the option configurable via YAML in the same style as `readonly_calendars` and expose it in the visual configurator for parity with other per-calendar settings.

### Description
- Added a new config list option `hide_badge_calendars` (default `[]`) and merged it into `this._config` so it can be set via YAML as `hide_badge_calendars`.
- Updated `renderCalendarBadgesInline()` to filter `this._config.entities` by `hide_badge_calendars` and return early when no visible badges remain so the compact header will not render an empty badge block.
- Updated `renderCalendarBadges()` with the same per-calendar filtering so the standard header view also skips configured calendars.
- Added a visual configurator subsection under the Event management section that reuses the existing list-checkbox UI via `renderCalendarListCheckboxes('hide_badge_calendars', ...)` so users can toggle badge hiding in the editor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f182a85e288331aebad5ae186ddffc)