### PR TITLE
Fix compact-height gap at bottom of calendar card

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -2158,7 +2158,7 @@ class SkylightCalendarCard extends HTMLElement {
       containerTopInViewport ?? this.getBoundingClientRect().top,
       0
     );
-    const bottomSpacing = 24;
+    const bottomSpacing = 0;
     const minimumHeight = 180;
 
     return Math.max(minimumHeight, Math.floor(viewportHeight - containerTop - bottomSpacing));
@@ -2170,7 +2170,7 @@ class SkylightCalendarCard extends HTMLElement {
     const resolvedMaxHeight = maxHeight || this.getCompactMaxHeight();
     if (!resolvedMaxHeight) return '';
 
-    return `max-height: ${resolvedMaxHeight}px; overflow-y: auto;`;
+    return `height: ${resolvedMaxHeight}px; max-height: ${resolvedMaxHeight}px; overflow-y: auto;`;
   }
 
   preserveAgendaScrollForNextRender() {


### PR DESCRIPTION
### Motivation
- The calendar card when used with `compact_height: true` left a small, variable gap at the bottom because the container only used `max-height` and the compact viewport calculation subtracted an extra hardcoded bottom spacing.

### Description
- Change `getCompactMaxHeight()` to remove the extra `24px` bottom spacing (`24` → `0`) so the available viewport height is not artificially reduced in `skylight-calendar-card.js`.
- Make `getCompactContainerStyle()` return an explicit `height` (while keeping `max-height`) so the compact container fills the resolved viewport height instead of collapsing shorter when content height varies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2ded1a01c833191e158789f70d4ed)