### PR TITLE
Upgrade workflow actions to v5 and only upload artifacts on failure

### DIFF
--- a/.github/workflows/playwright-visual.yml
+++ b/.github/workflows/playwright-visual.yml
@@ -9,15 +9,15 @@ jobs:
   visual-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
       - run: npm ci
       - run: npx playwright install --with-deps chromium
       - run: npm run test:visual
-      - uses: actions/upload-artifact@v4
-        if: always()
+      - uses: actions/upload-artifact@v5
+        if: failure()
         with:
           name: diff-images
           path: test-results/


### PR DESCRIPTION
### Motivation
- Upgrade GitHub Actions to current major versions and avoid uploading artifact diffs on successful runs to reduce noise and storage usage.

### Description
- Updated `.github/workflows/playwright-visual.yml` to use `actions/checkout@v5`, `actions/setup-node@v5`, and `actions/upload-artifact@v5`, and changed the artifact upload condition from `always()` to `failure()` so diff images are only saved for failed runs.

### Testing
- The Playwright visual test workflow (`npm ci`, `npx playwright install --with-deps chromium`, `npm run test:visual`) was executed in CI and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6c00d3c4483318ac14dd117e99656)