### PR TITLE
Allow customizing calendar badge icon color with CSS variable

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3907,7 +3907,7 @@ class SkylightCalendarCard extends HTMLElement {
         display: flex;
         align-items: center;
         justify-content: center;
-        color: white;
+        color: var(--skylight-calendar-filter-icon-color, white);
         font-size: 11px;
         font-weight: 600;
         overflow: hidden;
@@ -3915,6 +3915,7 @@ class SkylightCalendarCard extends HTMLElement {
 
       .calendar-badge-icon ha-icon {
         --mdc-icon-size: 14px;
+        color: inherit;
       }
 
       .calendar-badge-photo img {


### PR DESCRIPTION
### Motivation

- Make the calendar badge icon color configurable instead of hardcoding white so themes or consumers can override the icon color. 

### Description

- Replace hardcoded `color: white` in `.calendar-badge-icon` with `color: var(--skylight-calendar-filter-icon-color, white)` and add `color: inherit` to `.calendar-badge-icon ha-icon` in `skylight-calendar-card.js` so nested icons inherit the badge color.

### Testing

- No automated tests were run for this small styling change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6c4e85100833180b3264b4434c0a2)