### PR TITLE
Add workflow to generate Playwright visual baselines PR

### DIFF
--- a/.github/workflows/generate-playwright-baselines-pr.yml
+++ b/.github/workflows/generate-playwright-baselines-pr.yml
@@ -1,0 +1,45 @@
+name: Generate Playwright Baselines PR
+
+on:
+  workflow_dispatch:
+
+jobs:
+  generate-baselines-pr:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+
+      - run: npm ci
+
+      - run: npx playwright install --with-deps chromium
+
+      - name: Generate/update visual baselines
+        run: npx playwright test --update-snapshots
+
+      - name: Show generated snapshot changes
+        run: |
+          git status --short
+          find playwright -path "*-snapshots/*.png" -type f | sort
+
+      - name: Create or update pull request with updated baselines
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: playwright-baselines
+          delete-branch: true
+          title: Update Playwright visual baselines
+          commit-message: Add/update Playwright visual baselines
+          body: |
+            Updates Playwright visual baseline images generated in GitHub Actions.
+
+            Review the changed PNGs before merging.
+          add-paths: |
+            playwright/**/*-snapshots/*.png


### PR DESCRIPTION
### Motivation
- Provide a manual GitHub Actions workflow to regenerate and publish Playwright visual test baselines so reviewers can inspect image updates before merging.

### Description
- Add `.github/workflows/generate-playwright-baselines-pr.yml` which defines a `workflow_dispatch` job named `generate-baselines-pr` that runs on `ubuntu-latest`.
- Install Node 20 and project dependencies with `actions/setup-node@v5` and `npm ci`, then install Playwright Chromium with `npx playwright install --with-deps chromium`.
- Run visual tests to update snapshots with `npx playwright test --update-snapshots` and list any generated `*-snapshots/*.png` files.
- Use `peter-evans/create-pull-request@v7` to create or update a `playwright-baselines` pull request containing changed baseline PNGs.

### Testing
- Ran `git diff --check -- .github/workflows/generate-playwright-baselines-pr.yml` which returned no issues.
- Verified the workflow file contents were created and printed for review using standard file inspection commands, and the new file was added to the repository index successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fabe371f00833193adcc3ef8b59348)