### PR TITLE
Fix agenda view: clickable day rows and scroll preservation on save

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -7648,6 +7648,23 @@ class SkylightCalendarCard extends HTMLElement {
       });
     });
 
+    // Day row click handlers (agenda view)
+    this._root.querySelectorAll('.agenda-day-row').forEach(rowEl => {
+      rowEl.addEventListener('click', (e) => {
+        // Don't open if clicking on an event
+        if (e.target.classList.contains('agenda-event') || e.target.closest('.agenda-event')) {
+          return;
+        }
+
+        if (!this._config.enable_event_management || this.getWritableCalendars().length === 0) {
+          return;
+        }
+
+        const date = new Date(rowEl.getAttribute('data-date'));
+        this.showCreateEventModal(date);
+      });
+    });
+
     // Time slot click handlers (schedule view)
     this._root.querySelectorAll('.day-time-slot').forEach(slotEl => {
       slotEl.addEventListener('click', (e) => {
@@ -8470,7 +8487,7 @@ class SkylightCalendarCard extends HTMLElement {
 
         // Refresh events
         this._lastFetch = null;
-        await this.updateEvents();
+        await this.updateEvents({ preserveScroll: this._viewMode === 'agenda' });
       } catch (error) {
         console.error('Failed to create event:', error);
         this.showFormError(errorDiv, error.message || this.t('failedCreateEvent'));
@@ -8862,7 +8879,7 @@ class SkylightCalendarCard extends HTMLElement {
 
         // Refresh events
         this._lastFetch = null;
-        await this.updateEvents();
+        await this.updateEvents({ preserveScroll: this._viewMode === 'agenda' });
       } catch (error) {
         console.error('Failed to update event:', error);
 
@@ -8874,7 +8891,7 @@ class SkylightCalendarCard extends HTMLElement {
             await this.deleteEvent(event.entityId, event.uid, event.recurrence_id);
             modal.classList.remove('show');
             this._lastFetch = null;
-            await this.updateEvents();
+            await this.updateEvents({ preserveScroll: this._viewMode === 'agenda' });
             return;
           } catch (fallbackError) {
             console.error('Safety-net create+delete fallback failed:', fallbackError);
@@ -9560,7 +9577,7 @@ class SkylightCalendarCard extends HTMLElement {
 
         // Refresh events
         this._lastFetch = null;
-        await this.updateEvents();
+        await this.updateEvents({ preserveScroll: this._viewMode === 'agenda' });
       } catch (error) {
         console.error('Failed to delete event:', error);
         this._combinedDeleteTargets = null;


### PR DESCRIPTION
## Summary

Two small, related agenda-view UX fixes I noticed using the card on a fridge tablet.

### Bug A — agenda days aren't clickable to add an event

In every other view, tapping an empty area opens the create-event modal:
- Month: `.day-cell` handler
- Schedule: `.day-time-slot` handler
- Week-standard: `[data-click-target="day-header"]` handler

`.agenda-day-row` had no equivalent binding, so on the agenda view there's no way to start a new event by tapping a date — you have to switch views or use a different surface.

**Fix:** add an `.agenda-day-row` click handler mirroring the month one. Skips clicks landing on `.agenda-event` (so existing event taps still open the event modal), respects the `enable_event_management` config flag and the writable-calendars guard, then calls `showCreateEventModal(rowDate)`.

### Bug B — saving an event in agenda view jumps scroll to top

The four mutation paths all call `await this.updateEvents()` without options:

- `skylight-calendar-card.js:8473` — create
- `skylight-calendar-card.js:8865` — edit
- `skylight-calendar-card.js:8877` — edit safety-net (create + delete fallback)
- `skylight-calendar-card.js:9563` — delete

`updateEvents` already supports a `preserveScroll` option that wires into the existing `renderPreservingAgendaScroll()` machinery (see `:2339`, `:2435`), but these call sites weren't opting in. So a user scrolled deep into the agenda would lose their place every time they saved an event.

**Fix:** pass `{ preserveScroll: this._viewMode === 'agenda' }` at all four sites. Other views are unaffected because the option is a no-op outside agenda.

## Testing

- Verified locally on Home Assistant with the patched build: agenda day-tap opens the create modal, and create/edit/delete keep the agenda scroll position across the refresh.
- No tests added — happy to add Playwright coverage if you'd like, just point me at the right baseline workflow.

## Notes

- Diff is +21/-4, no behavioural changes outside agenda view.
- Disclosing AI assistance: this PR was written with help from Claude Code (Anthropic). The bugs and fixes were verified by a human against a real HA install before submission.