### PR TITLE
Rename Skylight Calendar Card to Daylight Calendar Card with backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/hacs/integration)
-[![GitHub release](https://img.shields.io/github/release/superdingo101/skylight-calendar-card.svg)](https://github.com/superdingo101/skylight-calendar-card/releases)
-[![GitHub stars](https://img.shields.io/github/stars/superdingo101/skylight-calendar-card.svg)](https://github.com/superdingo101/skylight-calendar-card/stargazers)
-![Github All Releases](https://img.shields.io/github/downloads/superdingo101/skylight-calendar-card/total.svg)
-[![GitHub issues](https://img.shields.io/github/issues/superdingo101/skylight-calendar-card.svg)](https://github.com/superdingo101/skylight-calendar-card/issues)
-[![License](https://img.shields.io/github/license/superdingo101/skylight-calendar-card.svg)](LICENSE)
+[![GitHub release](https://img.shields.io/github/release/superdingo101/daylight-calendar-card.svg)](https://github.com/superdingo101/daylight-calendar-card/releases)
+[![GitHub stars](https://img.shields.io/github/stars/superdingo101/daylight-calendar-card.svg)](https://github.com/superdingo101/daylight-calendar-card/stargazers)
+![Github All Releases](https://img.shields.io/github/downloads/superdingo101/daylight-calendar-card/total.svg)
+[![GitHub issues](https://img.shields.io/github/issues/superdingo101/daylight-calendar-card.svg)](https://github.com/superdingo101/daylight-calendar-card/issues)
+[![License](https://img.shields.io/github/license/superdingo101/daylight-calendar-card.svg)](LICENSE)
 <a><img src="https://img.shields.io/badge/Sponsor-GitHub%20Sponsors-pink?style=for-the-badge&logo=github" alt="GithHub Sponsors" style="height: 20px !important;" ></a>
 <a><img src="https://img.shields.io/badge/Donate-Buy%20me%20a%20beer-yellow?style=for-the-badge&logo=buy-me-a-coffee" alt="Buy Me a Coffee" style="height: 20px !important;" ></a>
 
-# Skylight Calendar Card for Home Assistant
+# Daylight Calendar Card for Home Assistant
 
-A beautiful, family-friendly Lovelace calendar card inspired by the Skylight Calendar display.
+> [!IMPORTANT]
+> **Project renamed:** `skylight-calendar-card` is now `daylight-calendar-card`.
+>
+> Existing dashboard YAML using `type: custom:skylight-calendar-card` continues to work, for now. New naming and configuration examples will transition gradually.
+
+A bright, family-friendly calendar card for Home Assistant dashboards.
 
 Designed for clarity at a glance, with flexible views and deep customization.
 
@@ -56,13 +61,13 @@ Designed for clarity at a glance, with flexible views and deep customization.
 
 ### Recommended: Install via HACS
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=superdingo101&repository=skylight-calendar-card&category=frontend)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=superdingo101&repository=daylight-calendar-card&category=frontend)
 
 OR
 
 1. Open **HACS → Frontend**
 2. Click **+ Explore & Download Repositories**
-3. Search for **Skylight Calendar Card**
+3. Search for **Daylight Calendar Card**
 4. Install and refresh your dashboard
 
 👉 If you don’t have HACS yet, follow: [https://hacs.xyz/docs/use/](https://hacs.xyz/docs/use/)
@@ -76,7 +81,7 @@ OR
 <summary>Without HACS</summary>
 
 1. Download:
-   [https://raw.githubusercontent.com/superdingo101/skylight-calendar-card/refs/heads/main/skylight-calendar-card.js](https://raw.githubusercontent.com/superdingo101/skylight-calendar-card/refs/heads/main/skylight-calendar-card.js)
+   [https://raw.githubusercontent.com/superdingo101/daylight-calendar-card/refs/heads/main/skylight-calendar-card.js](https://raw.githubusercontent.com/superdingo101/daylight-calendar-card/refs/heads/main/skylight-calendar-card.js)
 2. Place in:
    `<config>/www/skylight-calendar-card.js`
 3. Add resource:
@@ -96,7 +101,7 @@ OR
 ## ⚡ Quick Start
 
 ```yaml
-type: custom:skylight-calendar-card
+type: custom:daylight-calendar-card
 title: Family Calendar
 entities:
   - calendar.family
@@ -109,7 +114,7 @@ entities:
 
 ## 📚 Documentation
 
-Skylight Calendar Card includes a visual configurator for most common options.
+Daylight Calendar Card includes a visual configurator for most common options.
 
 Some advanced features are supported by the card but must be configured in YAML.
 
@@ -131,7 +136,7 @@ Full documentation is available in the wiki:
 * Development
 
 <p align="center">
-  <a href="https://github.com/superdingo101/skylight-calendar-card/wiki">
+  <a href="https://github.com/superdingo101/daylight-calendar-card/wiki">
     <img src="https://img.shields.io/badge/Docs-Read%20the%20Wiki-blue?logo=github&style=for-the-badge" />
   </a>
 </p>
@@ -141,7 +146,7 @@ Full documentation is available in the wiki:
 ## 💡 Tips
 
 * Use multiple calendars for a shared family dashboard
-* Pair with wall-mounted tablets for a Skylight-style experience
+* Pair with wall-mounted tablets for a Daylight-style experience
 * Combine with UIX/Card Mod for advanced styling
 
 ---
@@ -164,10 +169,10 @@ Still stuck? Open an issue below
 If you need help, have ideas, or want to contribute, use the options below:
 
 <p align="center">
-  <a href="https://github.com/superdingo101/skylight-calendar-card/issues">
+  <a href="https://github.com/superdingo101/daylight-calendar-card/issues">
     <img src="https://img.shields.io/badge/GitHub-Issues-green?logo=github&style=for-the-badge" />
   </a>
-  <a href="https://github.com/superdingo101/skylight-calendar-card/discussions">
+  <a href="https://github.com/superdingo101/daylight-calendar-card/discussions">
     <img src="https://img.shields.io/badge/GitHub-Discussions-lightgrey?logo=github&style=for-the-badge" />
   </a>
   <a href="https://community.home-assistant.io/t/skylight-calendar-card-a-family-friendly-schedule-card/981221/17">

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Skylight Calendar Card",
+  "name": "Daylight Calendar Card",
   "content_in_root": true,
   "filename": "skylight-calendar-card.js",
   "render_readme": true

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -12021,10 +12021,13 @@ class SkylightCalendarCardEditor extends HTMLElement {
   }
 }
 
+class LegacySkylightCalendarCard extends SkylightCalendarCard {}
+class LegacySkylightCalendarCardEditor extends SkylightCalendarCardEditor {}
+
 customElements.define('daylight-calendar-card', SkylightCalendarCard);
 customElements.define('daylight-calendar-card-editor', SkylightCalendarCardEditor);
-customElements.define('skylight-calendar-card', SkylightCalendarCard);
-customElements.define('skylight-calendar-card-editor', SkylightCalendarCardEditor);
+customElements.define('skylight-calendar-card', LegacySkylightCalendarCard);
+customElements.define('skylight-calendar-card-editor', LegacySkylightCalendarCardEditor);
 
 window.customCards = window.customCards || [];
 window.customCards.push({

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -2973,6 +2973,7 @@ class SkylightCalendarCard extends HTMLElement {
   getStyles() {
     return `
       :host,
+      daylight-calendar-card,
       skylight-calendar-card {
         display: block;
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
@@ -10355,7 +10356,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   static async getConfigElement() {
-    return document.createElement('skylight-calendar-card-editor');
+    return document.createElement('daylight-calendar-card-editor');
   }
 }
 
@@ -12020,14 +12021,16 @@ class SkylightCalendarCardEditor extends HTMLElement {
   }
 }
 
+customElements.define('daylight-calendar-card', SkylightCalendarCard);
+customElements.define('daylight-calendar-card-editor', SkylightCalendarCardEditor);
 customElements.define('skylight-calendar-card', SkylightCalendarCard);
 customElements.define('skylight-calendar-card-editor', SkylightCalendarCardEditor);
 
 window.customCards = window.customCards || [];
 window.customCards.push({
-  type: 'skylight-calendar-card',
-  name: 'Skylight Calendar Card',
-  description: 'A beautiful calendar card inspired by Skylight Calendar',
+  type: 'daylight-calendar-card',
+  name: 'Daylight Calendar Card',
+  description: 'A bright, family-friendly calendar card for Home Assistant dashboards.',
   preview: true,
-  documentationURL: 'https://github.com/superdingo101/skylight-calendar-card'
+  documentationURL: 'https://github.com/superdingo101/daylight-calendar-card'
 });

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -14,7 +14,12 @@ class HTMLElementMock {
 global.HTMLElement = HTMLElementMock;
 global.customElements = {
   registry: new Map(),
-  define(name, ctor) { this.registry.set(name, ctor); },
+  define(name, ctor) {
+    if (this.registry.has(name) || Array.from(this.registry.values()).includes(ctor)) {
+      throw new DOMException('This name or constructor has already been registered in the registry.', 'NotSupportedError');
+    }
+    this.registry.set(name, ctor);
+  },
   get(name) { return this.registry.get(name); }
 };
 global.window = { localStorage: { getItem: () => null, setItem: () => {} }, getComputedStyle: () => ({ color: 'rgb(0, 0, 0)' }) };
@@ -25,6 +30,12 @@ global.CustomEvent = class CustomEvent {
     this.detail = init.detail;
     this.bubbles = !!init.bubbles;
     this.composed = !!init.composed;
+  }
+};
+global.DOMException = global.DOMException || class DOMException extends Error {
+  constructor(message, name) {
+    super(message);
+    this.name = name;
   }
 };
 
@@ -53,8 +64,12 @@ function makeCard(config = { entities: ['calendar.family'] }) {
 
 
 test('registers daylight custom element while retaining skylight compatibility', () => {
-  assert.equal(DaylightCard, Card);
-  assert.equal(customElements.get('daylight-calendar-card-editor'), customElements.get('skylight-calendar-card-editor'));
+  assert.notEqual(DaylightCard, Card);
+  assert.equal(Card.prototype instanceof DaylightCard, true);
+  const DaylightEditor = customElements.get('daylight-calendar-card-editor');
+  const LegacyEditor = customElements.get('skylight-calendar-card-editor');
+  assert.notEqual(DaylightEditor, LegacyEditor);
+  assert.equal(LegacyEditor.prototype instanceof DaylightEditor, true);
   assert.deepEqual(window.customCards.at(-1), {
     type: 'daylight-calendar-card',
     name: 'Daylight Calendar Card',

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -39,6 +39,7 @@ after(() => {
 require('./skylight-calendar-card.js');
 
 const Card = customElements.get('skylight-calendar-card');
+const DaylightCard = customElements.get('daylight-calendar-card');
 const originalCardRender = Card.prototype.render;
 Card.prototype.render = function() {};
 Card.prototype.renderPreservingAgendaScroll = function() {};
@@ -49,6 +50,19 @@ function makeCard(config = { entities: ['calendar.family'] }) {
   card.setConfig(config);
   return card;
 }
+
+
+test('registers daylight custom element while retaining skylight compatibility', () => {
+  assert.equal(DaylightCard, Card);
+  assert.equal(customElements.get('daylight-calendar-card-editor'), customElements.get('skylight-calendar-card-editor'));
+  assert.deepEqual(window.customCards.at(-1), {
+    type: 'daylight-calendar-card',
+    name: 'Daylight Calendar Card',
+    description: 'A bright, family-friendly calendar card for Home Assistant dashboards.',
+    preview: true,
+    documentationURL: 'https://github.com/superdingo101/daylight-calendar-card'
+  });
+});
 
 function recurrenceCases() {
   return [


### PR DESCRIPTION
### Motivation

- Rebrand the integration from `skylight-calendar-card` to `daylight-calendar-card` while preserving existing dashboards and configuration.
- Ensure users can transition gradually by keeping compatibility with the original `skylight-calendar-card` custom element and resources.

### Description

- Updated `README.md` to replace occurrences of `Skylight Calendar Card` with `Daylight Calendar Card`, adjusted examples, links, and installation instructions to the new name and repository URLs.
- Updated `hacs.json` to set the package `name` to `Daylight Calendar Card` while leaving the shipped filename unchanged.
- Added `daylight-calendar-card` and `daylight-calendar-card-editor` custom element registrations and updated `window.customCards` to advertise the new `type`, while retaining the original `skylight-` custom element registrations for compatibility.
- Added the `daylight-calendar-card` host selector to the component styles and changed `getConfigElement` to return the new editor element name to support both old and new identifiers.

### Testing

- Ran unit tests with `npm test` and the test suite completed successfully.
- Added a unit test `registers daylight custom element while retaining skylight compatibility` which passed, confirming both new and legacy registrations and the updated `window.customCards` entry.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd6e86de2c8331a7af4b4725319f97)