### PR TITLE
Add header control visibility options

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1241,7 +1241,10 @@ class SkylightCalendarCard extends HTMLElement {
       hide_year: config.hide_year || false, // Hide year in header period label
       hide_calendars: config.hide_calendars || false, // Hide calendar badges from header area
       hide_calendar_names: config.hide_calendar_names || false, // Header calendar badges: show icons only
-      hide_controls: config.hide_controls || false, // Hide header controls (add/view/theme/navigation)
+      hide_controls: config.hide_controls || false, // Hide all header controls (add/view/theme/navigation)
+      hide_navigation_buttons: config.hide_navigation_buttons || false, // Hide previous/next/today header navigation buttons
+      hide_add_event_button: config.hide_add_event_button || false, // Hide add event button from header controls
+      hide_view_selector: config.hide_view_selector || false, // Hide view drop-down selector from header controls
       hide_dark_mode_toggle: config.hide_dark_mode_toggle || false, // Hide dark mode toggle from header controls
       show_dashboard_nav_button: config.show_dashboard_nav_button || false, // Show square dashboard navigation button at header left
       header_dashboard_path: this.normalizeDashboardPath(config.header_dashboard_path), // Dashboard path for optional header navigation button
@@ -5488,7 +5491,7 @@ class SkylightCalendarCard extends HTMLElement {
 
   renderStandardHeader() {
     const writableCalendars = this.getWritableCalendars();
-    const canAddEvents = this._config.enable_event_management && writableCalendars.length > 0;
+    const canAddEvents = this._config.enable_event_management && writableCalendars.length > 0 && !this._config.hide_add_event_button;
     const shouldShowControls = !this._config.hide_controls;
 
     return `
@@ -5502,10 +5505,10 @@ class SkylightCalendarCard extends HTMLElement {
             ${canAddEvents ? `<button class="add-event-button" id="add-event-btn"><span class="icon">+</span>${this.t('addEvent')}</button>` : ''}
             ${this.renderThemeToggle()}
             <div class="period-controls">
-              <button class="nav-button" id="prev-period" ${this.shouldDisablePreviousNavigation() ? 'disabled' : ''}>‹</button>
+              ${this.renderPeriodNavigationButtons('previous')}
               <div class="month-year">${this.getPeriodLabel()}</div>
-              <button class="nav-button" id="next-period">›</button>
-              <button class="today-button" id="today">${this.t('today')}</button>
+              ${this.renderPeriodNavigationButtons('next')}
+              ${this.renderPeriodNavigationButtons('today')}
             </div>
             ${this.renderViewModeButtons()}
           </div>
@@ -5516,7 +5519,7 @@ class SkylightCalendarCard extends HTMLElement {
 
   renderCompactHeader() {
     const writableCalendars = this.getWritableCalendars();
-    const canAddEvents = this._config.enable_event_management && writableCalendars.length > 0;
+    const canAddEvents = this._config.enable_event_management && writableCalendars.length > 0 && !this._config.hide_add_event_button;
     const shouldShowCalendars = !this._config.hide_calendars;
     const shouldShowControls = !this._config.hide_controls;
 
@@ -5530,10 +5533,10 @@ class SkylightCalendarCard extends HTMLElement {
         ${shouldShowControls ? `
           <div class="header-controls compact-header-controls">
             <div class="compact-period-controls">
-              <button class="nav-button" id="prev-period" ${this.shouldDisablePreviousNavigation() ? 'disabled' : ''}>‹</button>
+              ${this.renderPeriodNavigationButtons('previous')}
               <div class="month-year">${this.getPeriodLabel()}</div>
-              <button class="nav-button" id="next-period">›</button>
-              <button class="today-button" id="today">${this.t('today')}</button>
+              ${this.renderPeriodNavigationButtons('next')}
+              ${this.renderPeriodNavigationButtons('today')}
             </div>
             ${canAddEvents ? `<button class="compact-add-event-button" id="add-event-btn" aria-label="${this.t('addEvent')}" title="${this.t('addEvent')}">+</button>` : ''}
             ${this.renderThemeToggle()}
@@ -5586,7 +5589,27 @@ class SkylightCalendarCard extends HTMLElement {
     return `<button class="dashboard-nav-button" id="header-dashboard-btn" aria-label="${this.t('openDashboard')}" title="${this.t('openDashboard')}">⌂</button>`;
   }
 
+  renderPeriodNavigationButtons(buttonType) {
+    if (this._config.hide_navigation_buttons) return '';
+
+    if (buttonType === 'previous') {
+      return `<button class="nav-button" id="prev-period" ${this.shouldDisablePreviousNavigation() ? 'disabled' : ''}>‹</button>`;
+    }
+
+    if (buttonType === 'next') {
+      return '<button class="nav-button" id="next-period">›</button>';
+    }
+
+    if (buttonType === 'today') {
+      return `<button class="today-button" id="today">${this.t('today')}</button>`;
+    }
+
+    return '';
+  }
+
   renderViewModeButtons() {
+    if (this._config.hide_view_selector) return '';
+
     return `
       <div class="view-mode-buttons">
         <select class="view-mode-select" id="view-mode-select" aria-label="Select calendar view">
@@ -10349,6 +10372,9 @@ class SkylightCalendarCard extends HTMLElement {
       hide_calendars: false,
       hide_year: false,
       hide_controls: false,
+      hide_navigation_buttons: false,
+      hide_add_event_button: false,
+      hide_view_selector: false,
       hide_dark_mode_toggle: false,
       show_dashboard_nav_button: false,
       header_dashboard_path: null,
@@ -11013,7 +11039,10 @@ class SkylightCalendarCardEditor extends HTMLElement {
         <label><input type="checkbox" data-field="hide_year" ${this._config.hide_year ? 'checked' : ''}> Hide year in header period label</label>
         <label><input type="checkbox" data-field="hide_calendars" ${this._config.hide_calendars ? 'checked' : ''}> Hide calendar badges</label>
         <label><input type="checkbox" data-field="hide_calendar_names" ${this._config.hide_calendar_names ? 'checked' : ''}> Header badges: hide calendar names</label>
-        <label><input type="checkbox" data-field="hide_controls" ${this._config.hide_controls ? 'checked' : ''}> Hide header controls</label>
+        <label><input type="checkbox" data-field="hide_controls" ${this._config.hide_controls ? 'checked' : ''}> Hide all header controls</label>
+        <label><input type="checkbox" data-field="hide_navigation_buttons" ${this._config.hide_navigation_buttons ? 'checked' : ''}> Hide previous/next and today buttons</label>
+        <label><input type="checkbox" data-field="hide_add_event_button" ${this._config.hide_add_event_button ? 'checked' : ''}> Hide add event button</label>
+        <label><input type="checkbox" data-field="hide_view_selector" ${this._config.hide_view_selector ? 'checked' : ''}> Hide view selector</label>
         <label><input type="checkbox" data-field="show_dashboard_nav_button" ${this._config.show_dashboard_nav_button ? 'checked' : ''}> Show left dashboard navigation button</label>
       </div>
       ${this._config.show_dashboard_nav_button ? `

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -98,6 +98,7 @@ test('getStubConfig includes key configuration defaults', () => {
     'event_calendar_friendly_name', 'event_title_prefix', 'event_color_mode',
     'event_neutral_background', 'event_tint_opacity', 'event_color_bar_width', 'combine_style',
     'combine_background', 'hide_calendars', 'hide_year', 'hide_controls',
+    'hide_navigation_buttons', 'hide_add_event_button', 'hide_view_selector',
     'hide_dark_mode_toggle', 'show_dashboard_nav_button', 'header_dashboard_path',
     'header_weather_sensor', 'color_scheme', 'enable_event_management'
   ];
@@ -115,6 +116,9 @@ test('setConfig applies visual layout and styling options', () => {
     hide_calendars: true,
     hide_calendar_names: true,
     hide_controls: true,
+    hide_navigation_buttons: true,
+    hide_add_event_button: true,
+    hide_view_selector: true,
     hide_dark_mode_toggle: true,
     show_dashboard_nav_button: true,
     header_dashboard_path: 'lovelace-mobile',
@@ -161,6 +165,9 @@ test('setConfig applies visual layout and styling options', () => {
   assert.equal(card._config.hide_calendars, true);
   assert.equal(card._config.hide_calendar_names, true);
   assert.equal(card._config.hide_controls, true);
+  assert.equal(card._config.hide_navigation_buttons, true);
+  assert.equal(card._config.hide_add_event_button, true);
+  assert.equal(card._config.hide_view_selector, true);
   assert.equal(card._config.hide_dark_mode_toggle, true);
   assert.equal(card._config.show_dashboard_nav_button, true);
   assert.equal(card._config.header_dashboard_path, '/lovelace-mobile');
@@ -273,6 +280,48 @@ test('calendar render includes header controls and modal container', () => {
   assert.match(html, /id="next-period"/);
   assert.match(html, /id="today"/);
   assert.match(html, /id="event-modal"/);
+});
+
+test('hide_navigation_buttons hides previous, next, and today controls only', () => {
+  const card = new Card();
+  card._hass = { states: {}, locale: { language: 'en' }, language: 'en', themes: { darkMode: false } };
+  card.setConfig({ entities: ['calendar.family'], hide_navigation_buttons: true });
+
+  originalCardRender.call(card);
+  const html = card._root.innerHTML;
+
+  assert.doesNotMatch(html, /id="prev-period"/);
+  assert.doesNotMatch(html, /id="next-period"/);
+  assert.doesNotMatch(html, /id="today"/);
+  assert.match(html, /class="month-year"/);
+  assert.match(html, /id="view-mode-select"/);
+});
+
+test('hide_add_event_button hides add event control only', () => {
+  const card = new Card();
+  card._hass = { states: {}, locale: { language: 'en' }, language: 'en', themes: { darkMode: false } };
+  card.setConfig({ entities: ['calendar.family'], enable_event_management: true, hide_add_event_button: true });
+  card._calendarCapabilities = { 'calendar.family': { canCreate: true, isReadonly: false } };
+
+  originalCardRender.call(card);
+  const html = card._root.innerHTML;
+
+  assert.doesNotMatch(html, /id="add-event-btn"/);
+  assert.match(html, /id="prev-period"/);
+  assert.match(html, /id="view-mode-select"/);
+});
+
+test('hide_view_selector hides view drop-down selector only', () => {
+  const card = new Card();
+  card._hass = { states: {}, locale: { language: 'en' }, language: 'en', themes: { darkMode: false } };
+  card.setConfig({ entities: ['calendar.family'], hide_view_selector: true });
+
+  originalCardRender.call(card);
+  const html = card._root.innerHTML;
+
+  assert.doesNotMatch(html, /id="view-mode-select"/);
+  assert.match(html, /id="prev-period"/);
+  assert.match(html, /id="today"/);
 });
 
 test('header button listeners invoke expected actions', () => {


### PR DESCRIPTION
### Motivation
- Provide finer-grained control over which header controls are shown so consumers can hide only navigation, the add-event control, or the view selector without removing all header controls via `hide_controls`.
- Surface these options in the visual editor and default stub so they are discoverable and editable via the card editor.

### Description
- Added three boolean config options: `hide_navigation_buttons`, `hide_add_event_button`, and `hide_view_selector` to `skylight-calendar-card.js` and the stub returned by `getStubConfig()`.
- Updated header rendering to respect the new flags by: changing `canAddEvents` to honor `hide_add_event_button`, adding `renderPeriodNavigationButtons(buttonType)` to conditionally render previous/next/today based on `hide_navigation_buttons`, and gating `renderViewModeButtons()` on `hide_view_selector`.
- Exposed the new options in the visual editor markup so they appear as checkboxes in the editor UI.
- Added unit tests in `skylight-calendar-card.test.js` that validate the new stub keys, that `setConfig` preserves the new flags, and three render tests that assert hiding each new control behaves as expected.

### Testing
- Ran `node --check skylight-calendar-card.js` to validate syntax and the file check completed successfully.
- Ran `npm test` (which executes `node --test skylight-calendar-card.test.js`) and all tests passed (`66` passing tests at time of run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffc2c0e4d08331926528a72d3c7652)