### PR TITLE
Add weather forecast to agenda view

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3725,7 +3725,8 @@ class SkylightCalendarCard extends HTMLElement {
       }
 
       .week-day-forecast,
-      .week-standard-day-forecast {
+      .week-standard-day-forecast,
+      .agenda-day-forecast {
         display: inline-flex;
         align-items: center;
         justify-content: center;
@@ -3932,6 +3933,18 @@ class SkylightCalendarCard extends HTMLElement {
         font-weight: 700;
         color: #111827;
         margin-top: 4px;
+      }
+
+      .agenda-day-forecast {
+        margin-top: 6px;
+      }
+
+      .agenda-day-forecast .forecast-condition ha-icon {
+        --mdc-icon-size: 18px;
+      }
+
+      .agenda-day-forecast .forecast-temperatures {
+        font-size: 11px;
       }
 
       .agenda-day-row.today .agenda-day-label {
@@ -5999,6 +6012,7 @@ class SkylightCalendarCard extends HTMLElement {
           <div class="agenda-day-label">
             <div class="agenda-day-weekday">${dayNames[date.getDay()]}</div>
             <div class="agenda-day-date">${date.getDate()}</div>
+            ${this.renderDayForecast(date, 'agenda')}
           </div>
           <div class="agenda-day-events">
             ${events.map(event => {
@@ -10306,7 +10320,9 @@ class SkylightCalendarCard extends HTMLElement {
       ? 'week-standard-day-forecast'
       : viewMode === 'month'
         ? 'month-day-forecast'
-        : 'week-day-forecast';
+        : viewMode === 'agenda'
+          ? 'agenda-day-forecast'
+          : 'week-day-forecast';
 
     return `
       <div class="${forecastClass}">

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -408,6 +408,38 @@ test('weather renders Home Assistant mdi icons instead of emoji glyphs', () => {
   assert.doesNotMatch(forecastHtml, /☀️|⛅/);
 });
 
+test('agenda view renders daily weather forecast', () => {
+  const card = makeCard({
+    entities: ['calendar.family'],
+    default_view: 'agenda',
+    header_weather_sensor: 'weather.home'
+  });
+  card._viewMode = 'agenda';
+  card._events = [];
+  card.getAgendaEventMinHeight = () => '68px';
+  card._hass = {
+    states: {
+      'weather.home': {
+        state: 'sunny',
+        attributes: {
+          forecast: [
+            { datetime: '2026-05-14T12:00:00Z', condition: 'rainy', temperature: 18, templow: 9 }
+          ]
+        }
+      }
+    }
+  };
+  card._agendaStartDate = new Date('2026-05-14T00:00:00Z');
+  card._agendaEndDate = new Date('2026-05-14T23:59:59Z');
+
+  const html = card.renderAgenda();
+
+  assert.match(html, /class="agenda-day-forecast"/);
+  assert.match(html, /<ha-icon icon="mdi:weather-rainy"><\/ha-icon>/);
+  assert.match(html, /<span class="forecast-temp-high">18°<\/span>/);
+  assert.match(html, /<span class="forecast-temp-low">9°<\/span>/);
+});
+
 test('hide_navigation_buttons hides previous, next, and today controls only', () => {
   const card = new Card();
   card._hass = { states: {}, locale: { language: 'en' }, language: 'en', themes: { darkMode: false } };


### PR DESCRIPTION
### Motivation
- Surface the same daily weather forecast available in month/week/schedule views inside the agenda view so users see per-day forecast inline with agenda entries.

### Description
- Render the forecast inside each agenda day label by calling `this.renderDayForecast(date, 'agenda')` in `renderAgenda`.
- Extend `renderDayForecast` to recognize the `agenda` `viewMode` and map it to an `agenda-day-forecast` class.
- Add agenda-specific CSS rules for `.agenda-day-forecast` to control spacing, icon size, and temperature font sizing.
- Add a unit test `agenda view renders daily weather forecast` to verify an agenda day's forecast icon and high/low temperatures are rendered, and stub `getAgendaEventMinHeight` in the test to avoid DOM layout dependency.

### Testing
- Ran the test suite with `npm test`, and all tests passed (`73` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a061e6ab068833197797d6ce3dbc5a5)