### PR TITLE
Add calendar-scoped event keyword icons

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1200,6 +1200,7 @@ class SkylightCalendarCard extends HTMLElement {
     const normalizedCalendarColors = this.normalizeColorMap(config.colors || {});
     const normalizedEventFontColors = this.normalizeColorMap(config.event_font_colors || {});
     const normalizedEventStyles = this.normalizeEventStyles(config.event_styles || []);
+    const normalizedEventKeywordIcons = this.normalizeEventKeywordIcons(config.event_keyword_icons || []);
     const normalizedLocale = resolveLanguage(config.locale || config.language || this._hass?.locale?.language || this._hass?.language);
     const normalizedDayStyles = this.normalizeDayStyles(config.day_styles || [], normalizedLocale);
     const normalizedHeaderColor = this.normalizeSingleColor(config.header_color);
@@ -1293,6 +1294,7 @@ class SkylightCalendarCard extends HTMLElement {
       event_title_prefix: normalizedEventTitlePrefix, // Prefix event titles with calendar friendly name or badge icon
       event_font_colors: normalizedEventFontColors, // Per-calendar font colors for event bubble text
       event_styles: normalizedEventStyles, // Per-event styling rules with match logic
+      event_keyword_icons: normalizedEventKeywordIcons, // Per-keyword event icons with optional calendar scoping
       day_styles: normalizedDayStyles, // Per-day styling rules
       hide_times_for_calendars: config.hide_times_for_calendars || [], // Hide times in schedule view for specific calendars
       show_current_time_bar: config.show_current_time_bar || false, // Show a "now" indicator in schedule view
@@ -1342,6 +1344,7 @@ class SkylightCalendarCard extends HTMLElement {
       calendar_person_entities: normalizedCalendarPersonEntities,
       agenda_compact_events: config.agenda_compact_events ?? false,
       event_styles: normalizedEventStyles,
+      event_keyword_icons: normalizedEventKeywordIcons,
       day_styles: normalizedDayStyles
       ,
       event_color_mode: this.normalizeEventColorMode(config.event_color_mode ?? 'classic'),
@@ -1648,6 +1651,50 @@ class SkylightCalendarCard extends HTMLElement {
           priority,
           match,
           style: this.normalizeEventStyleBlock(style),
+          index
+        };
+      })
+      .filter(Boolean);
+  }
+
+  normalizeEventKeywordIcons(rawRules) {
+    if (!Array.isArray(rawRules)) return [];
+
+    return rawRules
+      .map((rule, index) => {
+        if (!rule || typeof rule !== 'object') return null;
+
+        const keyword = typeof rule.keyword === 'string' ? rule.keyword.trim() : '';
+        const icon = typeof rule.icon === 'string' ? rule.icon.trim() : '';
+        if (!keyword || !icon) return null;
+
+        const calendar = typeof rule.calendar === 'string' ? rule.calendar.trim() : '';
+        const rawCalendars = Array.isArray(rule.calendars)
+          ? rule.calendars
+          : (typeof rule.calendars === 'string' ? [rule.calendars] : []);
+        const calendars = Array.from(new Set([
+          ...(calendar ? [calendar] : []),
+          ...rawCalendars
+            .filter((entry) => typeof entry === 'string')
+            .map((entry) => entry.trim())
+            .filter(Boolean)
+        ]));
+
+        let match = { title: keyword };
+        if (Object.prototype.hasOwnProperty.call(rule, 'calendars') && calendars.length > 0) {
+          match = {
+            title: keyword,
+            any: calendars.map((calendarId) => ({ calendar: calendarId }))
+          };
+        } else if (calendar) {
+          match = { title: keyword, calendar };
+        }
+
+        return {
+          id: typeof rule.id === 'string' && rule.id.trim() ? rule.id.trim() : `event-keyword-icon-${index + 1}`,
+          keyword,
+          icon,
+          match,
           index
         };
       })
@@ -4515,6 +4562,12 @@ class SkylightCalendarCard extends HTMLElement {
         flex-shrink: 0;
       }
 
+      .week-standard-event-icon ha-icon {
+        --mdc-icon-size: 14px;
+        width: 14px;
+        height: 14px;
+      }
+
       .combined-corner-bubbles {
         position: absolute;
         right: 6px;
@@ -6425,6 +6478,12 @@ class SkylightCalendarCard extends HTMLElement {
       return '';
     }
 
+    const keywordIcon = this.getEventKeywordIcon(event);
+    if (keywordIcon) {
+      const iconColor = this.normalizeSingleColor(event?.color) || '#6b7280';
+      return `<div class="week-standard-event-icons"><div class="week-standard-event-icon" style="background: ${iconColor}; color: white;"><ha-icon icon="${this.escapeHtml(keywordIcon)}"></ha-icon></div></div>`;
+    }
+
     const styleOverrides = this.getEventStyleOverrides(event);
     const useFriendlyName = this._config.event_calendar_friendly_name;
     const hideCalendarBubble = styleOverrides?.hide_event_calendar_bubble ?? this._config.hide_event_calendar_bubble;
@@ -7227,6 +7286,16 @@ class SkylightCalendarCard extends HTMLElement {
     }
 
     return [event.color];
+  }
+
+  getMatchedEventKeywordIconRules(event) {
+    const configuredRules = Array.isArray(this._config?.event_keyword_icons) ? this._config.event_keyword_icons : [];
+    if (configuredRules.length === 0) return [];
+    return configuredRules.filter((rule) => this.eventMatchesRule(event, rule.match));
+  }
+
+  getEventKeywordIcon(event) {
+    return this.getMatchedEventKeywordIconRules(event)[0]?.icon || null;
   }
 
   getMatchedEventStyleRules(event) {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -665,6 +665,45 @@ test('virtual_calendars normalize and affect calendar token matching', () => {
 
 
 
+test('event_keyword_icons support calendar scoped keyword matches', () => {
+  const card = makeCard({
+    entities: ['calendar.kids', 'calendar.work'],
+    event_keyword_icons: [{ keyword: 'soccer', icon: 'mdi:soccer', calendar: 'calendar.kids' }]
+  });
+  const kidsEvent = { entityId: 'calendar.kids', color: '#f00', summary: 'Soccer practice', start: { dateTime: '2026-05-01T09:00:00Z' }, end: { dateTime: '2026-05-01T10:00:00Z' } };
+  const workEvent = { entityId: 'calendar.work', color: '#00f', summary: 'Soccer practice', start: { dateTime: '2026-05-01T09:00:00Z' }, end: { dateTime: '2026-05-01T10:00:00Z' } };
+
+  assert.deepEqual(card._config.event_keyword_icons[0].match, { title: 'soccer', calendar: 'calendar.kids' });
+  assert.equal(card.getEventKeywordIcon(kidsEvent), 'mdi:soccer');
+  assert.equal(card.getEventKeywordIcon(workEvent), null);
+});
+
+test('event_keyword_icons support multiple calendar and virtual calendar matches', () => {
+  const card = makeCard({
+    entities: ['calendar.family', 'calendar.health', 'calendar.kids'],
+    virtual_calendars: [{ id: 'family', name: 'Family', entities: ['calendar.family', 'calendar.kids'], color: '#778899' }],
+    event_keyword_icons: [
+      { keyword: 'dentist', icon: 'mdi:tooth', calendars: ['calendar.family', 'calendar.health'] },
+      { keyword: 'movie', icon: 'mdi:movie', calendar: 'virtual:family' }
+    ]
+  });
+  const familyDentist = { entityId: 'calendar.family', color: '#f00', summary: 'Dentist appointment', start: { dateTime: '2026-05-01T09:00:00Z' }, end: { dateTime: '2026-05-01T10:00:00Z' } };
+  const healthDentist = { entityId: 'calendar.health', color: '#0f0', summary: 'Dentist appointment', start: { dateTime: '2026-05-01T09:00:00Z' }, end: { dateTime: '2026-05-01T10:00:00Z' } };
+  const kidsDentist = { entityId: 'calendar.kids', color: '#00f', summary: 'Dentist appointment', start: { dateTime: '2026-05-01T09:00:00Z' }, end: { dateTime: '2026-05-01T10:00:00Z' } };
+  const kidsMovie = { entityId: 'calendar.kids', color: '#00f', summary: 'Movie night', start: { dateTime: '2026-05-01T18:00:00Z' }, end: { dateTime: '2026-05-01T20:00:00Z' } };
+
+  assert.deepEqual(card._config.event_keyword_icons[0].match, {
+    title: 'dentist',
+    any: [{ calendar: 'calendar.family' }, { calendar: 'calendar.health' }]
+  });
+  assert.equal(card.getEventKeywordIcon(familyDentist), 'mdi:tooth');
+  assert.equal(card.getEventKeywordIcon(healthDentist), 'mdi:tooth');
+  assert.equal(card.getEventKeywordIcon(kidsDentist), null);
+  assert.equal(card.getEventKeywordIcon(kidsMovie), 'mdi:movie');
+});
+
+
+
 test('feature order: combine then virtual then event styles influences visible colors/style', () => {
   const card = makeCard({
     entities: ['calendar.a', 'calendar.b'],


### PR DESCRIPTION
### Motivation
- Allow `event_keyword_icons` rules to scope keyword->icon matches to specific calendars using `calendar` and/or `calendars` so keyword icons only apply for configured calendars (including virtual calendar tokens). 

### Description
- Added `normalizeEventKeywordIcons(rawRules)` which accepts `keyword`, `icon`, optional `calendar` and/or `calendars` and builds `match` objects as `{ title: keyword }`, `{ title: keyword, calendar: rule.calendar }`, or `{ title: keyword, any: [...] }` as appropriate. 
- Hooked normalization into `setConfig` as `event_keyword_icons` and preserved the normalized value after the config spread so the card uses the normalized rules at runtime. 
- Reused existing matching infrastructure by evaluating keyword rules with `eventMatchesRule` (via new `getMatchedEventKeywordIconRules` and `getEventKeywordIcon`) so real calendar IDs, friendly names, and `virtual:...` tokens continue to behave identically to `event_styles`. 
- Rendered matched keyword icons in `renderEventIcon` (before calendar badges) and added CSS sizing for `ha-icon` inside `.week-standard-event-icon` for consistent MDI icon sizing. 

### Testing
- Added unit tests in `skylight-calendar-card.test.js` that assert: `event_keyword_icons` normalizes to the expected `match` object; a keyword icon matches only the configured calendar; a same-title event on another calendar does not match; multiple calendars and virtual calendar tokens are supported. 
- Ran the test suite with `npm test`; all tests passed (`75` tests run, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a49074ac88331b4507fb2ef402763)