### PR TITLE
Add rich event descriptions (Markdown & safe HTML) to event modal with styles and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Designed for clarity at a glance, with flexible views and deep customization.
 * 🗓️ **Schedule View** – Detailed list-style agenda
 * 👨‍👩‍👧‍👦 **Multi-calendar support** – Combine multiple calendars into one view
 * 📝 **Full event management** – Create, edit, and manage events (integration dependent)
+* ✨ **Rich event descriptions** – Display Markdown, basic HTML, and safe inline markup in event details
 * 🌤️ **Weather forecast display** – Built-in weather insights alongside your schedule
 * 🎨 **Highly customizable** – Layout, styling, visibility, and behavior options
 * ⚡ **Fast & responsive** – Optimized for wall tablets and dashboards

--- a/playwright/visual.spec.js
+++ b/playwright/visual.spec.js
@@ -71,6 +71,27 @@ const hostileEvents = {
   ]
 };
 
+const richDescriptionEvents = {
+  'calendar.family': [
+    {
+      summary: 'Markdown Description Demo',
+      start: '2026-03-15T10:30:00Z',
+      end: '2026-03-15T11:00:00Z',
+      location: 'Kitchen',
+      description: '## Markdown Details\n\nBring **snacks** and [menu](https://example.com/menu).\n- Chips\n- Drinks\n\nUse `door code`.'
+    }
+  ],
+  'calendar.work': [
+    {
+      summary: 'HTML Description Demo',
+      start: '2026-03-15T12:00:00Z',
+      end: '2026-03-15T12:30:00Z',
+      location: 'Conference Room',
+      description: '<h3>HTML Details</h3><p>Please bring <em>printed notes</em>.</p><blockquote>Setup starts early.</blockquote><p><a href="/local/rich-info">More info</a></p>'
+    }
+  ]
+};
+
 const defaultColors = { 'calendar.family': '#ff5f66', 'calendar.work': '#14c8bd' };
 
 const cases = [
@@ -209,6 +230,43 @@ test.beforeEach(async ({ page }) => {
     }
     window.Date = MockDate;
   }, FIXED_NOW);
+});
+
+test('visual: event modal renders rich markdown and HTML descriptions', async ({ page }) => {
+  const fixtureUrl = `file://${path.join(process.cwd(), 'playwright', 'ha-fixture.html')}`;
+  await page.goto(fixtureUrl);
+  await page.evaluate((params) => window.renderCalendarCard(params), {
+    config: { entities: ['calendar.family', 'calendar.work'], title: 'Rich Description Calendar', default_view: 'agenda' },
+    events: richDescriptionEvents,
+    darkMode: false
+  });
+
+  const card = page.locator('skylight-calendar-card');
+  await expect(card).toBeVisible();
+
+  await card.locator('.agenda-event').filter({ hasText: 'Markdown Description Demo' }).click();
+  const modal = card.locator('#event-modal');
+  await expect(modal).toHaveClass(/show/);
+
+  const markdownDescription = modal.locator('.event-description-content');
+  await expect(markdownDescription.locator('h2')).toHaveText('Markdown Details');
+  await expect(markdownDescription.locator('strong')).toHaveText('snacks');
+  await expect(markdownDescription.locator('a')).toHaveAttribute('href', 'https://example.com/menu');
+  await expect(markdownDescription.locator('ul li')).toHaveText(['Chips', 'Drinks']);
+  await expect(markdownDescription.locator('code')).toHaveText('door code');
+  await expect(markdownDescription).toHaveCSS('overflow-wrap', 'anywhere');
+
+  await modal.locator('.modal-close').click();
+  await expect(modal).not.toHaveClass(/show/);
+
+  await card.locator('.agenda-event').filter({ hasText: 'HTML Description Demo' }).click();
+  await expect(modal).toHaveClass(/show/);
+
+  const htmlDescription = modal.locator('.event-description-content');
+  await expect(htmlDescription.locator('h3')).toHaveText('HTML Details');
+  await expect(htmlDescription.locator('em')).toHaveText('printed notes');
+  await expect(htmlDescription.locator('blockquote')).toHaveText('Setup starts early.');
+  await expect(htmlDescription.locator('a')).toHaveAttribute('href', '/local/rich-info');
 });
 
 for (const scenario of cases) {

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -4643,6 +4643,91 @@ class SkylightCalendarCard extends HTMLElement {
         flex: 1;
       }
 
+      .modal-row-description {
+        align-items: flex-start;
+      }
+
+      .event-description-content {
+        line-height: 1.5;
+        overflow-wrap: anywhere;
+      }
+
+      .event-description-content > :first-child {
+        margin-top: 0;
+      }
+
+      .event-description-content > :last-child {
+        margin-bottom: 0;
+      }
+
+      .event-description-content p,
+      .event-description-content ul,
+      .event-description-content ol,
+      .event-description-content blockquote,
+      .event-description-content pre {
+        margin: 0 0 10px;
+      }
+
+      .event-description-content ul,
+      .event-description-content ol {
+        padding-left: 20px;
+      }
+
+      .event-description-content li + li {
+        margin-top: 4px;
+      }
+
+      .event-description-content h1,
+      .event-description-content h2,
+      .event-description-content h3,
+      .event-description-content h4,
+      .event-description-content h5,
+      .event-description-content h6 {
+        margin: 0 0 8px;
+        font-weight: 700;
+        line-height: 1.25;
+        color: #111827;
+      }
+
+      .event-description-content h1 { font-size: 20px; }
+      .event-description-content h2 { font-size: 18px; }
+      .event-description-content h3 { font-size: 16px; }
+      .event-description-content h4,
+      .event-description-content h5,
+      .event-description-content h6 { font-size: 14px; }
+
+      .event-description-content blockquote {
+        border-left: 3px solid #d1d5db;
+        color: #4b5563;
+        padding-left: 10px;
+      }
+
+      .event-description-content code {
+        background: #f3f4f6;
+        border-radius: 4px;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        font-size: 0.9em;
+        padding: 1px 4px;
+      }
+
+      .event-description-content pre {
+        background: #f3f4f6;
+        border-radius: 8px;
+        overflow-x: auto;
+        padding: 10px;
+        white-space: pre-wrap;
+      }
+
+      .event-description-content pre code {
+        background: transparent;
+        padding: 0;
+      }
+
+      .event-description-content a {
+        color: #2563eb;
+        text-decoration: underline;
+      }
+
       #create-event-form,
       #edit-event-form {
         display: flex;
@@ -5237,6 +5322,29 @@ class SkylightCalendarCard extends HTMLElement {
       .calendar-container.dark-mode .modal-value,
       .calendar-container.dark-mode .form-label {
         color: #d6dee8;
+      }
+
+      .calendar-container.dark-mode .event-description-content h1,
+      .calendar-container.dark-mode .event-description-content h2,
+      .calendar-container.dark-mode .event-description-content h3,
+      .calendar-container.dark-mode .event-description-content h4,
+      .calendar-container.dark-mode .event-description-content h5,
+      .calendar-container.dark-mode .event-description-content h6 {
+        color: #f8fafc;
+      }
+
+      .calendar-container.dark-mode .event-description-content blockquote {
+        border-left-color: #64748b;
+        color: #cbd5e1;
+      }
+
+      .calendar-container.dark-mode .event-description-content code,
+      .calendar-container.dark-mode .event-description-content pre {
+        background: #28313d;
+      }
+
+      .calendar-container.dark-mode .event-description-content a {
+        color: #93c5fd;
       }
 
       .calendar-container.dark-mode .form-required {
@@ -9842,9 +9950,9 @@ class SkylightCalendarCard extends HTMLElement {
           </div>
         ` : ''}
         ${event.description ? `
-          <div class="modal-row">
+          <div class="modal-row modal-row-description">
             <div class="modal-label">📝 ${this.t('description')}</div>
-            <div class="modal-value" style="white-space: pre-wrap;">${this.escapeHtml(event.description)}</div>
+            <div class="modal-value event-description-content">${this.renderEventDescription(event.description)}</div>
           </div>
         ` : ''}
         ${event.attendees && event.attendees.length > 0 ? `
@@ -10485,6 +10593,180 @@ class SkylightCalendarCard extends HTMLElement {
 
     const initial = name.charAt(0).toUpperCase();
     return `<div class="calendar-badge-icon${personIconClass}" style="background: ${iconBackground}">${this.escapeHtml(initial)}</div>`;
+  }
+
+  renderEventDescription(description) {
+    const text = String(description ?? '').trim();
+    if (!text) return '';
+
+    return this.containsBlockHtml(text)
+      ? this.sanitizeBasicDescriptionHtml(text)
+      : this.renderMarkdownDescription(text);
+  }
+
+  containsBlockHtml(text) {
+    return /<\/?(?:p|div|ul|ol|li|blockquote|pre|h[1-6]|table|tr|td|th)\b/i.test(String(text ?? ''));
+  }
+
+  renderMarkdownDescription(text) {
+    const lines = String(text ?? '').replace(/\r\n?/g, '\n').split('\n');
+    const htmlBlocks = [];
+    let paragraphLines = [];
+    let listItems = [];
+    let listType = null;
+    let quoteLines = [];
+
+    const flushParagraph = () => {
+      if (paragraphLines.length === 0) return;
+      htmlBlocks.push(`<p>${paragraphLines.map(line => this.renderMarkdownInline(line)).join('<br>')}</p>`);
+      paragraphLines = [];
+    };
+
+    const flushList = () => {
+      if (!listType || listItems.length === 0) return;
+      htmlBlocks.push(`<${listType}>${listItems.map(item => `<li>${this.renderMarkdownInline(item)}</li>`).join('')}</${listType}>`);
+      listItems = [];
+      listType = null;
+    };
+
+    const flushQuote = () => {
+      if (quoteLines.length === 0) return;
+      htmlBlocks.push(`<blockquote>${quoteLines.map(line => this.renderMarkdownInline(line)).join('<br>')}</blockquote>`);
+      quoteLines = [];
+    };
+
+    const flushAll = () => {
+      flushParagraph();
+      flushList();
+      flushQuote();
+    };
+
+    lines.forEach((line) => {
+      if (!line.trim()) {
+        flushAll();
+        return;
+      }
+
+      const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
+      if (headingMatch) {
+        flushAll();
+        const level = headingMatch[1].length;
+        htmlBlocks.push(`<h${level}>${this.renderMarkdownInline(headingMatch[2])}</h${level}>`);
+        return;
+      }
+
+      const unorderedMatch = line.match(/^\s*[-*+]\s+(.+)$/);
+      if (unorderedMatch) {
+        flushParagraph();
+        flushQuote();
+        if (listType && listType !== 'ul') flushList();
+        listType = 'ul';
+        listItems.push(unorderedMatch[1]);
+        return;
+      }
+
+      const orderedMatch = line.match(/^\s*\d+\.\s+(.+)$/);
+      if (orderedMatch) {
+        flushParagraph();
+        flushQuote();
+        if (listType && listType !== 'ol') flushList();
+        listType = 'ol';
+        listItems.push(orderedMatch[1]);
+        return;
+      }
+
+      const quoteMatch = line.match(/^\s*>\s?(.*)$/);
+      if (quoteMatch) {
+        flushParagraph();
+        flushList();
+        quoteLines.push(quoteMatch[1]);
+        return;
+      }
+
+      flushList();
+      flushQuote();
+      paragraphLines.push(line);
+    });
+
+    flushAll();
+    return htmlBlocks.join('');
+  }
+
+  renderMarkdownInline(text) {
+    const codeSpans = [];
+    let html = this.escapeHtml(text).replace(/`([^`]+)`/g, (_match, code) => {
+      const token = `§CODESPAN${codeSpans.length}§`;
+      codeSpans.push(`<code>${code}</code>`);
+      return token;
+    });
+
+    html = html.replace(/\[([^\]]+)]\(([^)\s]+)\)/g, (_match, label, url) => {
+      const safeUrl = this.getSafeDescriptionUrl(this.decodeHtmlEntities(url));
+      if (!safeUrl) return label;
+      return `<a href="${this.escapeHtmlAttribute(safeUrl)}" target="_blank" rel="noopener noreferrer">${label}</a>`;
+    });
+
+    html = html
+      .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+      .replace(/__([^_]+)__/g, '<strong>$1</strong>')
+      .replace(/~~([^~]+)~~/g, '<s>$1</s>')
+      .replace(/\*([^*]+)\*/g, '<em>$1</em>')
+      .replace(/_([^_]+)_/g, '<em>$1</em>');
+
+    html = this.restoreAllowedDescriptionTags(html);
+    codeSpans.forEach((codeHtml, index) => {
+      html = html.replace(`§CODESPAN${index}§`, codeHtml);
+    });
+
+    return html;
+  }
+
+  sanitizeBasicDescriptionHtml(text) {
+    const cleanText = String(text ?? '').replace(/<script\b[\s\S]*?<\/script>/gi, '').replace(/<style\b[\s\S]*?<\/style>/gi, '');
+    const escaped = this.escapeHtml(cleanText).replace(/\r\n?|\n/g, '<br>');
+    return this.restoreAllowedDescriptionTags(escaped);
+  }
+
+  restoreAllowedDescriptionTags(html) {
+    const allowedSimpleTags = 'b|strong|i|em|u|s|br|p|ul|ol|li|blockquote|code|pre|h[1-6]';
+
+    const renderAnchor = (attrs, content = '') => {
+      const hrefMatch = attrs.match(/href\s*=\s*(?:&quot;([^&]*)&quot;|&#39;([^&]*)&(?:#39|apos);|([^\s&]+))/i);
+      const href = hrefMatch ? this.decodeHtmlEntities(hrefMatch[1] || hrefMatch[2] || hrefMatch[3] || '') : '';
+      const safeUrl = this.getSafeDescriptionUrl(href);
+      if (!safeUrl) return content;
+      return `<a href="${this.escapeHtmlAttribute(safeUrl)}" target="_blank" rel="noopener noreferrer">${content}</a>`;
+    };
+
+    return String(html ?? '')
+      .replace(/&lt;a\s+([\s\S]*?)&gt;([\s\S]*?)&lt;\/a&gt;/gi, (_match, attrs, content) => renderAnchor(attrs, content))
+      .replace(/&lt;a\s+([\s\S]*?)&gt;/gi, (_match, attrs) => renderAnchor(attrs).replace('</a>', ''))
+      .replace(/&lt;\/a&gt;/gi, '</a>')
+      .replace(new RegExp(`&lt;(/?)(${allowedSimpleTags})(?:\\s+[\\s\\S]*?)?\\s*(/?)&gt;`, 'gi'), (_match, closing, tag, selfClosing) => {
+        const normalizedTag = tag.toLowerCase();
+        if (normalizedTag === 'br') return '<br>';
+        return closing ? `</${normalizedTag}>` : `<${normalizedTag}${selfClosing ? ' /' : ''}>`;
+      });
+  }
+
+  getSafeDescriptionUrl(url) {
+    const value = String(url ?? '').trim();
+    if (!value) return '';
+
+    if (/^(https?:|mailto:|tel:)/i.test(value) || value.startsWith('/') || value.startsWith('#')) {
+      return value;
+    }
+
+    return '';
+  }
+
+  decodeHtmlEntities(text) {
+    return String(text ?? '')
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;|&apos;/g, "'")
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>');
   }
 
   escapeHtml(text) {

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -10728,7 +10728,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   restoreAllowedDescriptionTags(html) {
-    const allowedSimpleTags = 'b|strong|i|em|u|s|br|p|ul|ol|li|blockquote|code|pre|h[1-6]';
+    const allowedSimpleTags = 'b|strong|i|em|u|s|br|p|div|ul|ol|li|blockquote|code|pre|h[1-6]|table|thead|tbody|tfoot|tr|td|th';
 
     const renderAnchor = (attrs, content = '') => {
       const hrefMatch = attrs.match(/href\s*=\s*(?:&quot;([^&]*)&quot;|&#39;([^&]*)&(?:#39|apos);|"([^"]*)"|'([^']*)'|([^\s&"']+))/i);

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -10731,8 +10731,8 @@ class SkylightCalendarCard extends HTMLElement {
     const allowedSimpleTags = 'b|strong|i|em|u|s|br|p|ul|ol|li|blockquote|code|pre|h[1-6]';
 
     const renderAnchor = (attrs, content = '') => {
-      const hrefMatch = attrs.match(/href\s*=\s*(?:&quot;([^&]*)&quot;|&#39;([^&]*)&(?:#39|apos);|([^\s&]+))/i);
-      const href = hrefMatch ? this.decodeHtmlEntities(hrefMatch[1] || hrefMatch[2] || hrefMatch[3] || '') : '';
+      const hrefMatch = attrs.match(/href\s*=\s*(?:&quot;([^&]*)&quot;|&#39;([^&]*)&(?:#39|apos);|"([^"]*)"|'([^']*)'|([^\s&"']+))/i);
+      const href = hrefMatch ? this.decodeHtmlEntities(hrefMatch[1] || hrefMatch[2] || hrefMatch[3] || hrefMatch[4] || hrefMatch[5] || '') : '';
       const safeUrl = this.getSafeDescriptionUrl(href);
       if (!safeUrl) return content;
       return `<a href="${this.escapeHtmlAttribute(safeUrl)}" target="_blank" rel="noopener noreferrer">${content}</a>`;

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -414,6 +414,15 @@ test('renderEventDescription restores HTML links escaped with literal quoted hre
   assert.match(html, /<a href="\/local\/rich-info" target="_blank" rel="noopener noreferrer">More info<\/a>/);
 });
 
+test('renderEventDescription keeps common HTML wrappers from rendering as raw text', () => {
+  const card = makeCard();
+  const html = card.renderEventDescription('<div>Line 1</div><div>Line 2</div><table><tr><th>When</th><td>Noon</td></tr></table>');
+
+  assert.match(html, /<div>Line 1<\/div><div>Line 2<\/div>/);
+  assert.match(html, /<table><tr><th>When<\/th><td>Noon<\/td><\/tr><\/table>/);
+  assert.doesNotMatch(html, /&lt;\/?(?:div|table|tr|th|td)\b/i);
+});
+
 test('weather renders Home Assistant mdi icons instead of emoji glyphs', () => {
   const card = makeCard({
     entities: ['calendar.family'],

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -380,6 +380,28 @@ test('calendar render includes header controls and modal container', () => {
 });
 
 
+
+test('renderEventDescription supports markdown formatting with safe links', () => {
+  const card = makeCard();
+  const html = card.renderEventDescription('# Details\n\nBring **snacks** and [agenda](https://example.com/path?a=1&b=2).\n- RSVP\n- Arrive `early`');
+
+  assert.match(html, /<h1>Details<\/h1>/);
+  assert.match(html, /<strong>snacks<\/strong>/);
+  assert.match(html, /<a href="https:\/\/example\.com\/path\?a=1&amp;b=2" target="_blank" rel="noopener noreferrer">agenda<\/a>/);
+  assert.match(html, /<ul><li>RSVP<\/li><li>Arrive <code>early<\/code><\/li><\/ul>/);
+});
+
+test('renderEventDescription allows basic HTML but strips scripts and unsafe links', () => {
+  const card = makeCard();
+  const html = card.renderEventDescription('<p><b>Bring plates</b></p><script>alert(1)</script><a href="javascript:alert(1)">bad</a><a href="/local/info">good</a>');
+
+  assert.match(html, /<p><b>Bring plates<\/b><\/p>/);
+  assert.doesNotMatch(html, /<script|alert\(1\)|javascript:/);
+  assert.match(html, />bad/);
+  assert.doesNotMatch(html, /bad<\/a>/);
+  assert.match(html, /<a href="\/local\/info" target="_blank" rel="noopener noreferrer">good<\/a>/);
+});
+
 test('weather renders Home Assistant mdi icons instead of emoji glyphs', () => {
   const card = makeCard({
     entities: ['calendar.family'],

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -402,6 +402,18 @@ test('renderEventDescription allows basic HTML but strips scripts and unsafe lin
   assert.match(html, /<a href="\/local\/info" target="_blank" rel="noopener noreferrer">good<\/a>/);
 });
 
+test('renderEventDescription restores HTML links escaped with literal quoted hrefs', () => {
+  const card = makeCard();
+  card.escapeHtml = (text) => String(text ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+
+  const html = card.renderEventDescription('<p><a href="/local/rich-info">More info</a></p>');
+
+  assert.match(html, /<a href="\/local\/rich-info" target="_blank" rel="noopener noreferrer">More info<\/a>/);
+});
+
 test('weather renders Home Assistant mdi icons instead of emoji glyphs', () => {
   const card = makeCard({
     entities: ['calendar.family'],


### PR DESCRIPTION
### Motivation

- Provide richer, safer event details by rendering Markdown and a limited set of safe HTML inside the event modal instead of plain escaped text.
- Improve readability and formatting for long descriptions, code spans, lists, headings and links while preventing unsafe content and external injection.

### Description

- Added a short README feature note about `Rich event descriptions` in `README.md` to advertise the capability.
- Introduced CSS rules for `.event-description-content` and dark-mode variants to style headings, lists, blockquotes, code blocks and links inside the modal.
- Replaced the plain-escaped description in the modal template with a `event-description-content` container that renders via a new `renderEventDescription` flow in `skylight-calendar-card.js`.
- Implemented `renderEventDescription`, `containsBlockHtml`, `renderMarkdownDescription`, `renderMarkdownInline`, `sanitizeBasicDescriptionHtml`, `restoreAllowedDescriptionTags`, `getSafeDescriptionUrl`, and `decodeHtmlEntities` to support lightweight Markdown, allow a safe subset of HTML, strip scripts/styles, and normalize safe link targets; reused existing `escapeHtml`/`escapeHtmlAttribute` helpers for safety.
- Added tests: a Playwright visual test in `playwright/visual.spec.js` to validate rendered Markdown and HTML inside the event modal, and unit tests in `skylight-calendar-card.test.js` to assert Markdown rendering, safe links, and HTML sanitization behavior.

### Testing

- Ran the unit tests covering `renderEventDescription` in `skylight-calendar-card.test.js`, which validated headings, emphasis, code spans, lists and safe/unsafe link behaviors and succeeded. 
- Executed the Playwright visual test `visual: event modal renders rich markdown and HTML descriptions` in `playwright/visual.spec.js`, which opens the card fixture and asserts modal content rendering for both Markdown and HTML examples and succeeded. 
- Ran the existing visual/unit suites to ensure no regressions in other render paths and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b4d871be48331bc03d04ad7a4934a)