### PR TITLE
Restore HTML links with literal quoted hrefs in rich descriptions

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -10731,8 +10731,8 @@ class SkylightCalendarCard extends HTMLElement {
     const allowedSimpleTags = 'b|strong|i|em|u|s|br|p|ul|ol|li|blockquote|code|pre|h[1-6]';
 
     const renderAnchor = (attrs, content = '') => {
-      const hrefMatch = attrs.match(/href\s*=\s*(?:&quot;([^&]*)&quot;|&#39;([^&]*)&(?:#39|apos);|([^\s&]+))/i);
-      const href = hrefMatch ? this.decodeHtmlEntities(hrefMatch[1] || hrefMatch[2] || hrefMatch[3] || '') : '';
+      const hrefMatch = attrs.match(/href\s*=\s*(?:&quot;([^&]*)&quot;|&#39;([^&]*)&(?:#39|apos);|"([^"]*)"|'([^']*)'|([^\s&"']+))/i);
+      const href = hrefMatch ? this.decodeHtmlEntities(hrefMatch[1] || hrefMatch[2] || hrefMatch[3] || hrefMatch[4] || hrefMatch[5] || '') : '';
       const safeUrl = this.getSafeDescriptionUrl(href);
       if (!safeUrl) return content;
       return `<a href="${this.escapeHtmlAttribute(safeUrl)}" target="_blank" rel="noopener noreferrer">${content}</a>`;

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -402,6 +402,18 @@ test('renderEventDescription allows basic HTML but strips scripts and unsafe lin
   assert.match(html, /<a href="\/local\/info" target="_blank" rel="noopener noreferrer">good<\/a>/);
 });
 
+test('renderEventDescription restores HTML links escaped with literal quoted hrefs', () => {
+  const card = makeCard();
+  card.escapeHtml = (text) => String(text ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+
+  const html = card.renderEventDescription('<p><a href="/local/rich-info">More info</a></p>');
+
+  assert.match(html, /<a href="\/local\/rich-info" target="_blank" rel="noopener noreferrer">More info<\/a>/);
+});
+
 test('weather renders Home Assistant mdi icons instead of emoji glyphs', () => {
   const card = makeCard({
     entities: ['calendar.family'],


### PR DESCRIPTION
### Motivation
- The event modal visual test failed because sanitized HTML anchors that browsers escape with literal quoted `href` attributes were not being restored by the existing link parsing logic. 
- The goal is to preserve safe local links such as `/local/rich-info` when the description HTML has been browser-escaped with literal quotes instead of `&quot;` entities.

### Description
- Updated the `restoreAllowedDescriptionTags` anchor parser in `skylight-calendar-card.js` to expand the `href` capture regex to also match literal double-quoted and single-quoted href values as well as unquoted values. 
- The regex change is localized to the `renderAnchor` helper so allowed links continue to be validated by `getSafeDescriptionUrl` before being restored. 
- Added a unit regression test `renderEventDescription restores HTML links escaped with literal quoted hrefs` to `skylight-calendar-card.test.js` that simulates browser-style escaping and verifies the `/local/rich-info` anchor is preserved and restored safely.

### Testing
- Ran `npm test`, which executed the unit test suite and reported all tests passing (76 passed, 0 failed). 
- Attempted the focused visual test with `npm run test:visual -- --grep "rich markdown"`, but it could not run because Playwright browser executables were not present in the environment. 
- Attempted `npx playwright install chromium` to fetch browsers, but the download failed with a 403 from the Playwright CDN, preventing local execution of the visual tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b9ba1d80c8331b8cfdfae0b539e15)