### PR TITLE
Measure month compact layout with RAF/ResizeObserver and add regression test for view selector clickability

### DIFF
--- a/playwright/visual.spec.js
+++ b/playwright/visual.spec.js
@@ -333,4 +333,8 @@ test('regression: month compact-height view selector stays clickable without dev
 
   await selector.selectOption('month');
   await expect(card.locator('.calendar-grid')).toBeVisible();
+
+  await page.setViewportSize({ width: 1280, height: 760 });
+  await expect(card.locator('.calendar-grid')).toBeVisible();
+  await expect(selector).toBeEnabled();
 });

--- a/playwright/visual.spec.js
+++ b/playwright/visual.spec.js
@@ -310,3 +310,27 @@ for (const scenario of cases) {
     });
   });
 }
+
+test('regression: month compact-height view selector stays clickable without devtools', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+
+  const fixtureUrl = `file://${path.join(process.cwd(), 'playwright', 'ha-fixture.html')}`;
+  await page.goto(fixtureUrl);
+  await page.evaluate((params) => window.renderCalendarCard(params), {
+    config: { entities: ['calendar.family', 'calendar.work'], title: 'Regression Calendar', default_view: 'month', compact_height: true },
+    events: baseEvents,
+    darkMode: false
+  });
+
+  const card = page.locator('skylight-calendar-card');
+  await expect(card).toContainText('Month');
+
+  const selector = card.locator('#view-mode-select');
+  await expect(selector).toBeVisible();
+  await expect(selector).toBeEnabled();
+  await selector.selectOption('agenda');
+  await expect(card.locator('.agenda-container')).toBeVisible();
+
+  await selector.selectOption('month');
+  await expect(card.locator('.calendar-grid')).toBeVisible();
+});

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -911,6 +911,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._monthMeasureRenderRaf = null;
     this._monthGridResizeObserver = null;
     this._monthCompactMeasurementDirty = true;
+    this._lastCompactMonthViewportHeight = null;
     this._handleViewportResize = () => {
       if (this.isEventManagementDialogOpen()) {
         return;
@@ -2824,11 +2825,21 @@ class SkylightCalendarCard extends HTMLElement {
     if (!container) return;
 
     const measuredContainerTop = Math.max(container.getBoundingClientRect().top, 0);
+    const viewportHeight = window.visualViewport?.height || window.innerHeight;
     if (!Number.isFinite(measuredContainerTop)) return;
+    if (!Number.isFinite(viewportHeight)) return;
 
     const containerTopChanged = this._monthContainerTopInViewport === null || Math.abs(this._monthContainerTopInViewport - measuredContainerTop) > 1;
+    const viewportHeightChanged = this._lastCompactMonthViewportHeight === null || Math.abs(this._lastCompactMonthViewportHeight - viewportHeight) > 1;
+
     if (containerTopChanged) {
       this._monthContainerTopInViewport = measuredContainerTop;
+    }
+    if (viewportHeightChanged) {
+      this._lastCompactMonthViewportHeight = viewportHeight;
+    }
+
+    if (containerTopChanged || viewportHeightChanged) {
       if (this._monthMeasureRenderRaf === null) {
         this._monthMeasureRenderRaf = window.requestAnimationFrame(() => {
           this._monthMeasureRenderRaf = null;

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -907,13 +907,23 @@ class SkylightCalendarCard extends HTMLElement {
     this._weatherForecastRefreshInFlight = false;
     this._weatherForecastRefreshRetryAtByEntity = new Map();
     this._modalVisibilityObserver = null;
+    this._monthMeasureRaf = null;
+    this._monthMeasureRenderRaf = null;
+    this._monthGridResizeObserver = null;
+    this._monthCompactMeasurementDirty = true;
     this._handleViewportResize = () => {
       if (this.isEventManagementDialogOpen()) {
         return;
       }
 
-      if (this._config.compact_height && (this._viewMode === 'week-standard' || this._viewMode === 'agenda' || (this._viewMode === 'month' && !this.shouldShowAllEventsInMonth()))) {
+      if (this._config.compact_height && (this._viewMode === 'week-standard' || this._viewMode === 'agenda')) {
         this.render();
+        return;
+      }
+
+      if (this._viewMode === 'month' && this._config.compact_height && !this.shouldShowAllEventsInMonth()) {
+        this._monthCompactMeasurementDirty = true;
+        this.scheduleMonthCompactTopMeasurement();
         return;
       }
 
@@ -2668,6 +2678,11 @@ class SkylightCalendarCard extends HTMLElement {
   disconnectedCallback() {
     window.removeEventListener('resize', this._handleViewportResize);
     window.visualViewport?.removeEventListener('resize', this._handleViewportResize);
+    this.cancelMonthCompactMeasurement();
+    if (this._monthGridResizeObserver) {
+      this._monthGridResizeObserver.disconnect();
+      this._monthGridResizeObserver = null;
+    }
     this.detachSystemThemeListener();
     this.teardownWeatherForecastSubscription();
     if (this._modalVisibilityObserver) {
@@ -2755,6 +2770,52 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
 
+
+  cancelMonthCompactMeasurement() {
+    if (this._monthMeasureRaf !== null) {
+      window.cancelAnimationFrame(this._monthMeasureRaf);
+      this._monthMeasureRaf = null;
+    }
+
+    if (this._monthMeasureRenderRaf !== null) {
+      window.cancelAnimationFrame(this._monthMeasureRenderRaf);
+      this._monthMeasureRenderRaf = null;
+    }
+  }
+
+  scheduleMonthCompactTopMeasurement(force = false) {
+    if (this._viewMode !== 'month' || !this._config.compact_height || this.shouldShowAllEventsInMonth()) return;
+    if (this.isEventManagementDialogOpen()) return;
+    if (!force && !this._monthCompactMeasurementDirty && this._monthContainerTopInViewport !== null) return;
+    if (this._monthMeasureRaf !== null) return;
+
+    this._monthMeasureRaf = window.requestAnimationFrame(() => {
+      this._monthMeasureRaf = null;
+      this.updateMonthContainerTopInViewportFromDom();
+      this._monthCompactMeasurementDirty = false;
+    });
+  }
+
+  observeMonthGridResize() {
+    if (!this._root || typeof window.ResizeObserver !== 'function') return;
+
+    if (this._monthGridResizeObserver) {
+      this._monthGridResizeObserver.disconnect();
+      this._monthGridResizeObserver = null;
+    }
+
+    if (this._viewMode !== 'month' || !this._config.compact_height || this.shouldShowAllEventsInMonth()) return;
+
+    const container = this._root.querySelector('.calendar-container');
+    if (!container) return;
+
+    this._monthGridResizeObserver = new window.ResizeObserver(() => {
+      this._monthCompactMeasurementDirty = true;
+      this.scheduleMonthCompactTopMeasurement();
+    });
+    this._monthGridResizeObserver.observe(container);
+  }
+
   updateMonthContainerTopInViewportFromDom() {
     if (this._viewMode !== 'month' || !this._config.compact_height || this.shouldShowAllEventsInMonth() || !this._root) return;
     if (this.isEventManagementDialogOpen()) return;
@@ -2768,7 +2829,12 @@ class SkylightCalendarCard extends HTMLElement {
     const containerTopChanged = this._monthContainerTopInViewport === null || Math.abs(this._monthContainerTopInViewport - measuredContainerTop) > 1;
     if (containerTopChanged) {
       this._monthContainerTopInViewport = measuredContainerTop;
-      this.render();
+      if (this._monthMeasureRenderRaf === null) {
+        this._monthMeasureRenderRaf = window.requestAnimationFrame(() => {
+          this._monthMeasureRenderRaf = null;
+          this.render();
+        });
+      }
     }
   }
 
@@ -5679,7 +5745,13 @@ class SkylightCalendarCard extends HTMLElement {
     this.updateCompactHeaderWrapState();
     this.updateCalendarBadgesScrollState();
     this.updateWeekStandardFixedOffsetHeightFromDom();
-    this.updateMonthContainerTopInViewportFromDom();
+    this.observeMonthGridResize();
+    if (this._viewMode === 'month' && this._config.compact_height && !this.shouldShowAllEventsInMonth()) {
+      if (this._monthContainerTopInViewport === null) {
+        this._monthCompactMeasurementDirty = true;
+      }
+      this.scheduleMonthCompactTopMeasurement();
+    }
     this.updateAgendaContainerTopInViewportFromDom();
 
     if (shouldRestoreAgendaScrollPosition) {


### PR DESCRIPTION
### Motivation
- Fix a regression where the month view in `compact_height` mode could become unresponsive (view mode selector not clickable) due to immediate/measured re-renders on viewport changes or layout thrash. 
- Reduce render thrashing and avoid blocking interactions by decoupling DOM measurements from immediate `render()` calls.

### Description
- Introduced measurement state and helpers: `_monthMeasureRaf`, `_monthMeasureRenderRaf`, `_monthGridResizeObserver`, and `_monthCompactMeasurementDirty`, and added `cancelMonthCompactMeasurement()`, `scheduleMonthCompactTopMeasurement()`, and `observeMonthGridResize()` to manage measurements safely with `requestAnimationFrame` and `ResizeObserver`.
- Adjusted `_handleViewportResize` to avoid forcing a full `render()` for month compact mode and instead mark measurement dirty and schedule top measurement with `scheduleMonthCompactTopMeasurement()`.
- Changed `updateMonthContainerTopInViewportFromDom()` to batch the `render()` call via RAF and added cleanup in `disconnectedCallback()` to cancel RAFs and disconnect the resize observer.
- Added a Playwright regression test `regression: month compact-height view selector stays clickable without devtools` in `playwright/visual.spec.js` to verify the view selector remains visible and selectable when switching between `agenda` and `month` in compact mode.

### Testing
- Ran the Playwright visual tests including the new regression test `regression: month compact-height view selector stays clickable without devtools`, and the test passed.
- The existing visual snapshot assertions in `playwright/visual.spec.js` were exercised as part of the test run and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bf80e043c8331808de3e4e1612ad1)