### PR TITLE
Respect hide_times_for_calendars in week-compact and month views and add tests

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -7229,7 +7229,7 @@ class SkylightCalendarCard extends HTMLElement {
 
     return `
       <div class="week-compact-event" style="${eventStyle} --event-bubble-font-size: ${this.getEventBubbleFontSize(event)}; --event-time-font-size: ${this.getEventTimeFontSize(event)}; --event-location-font-size: ${this.getEventLocationFontSize(event)}; --event-bubble-text-color: ${this.getEventBubbleFontColor(event)};" data-event='${JSON.stringify(event).replace(/'/g, "&#39;")}'>
-        <div class="week-compact-event-time">${timeLabel}</div>
+        ${this.shouldShowEventTime(event) ? `<div class="week-compact-event-time">${timeLabel}</div>` : ''}
         <div class="week-compact-event-title">${this.renderEventTitleWithPrefix(event, event.summary || this.t('untitledEvent'))}</div>
         ${this.shouldShowEventLocation(event) ? `<div class="week-compact-event-location">📍 ${this.escapeHtml(this.getDisplayLocation(event.location, event))}</div>` : ''}
         ${this.renderCombinedCornerBubbles(event)}
@@ -7245,7 +7245,7 @@ class SkylightCalendarCard extends HTMLElement {
 
     return `
       <div class="event" style="${eventStyle}; --event-bubble-font-size: ${this.getEventBubbleFontSize(event)}; --event-time-font-size: ${this.getEventTimeFontSize(event)}; --event-bubble-text-color: ${this.getEventBubbleFontColor(event)};" data-event='${JSON.stringify(event).replace(/'/g, "&#39;")}'>
-        ${!isAllDaySegment ? `<span class="event-time">${this.formatTime(segmentStart)}</span>` : ''}
+        ${!isAllDaySegment && this.shouldShowEventTime(event) ? `<span class="event-time">${this.formatTime(segmentStart)}</span>` : ''}
         ${this.renderEventTitleWithPrefix(event, event.summary || this.t('untitledEvent'))}
         ${this.renderCombinedCornerBubbles(event)}
       </div>
@@ -10150,7 +10150,7 @@ class SkylightCalendarCard extends HTMLElement {
               const eventStyle = this.getEventStyle(event);
               return `
                 <div class="week-compact-event" style="${eventStyle} --event-bubble-font-size: ${this.getEventBubbleFontSize(event)}; --event-time-font-size: ${this.getEventTimeFontSize(event)}; --event-location-font-size: ${this.getEventLocationFontSize(event)}; --event-bubble-text-color: ${this.getEventBubbleFontColor(event)};" data-event='${JSON.stringify(event).replace(/'/g, "&#39;")}'>
-                  ${this.shouldShowEventTime(event) ? `<div class="week-compact-event-time">${timeLabel}</div>` : ''}
+                  ${this.shouldShowEventTime(event) ? `${this.shouldShowEventTime(event) ? `<div class="week-compact-event-time">${timeLabel}</div>` : ''}` : ''}
                   <div class="week-compact-event-title">${this.renderEventTitleWithPrefix(event, event.summary || this.t('untitledEvent'))}</div>
                   ${this.shouldShowEventLocation(event) ? `<div class="week-compact-event-location">📍 ${this.escapeHtml(this.getDisplayLocation(event.location, event))}</div>` : ''}
                   ${this.renderCombinedCornerBubbles(event)}

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -967,3 +967,60 @@ test('editor color swatches show effective calendar and event font colors', () =
   assert.equal(editor.getColorValue('event_font_colors', 'calendar.work'), '#000000');
   assert.equal(editor.getColorValue('event_font_colors', 'calendar.school'), '#123456');
 });
+
+test('hide_times_for_calendars applies across agenda, week-standard, week-compact, and month renderers', () => {
+  const hiddenEntityId = 'calendar.hidden';
+  const visibleEntityId = 'calendar.visible';
+  const baseDate = new Date('2026-05-14T00:00:00Z');
+
+  const hiddenEvent = {
+    entityId: hiddenEntityId,
+    color: '#3366ff',
+    summary: 'Hidden time event',
+    start: { dateTime: '2026-05-14T09:00:00Z' },
+    end: { dateTime: '2026-05-14T10:00:00Z' }
+  };
+  const visibleEvent = {
+    ...hiddenEvent,
+    entityId: visibleEntityId,
+    summary: 'Visible time event'
+  };
+
+  const card = makeCard({
+    entities: [hiddenEntityId, visibleEntityId],
+    hide_times_for_calendars: [hiddenEntityId]
+  });
+  card._hass = { states: {}, locale: { language: 'en' }, language: 'en', themes: { darkMode: false } };
+
+  const hiddenWeekCompact = card.renderWeekCompactEvent(hiddenEvent, baseDate);
+  const visibleWeekCompact = card.renderWeekCompactEvent(visibleEvent, baseDate);
+  assert.doesNotMatch(hiddenWeekCompact, /week-compact-event-time/);
+  assert.match(visibleWeekCompact, /week-compact-event-time/);
+
+  const hiddenMonthStandard = card.renderEvent(hiddenEvent, baseDate);
+  const visibleMonthStandard = card.renderEvent(visibleEvent, baseDate);
+  assert.doesNotMatch(hiddenMonthStandard, /class="event-time"/);
+  assert.match(visibleMonthStandard, /class="event-time"/);
+
+  card._config.show_all_details_month = true;
+  const hiddenMonthWeekCompact = card.renderMonthDayEvent(hiddenEvent, baseDate);
+  const visibleMonthWeekCompact = card.renderMonthDayEvent(visibleEvent, baseDate);
+  assert.doesNotMatch(hiddenMonthWeekCompact, /week-compact-event-time/);
+  assert.match(visibleMonthWeekCompact, /week-compact-event-time/);
+
+  const hiddenWeekStandard = card.renderTimedEventsForDay([hiddenEvent], baseDate, 0, 23, 40);
+  const visibleWeekStandard = card.renderTimedEventsForDay([visibleEvent], baseDate, 0, 23, 40);
+  assert.doesNotMatch(hiddenWeekStandard, /week-standard-event-time/);
+  assert.match(visibleWeekStandard, /week-standard-event-time/);
+
+  card._viewMode = 'agenda';
+  card._events = [hiddenEvent, visibleEvent];
+  card.getAgendaDays = () => [baseDate];
+  card.getAgendaEventMinHeight = () => '68px';
+  card.getCompactMaxHeight = () => null;
+  card.getCompactContainerStyle = () => '';
+  card.getEventsForDay = () => [hiddenEvent, visibleEvent];
+
+  const agendaHtml = card.renderAgenda();
+  assert.equal((agendaHtml.match(/agenda-event-time/g) || []).length, 1);
+});


### PR DESCRIPTION
### Motivation
- `hide_times_for_calendars` was not being applied consistently: week-compact event rows and month-standard event bubbles could still show start times for calendars configured to hide times.
- Add regression coverage to ensure the setting is respected across all renderers (agenda, week-standard, week-compact, month standard, and month show-all-details).

### Description
- Gate week-compact time rendering with `shouldShowEventTime(event)` so compact event rows omit the time for hidden calendars (`skylight-calendar-card.js`).
- Gate month-standard inline event time with `shouldShowEventTime(event)` so month day bubbles omit start times for hidden calendars (`skylight-calendar-card.js`).
- Add a test `hide_times_for_calendars applies across agenda, week-standard, week-compact, and month renderers` to `skylight-calendar-card.test.js` that validates behavior in agenda, week-standard, week-compact, month standard, and month-as-week-compact modes.

### Testing
- Ran the full test suite with `npm test -- --runInBand` and the run completed successfully with all tests passing (78 passed, 0 failed).
- The new regression test was included in that run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c6df32dc48331be3dd2609719326e)