### PR TITLE
Add day_badges feature: parsing, normalization, rendering, and tests

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1213,6 +1213,7 @@ class SkylightCalendarCard extends HTMLElement {
     const normalizedEventStyles = this.normalizeEventStyles(config.event_styles || []);
     const normalizedLocale = resolveLanguage(config.locale || config.language || this._hass?.locale?.language || this._hass?.language);
     const normalizedDayStyles = this.normalizeDayStyles(config.day_styles || [], normalizedLocale);
+    const normalizedDayBadges = this.normalizeDayBadges(config.day_badges || []);
     const normalizedHeaderColor = this.normalizeSingleColor(config.header_color);
     const normalizedHeaderTextColor = this.normalizeSingleColor(config.header_text_color);
     const hasConfiguredHeaderBackgroundOpacity = config.header_background_opacity !== undefined && config.header_background_opacity !== null && config.header_background_opacity !== '';
@@ -1305,6 +1306,7 @@ class SkylightCalendarCard extends HTMLElement {
       event_font_colors: normalizedEventFontColors, // Per-calendar font colors for event bubble text
       event_styles: normalizedEventStyles, // Per-event styling rules with match logic
       day_styles: normalizedDayStyles, // Per-day styling rules
+      day_badges: normalizedDayBadges, // Per-day header badges (YAML only)
       hide_times_for_calendars: config.hide_times_for_calendars || [], // Hide times in schedule view for specific calendars
       show_current_time_bar: config.show_current_time_bar || false, // Show a "now" indicator in schedule view
       header_color: normalizedHeaderColor !== undefined ? normalizedHeaderColor : 'var(--primary-color)', // Custom header background color/gradient
@@ -1353,8 +1355,8 @@ class SkylightCalendarCard extends HTMLElement {
       calendar_person_entities: normalizedCalendarPersonEntities,
       agenda_compact_events: config.agenda_compact_events ?? false,
       event_styles: normalizedEventStyles,
-      day_styles: normalizedDayStyles
-      ,
+      day_styles: normalizedDayStyles,
+      day_badges: normalizedDayBadges,
       event_color_mode: this.normalizeEventColorMode(config.event_color_mode ?? 'classic'),
       event_neutral_background: this.normalizeSingleColor(config.event_neutral_background) || '#F8F3E9',
       event_tint_opacity: this.normalizeBackgroundOpacity(config.event_tint_opacity, 80),
@@ -1737,6 +1739,109 @@ class SkylightCalendarCard extends HTMLElement {
         return normalized;
       })
       .filter(Boolean);
+  }
+
+
+
+  normalizeDayBadgeConditions(rawConditions) {
+    if (!rawConditions || typeof rawConditions !== 'object' || Array.isArray(rawConditions)) return null;
+
+    const normalized = { ...rawConditions };
+
+    if (normalized.title_contains !== undefined && normalized.title === undefined) {
+      normalized.title = `contains:${normalized.title_contains}`;
+      delete normalized.title_contains;
+    }
+
+    if (normalized.summary_contains !== undefined && normalized.summary === undefined) {
+      normalized.summary = `contains:${normalized.summary_contains}`;
+      delete normalized.summary_contains;
+    }
+
+    if (normalized.location_contains !== undefined && normalized.location === undefined) {
+      normalized.location = `contains:${normalized.location_contains}`;
+      delete normalized.location_contains;
+    }
+
+    if (normalized.calendar_entity !== undefined && normalized.calendar === undefined) {
+      normalized.calendar = normalized.calendar_entity;
+      delete normalized.calendar_entity;
+    }
+
+    if (normalized.entity_id !== undefined && normalized.calendar === undefined) {
+      normalized.calendar = normalized.entity_id;
+      delete normalized.entity_id;
+    }
+
+    if (normalized.entity !== undefined && normalized.calendar === undefined) {
+      normalized.calendar = normalized.entity;
+      delete normalized.entity;
+    }
+
+    if (normalized.all_day !== undefined && normalized.all_day_event === undefined) {
+      normalized.all_day_event = normalized.all_day;
+      delete normalized.all_day;
+    }
+
+    if (normalized.all_day_event !== undefined && normalized.all_day === undefined) {
+      normalized.all_day = normalized.all_day_event;
+      delete normalized.all_day_event;
+    }
+
+    return normalized;
+  }
+
+  normalizeDayBadges(rawRules) {
+    if (!Array.isArray(rawRules)) return [];
+
+    return rawRules
+      .map((rule) => {
+        if (!rule || typeof rule !== 'object') return null;
+        const conditions = this.normalizeDayBadgeConditions(rule.conditions);
+        if (!conditions) return null;
+
+        const text = this.normalizeEventTextValue(rule.text);
+        const icon = this.normalizeEventTextValue(rule.icon);
+        const normalizedText = text || '';
+        const normalizedIcon = icon || '';
+        if (!normalizedText && !normalizedIcon) return null;
+
+        const normalized = {
+          conditions
+        };
+        if (normalizedText) normalized.text = normalizedText;
+        if (!normalizedText && normalizedIcon) normalized.icon = normalizedIcon;
+
+        const backgroundColor = this.normalizeSingleColor(rule.background_color);
+        if (backgroundColor) normalized.background_color = backgroundColor;
+        const color = this.normalizeSingleColor(rule.color);
+        if (color) normalized.color = color;
+
+        const size = this.normalizeStyleSizeValue(rule.size);
+        if (size) normalized.size = size;
+
+        const fontSize = this.normalizeStyleSizeValue(rule.font_size);
+        if (fontSize) normalized.font_size = fontSize;
+        return normalized;
+      })
+      .filter(Boolean);
+  }
+
+
+  normalizeStyleSizeValue(value) {
+    if (value === undefined || value === null || value === '') return null;
+
+    if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+      return `${value}px`;
+    }
+
+    const trimmed = String(value).trim();
+    if (!trimmed) return null;
+    if (/^\d*\.?\d+(px|rem|em|%)$/i.test(trimmed)) return trimmed;
+
+    const parsed = Number(trimmed);
+    if (Number.isFinite(parsed) && parsed > 0) return `${parsed}px`;
+    return null;
   }
 
   normalizeStyleBorderWidth(value) {
@@ -3247,7 +3352,7 @@ class SkylightCalendarCard extends HTMLElement {
       }
 
       .calendar-badge-inline .calendar-badge-name {
-        font-size: 12px;
+        font-size: var(--day-badge-font-size, 12px);
       }
 
       .calendar-badge-inline .calendar-badge-person-state {
@@ -3588,7 +3693,7 @@ class SkylightCalendarCard extends HTMLElement {
         padding: 12px 8px;
         text-align: center;
         font-weight: 600;
-        font-size: 12px;
+        font-size: var(--day-badge-font-size, 12px);
         text-transform: uppercase;
         color: #6b7280;
         letter-spacing: 0.5px;
@@ -3664,6 +3769,35 @@ class SkylightCalendarCard extends HTMLElement {
         margin-bottom: 4px;
       }
 
+      .day-badges {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        margin-left: auto;
+        max-width: 100%;
+        overflow: hidden;
+      }
+
+      .day-badge {
+        width: var(--day-badge-size, 30px);
+        height: var(--day-badge-size, 30px);
+        min-width: var(--day-badge-size, 30px);
+        border-radius: 999px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: var(--day-badge-font-size, 12px);
+        font-weight: 700;
+        line-height: 1;
+        background: var(--day-badge-background, var(--primary-color));
+        color: var(--day-badge-color, var(--text-primary-color, #fff));
+      }
+
+      .day-badge ha-icon {
+        --mdc-icon-size: calc(var(--day-badge-size, 30px) * 0.53);
+        color: inherit;
+      }
+
       .day-header-row {
         display: flex;
         align-items: flex-start;
@@ -3692,7 +3826,7 @@ class SkylightCalendarCard extends HTMLElement {
       }
 
       .month-day-forecast .forecast-temperatures {
-        font-size: 12px;
+        font-size: var(--day-badge-font-size, 12px);
         gap: 2px;
       }
 
@@ -3835,7 +3969,7 @@ class SkylightCalendarCard extends HTMLElement {
       }
 
       .week-day-name {
-        font-size: 12px;
+        font-size: var(--day-badge-font-size, 12px);
         font-weight: 600;
         text-transform: uppercase;
         color: #6b7280;
@@ -3998,7 +4132,7 @@ class SkylightCalendarCard extends HTMLElement {
       }
 
       .agenda-day-weekday {
-        font-size: 12px;
+        font-size: var(--day-badge-font-size, 12px);
         font-weight: 600;
         text-transform: uppercase;
         color: #6b7280;
@@ -4127,7 +4261,7 @@ class SkylightCalendarCard extends HTMLElement {
 
       .agenda-empty-day {
         color: #9ca3af;
-        font-size: 12px;
+        font-size: var(--day-badge-font-size, 12px);
         padding: 8px 0;
       }
 
@@ -4386,7 +4520,7 @@ class SkylightCalendarCard extends HTMLElement {
       }
 
       .week-standard-day-name {
-        font-size: 12px;
+        font-size: var(--day-badge-font-size, 12px);
         font-weight: 600;
         text-transform: uppercase;
         color: #6b7280;
@@ -6063,6 +6197,7 @@ class SkylightCalendarCard extends HTMLElement {
                   <div class="week-day-name">${dayNames[date.getDay()]}</div>
                   <div class="week-day-meta-row">
                     <div class="week-day-date">${date.getDate()}</div>
+                    ${this.renderDayBadges(date, events)}
                     ${this.renderDayForecast(date, 'week-compact')}
                   </div>
                 </div>
@@ -6147,6 +6282,7 @@ class SkylightCalendarCard extends HTMLElement {
                   <div class="week-standard-day-name">${dayNames[date.getDay()]}</div>
                   <div class="week-day-meta-row">
                     <div class="week-standard-day-date">${date.getDate()}</div>
+                    ${this.renderDayBadges(date, dayEvents)}
                     ${this.renderDayForecast(date, 'week-standard')}
                   </div>
                 </div>
@@ -7179,6 +7315,33 @@ class SkylightCalendarCard extends HTMLElement {
     `;
   }
 
+  getDayBadges(date, dayEvents) {
+    const rules = Array.isArray(this._config?.day_badges) ? this._config.day_badges : [];
+    if (!rules.length || !Array.isArray(dayEvents) || !dayEvents.length) return [];
+
+    return rules.filter((rule) => dayEvents.some((event) => this.eventMatchesRule(event, rule.conditions)));
+  }
+
+  renderDayBadges(date, dayEvents) {
+    const badges = this.getDayBadges(date, dayEvents);
+    if (!badges.length) return '';
+
+    const badgesHtml = badges.map((badge) => {
+      const style = [
+        badge.background_color ? `--day-badge-background: ${badge.background_color};` : '',
+        badge.color ? `--day-badge-color: ${badge.color};` : '',
+        badge.size ? `--day-badge-size: ${badge.size};` : '',
+        badge.font_size ? `--day-badge-font-size: ${badge.font_size};` : ''
+      ].join(' ');
+      const content = badge.text
+        ? `<span class="day-badge-text">${this.escapeHtml(badge.text)}</span>`
+        : `<ha-icon icon="${this.escapeHtml(badge.icon)}"></ha-icon>`;
+      return `<span class="day-badge" style="${style}">${content}</span>`;
+    }).join('');
+
+    return `<div class="day-badges">${badgesHtml}</div>`;
+  }
+
   renderDay(dayNum, date, isOtherMonth) {
     const today = new Date();
     const isToday = date.toDateString() === today.toDateString();
@@ -7202,6 +7365,7 @@ class SkylightCalendarCard extends HTMLElement {
       <div class="${classes}" data-date="${date.toISOString()}"${dayStyleAttr}>
         <div class="day-header-row">
           <div class="day-number">${dayNum}</div>
+          ${this.renderDayBadges(date, dayEvents)}
           ${this.renderDayForecast(date, 'month')}
         </div>
         ${dayEvents.slice(0, visibleEvents).map(event => this.renderMonthDayEvent(event, date)).join('')}
@@ -10925,6 +11089,7 @@ class SkylightCalendarCard extends HTMLElement {
       event_neutral_background: '#F8F3E9',
       event_tint_opacity: 80,
       event_color_bar_width: 18,
+      day_badges: [],
       hide_calendars: false,
       hide_year: false,
       hide_controls: false,

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1748,43 +1748,59 @@ class SkylightCalendarCard extends HTMLElement {
 
     const normalized = { ...rawConditions };
 
-    if (normalized.title_contains !== undefined && normalized.title === undefined) {
-      normalized.title = `contains:${normalized.title_contains}`;
+    if (normalized.title_contains !== undefined) {
+      if (normalized.title === undefined) {
+        normalized.title = `contains:${normalized.title_contains}`;
+      }
       delete normalized.title_contains;
     }
 
-    if (normalized.summary_contains !== undefined && normalized.summary === undefined) {
-      normalized.summary = `contains:${normalized.summary_contains}`;
+    if (normalized.summary_contains !== undefined) {
+      if (normalized.summary === undefined) {
+        normalized.summary = `contains:${normalized.summary_contains}`;
+      }
       delete normalized.summary_contains;
     }
 
-    if (normalized.location_contains !== undefined && normalized.location === undefined) {
-      normalized.location = `contains:${normalized.location_contains}`;
+    if (normalized.location_contains !== undefined) {
+      if (normalized.location === undefined) {
+        normalized.location = `contains:${normalized.location_contains}`;
+      }
       delete normalized.location_contains;
     }
 
-    if (normalized.calendar_entity !== undefined && normalized.calendar === undefined) {
-      normalized.calendar = normalized.calendar_entity;
+    if (normalized.calendar_entity !== undefined) {
+      if (normalized.calendar === undefined) {
+        normalized.calendar = normalized.calendar_entity;
+      }
       delete normalized.calendar_entity;
     }
 
-    if (normalized.entity_id !== undefined && normalized.calendar === undefined) {
-      normalized.calendar = normalized.entity_id;
+    if (normalized.entity_id !== undefined) {
+      if (normalized.calendar === undefined) {
+        normalized.calendar = normalized.entity_id;
+      }
       delete normalized.entity_id;
     }
 
-    if (normalized.entity !== undefined && normalized.calendar === undefined) {
-      normalized.calendar = normalized.entity;
+    if (normalized.entity !== undefined) {
+      if (normalized.calendar === undefined) {
+        normalized.calendar = normalized.entity;
+      }
       delete normalized.entity;
     }
 
-    if (normalized.all_day !== undefined && normalized.all_day_event === undefined) {
-      normalized.all_day_event = normalized.all_day;
+    if (normalized.all_day !== undefined) {
+      if (normalized.all_day_event === undefined) {
+        normalized.all_day_event = normalized.all_day;
+      }
       delete normalized.all_day;
     }
 
-    if (normalized.all_day_event !== undefined && normalized.all_day === undefined) {
-      normalized.all_day = normalized.all_day_event;
+    if (normalized.all_day_event !== undefined) {
+      if (normalized.all_day === undefined) {
+        normalized.all_day = normalized.all_day_event;
+      }
       delete normalized.all_day_event;
     }
 

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -675,6 +675,61 @@ test('event_styles apply rule priority and match logic', () => {
   assert.equal(card.eventMatchesRule(event, { title: 'meeting', not: { title: 'holiday' } }), true);
 });
 
+
+test('day_badges renders text badge when event title matches', () => {
+  const card = makeCard({ entities: ['calendar.a'], day_badges: [{ conditions: { title_contains: 'ballet' }, text: 'PL', background_color: '#ff4b2b', color: '#000000' }] });
+  const events = [{ entityId: 'calendar.a', summary: 'Ballet Practice', start: { dateTime: '2026-05-01T10:00:00Z' }, end: { dateTime: '2026-05-01T11:00:00Z' } }];
+  const html = card.renderDayBadges(new Date('2026-05-01T00:00:00Z'), events);
+  assert.match(html, /day-badge-text">PL</);
+});
+
+test('day_badges renders icon badge when event title matches', () => {
+  const card = makeCard({ entities: ['calendar.a'], day_badges: [{ conditions: { title: 'ballet' }, icon: 'mdi:shoe-ballet' }] });
+  const events = [{ entityId: 'calendar.a', summary: 'Ballet Practice', start: { dateTime: '2026-05-01T10:00:00Z' }, end: { dateTime: '2026-05-01T11:00:00Z' } }];
+  const html = card.renderDayBadges(new Date('2026-05-01T00:00:00Z'), events);
+  assert.match(html, /ha-icon icon="mdi:shoe-ballet"/);
+});
+
+test('day_badges prefers text when both text and icon are configured', () => {
+  const card = makeCard({ entities: ['calendar.a'], day_badges: [{ conditions: { title: 'ballet' }, text: 'PL', icon: 'mdi:shoe-ballet' }] });
+  const events = [{ entityId: 'calendar.a', summary: 'Ballet Practice', start: { dateTime: '2026-05-01T10:00:00Z' }, end: { dateTime: '2026-05-01T11:00:00Z' } }];
+  const html = card.renderDayBadges(new Date('2026-05-01T00:00:00Z'), events);
+  assert.match(html, /day-badge-text">PL</);
+  assert.doesNotMatch(html, /mdi:shoe-ballet/);
+});
+
+test('day_badges does not render on non-matching days', () => {
+  const card = makeCard({ entities: ['calendar.a'], day_badges: [{ conditions: { title: 'ballet' }, text: 'PL' }] });
+  const events = [{ entityId: 'calendar.a', summary: 'Daily Sync', start: { dateTime: '2026-05-01T10:00:00Z' }, end: { dateTime: '2026-05-01T11:00:00Z' } }];
+  assert.equal(card.renderDayBadges(new Date('2026-05-01T00:00:00Z'), events), '');
+});
+
+test('day_badges renders multiple matching badge rules', () => {
+  const card = makeCard({ entities: ['calendar.a'], day_badges: [
+    { conditions: { title: 'sync' }, text: 'S' },
+    { conditions: { calendar: 'calendar.a' }, icon: 'mdi:calendar' }
+  ] });
+
+
+
+test('day_badges supports legacy-style condition aliases', () => {
+  const card = makeCard({ entities: ['calendar.a'], day_badges: [{ conditions: { entity: 'calendar.a', location_contains: 'mountain' }, text: 'L' }] });
+  const events = [{ entityId: 'calendar.a', summary: 'Run', location: 'Black Mountain Rd', start: { dateTime: '2026-05-01T10:00:00Z' }, end: { dateTime: '2026-05-01T11:00:00Z' } }];
+  const html = card.renderDayBadges(new Date('2026-05-01T00:00:00Z'), events);
+  assert.match(html, /day-badge-text">L</);
+});
+test('day_badges supports configurable size and font_size', () => {
+  const card = makeCard({ entities: ['calendar.a'], day_badges: [{ conditions: { title: 'ballet' }, text: 'PL', size: 32, font_size: '14px' }] });
+  const events = [{ entityId: 'calendar.a', summary: 'Ballet Practice', start: { dateTime: '2026-05-01T10:00:00Z' }, end: { dateTime: '2026-05-01T11:00:00Z' } }];
+  const html = card.renderDayBadges(new Date('2026-05-01T00:00:00Z'), events);
+  assert.match(html, /--day-badge-size: 32px;/);
+  assert.match(html, /--day-badge-font-size: 14px;/);
+});
+
+  const events = [{ entityId: 'calendar.a', summary: 'Daily Sync', start: { dateTime: '2026-05-01T10:00:00Z' }, end: { dateTime: '2026-05-01T11:00:00Z' } }];
+  const html = card.renderDayBadges(new Date('2026-05-01T00:00:00Z'), events);
+  assert.equal((html.match(/class="day-badge"/g) || []).length, 2);
+});
 test('day_styles evaluate today/weekend/has_event rules and auto background', () => {
   const card = makeCard({
     entities: ['calendar.a'],

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -710,7 +710,10 @@ test('day_badges renders multiple matching badge rules', () => {
     { conditions: { calendar: 'calendar.a' }, icon: 'mdi:calendar' }
   ] });
 
-
+  const events = [{ entityId: 'calendar.a', summary: 'Daily Sync', start: { dateTime: '2026-05-01T10:00:00Z' }, end: { dateTime: '2026-05-01T11:00:00Z' } }];
+  const html = card.renderDayBadges(new Date('2026-05-01T00:00:00Z'), events);
+  assert.equal((html.match(/class="day-badge"/g) || []).length, 2);
+});
 
 test('day_badges supports legacy-style condition aliases', () => {
   const card = makeCard({ entities: ['calendar.a'], day_badges: [{ conditions: { entity: 'calendar.a', location_contains: 'mountain' }, text: 'L' }] });
@@ -718,17 +721,13 @@ test('day_badges supports legacy-style condition aliases', () => {
   const html = card.renderDayBadges(new Date('2026-05-01T00:00:00Z'), events);
   assert.match(html, /day-badge-text">L</);
 });
+
 test('day_badges supports configurable size and font_size', () => {
   const card = makeCard({ entities: ['calendar.a'], day_badges: [{ conditions: { title: 'ballet' }, text: 'PL', size: 32, font_size: '14px' }] });
   const events = [{ entityId: 'calendar.a', summary: 'Ballet Practice', start: { dateTime: '2026-05-01T10:00:00Z' }, end: { dateTime: '2026-05-01T11:00:00Z' } }];
   const html = card.renderDayBadges(new Date('2026-05-01T00:00:00Z'), events);
   assert.match(html, /--day-badge-size: 32px;/);
   assert.match(html, /--day-badge-font-size: 14px;/);
-});
-
-  const events = [{ entityId: 'calendar.a', summary: 'Daily Sync', start: { dateTime: '2026-05-01T10:00:00Z' }, end: { dateTime: '2026-05-01T11:00:00Z' } }];
-  const html = card.renderDayBadges(new Date('2026-05-01T00:00:00Z'), events);
-  assert.equal((html.match(/class="day-badge"/g) || []).length, 2);
 });
 test('day_styles evaluate today/weekend/has_event rules and auto background', () => {
   const card = makeCard({


### PR DESCRIPTION
### Motivation
- Add per-day header badges to surface quick visual markers for days that match event-based conditions.
- Provide a YAML-friendly API with legacy alias support and size/font customization for badges.

### Description
- Introduce `day_badges` configuration parsing and normalization via `normalizeDayBadges` and `normalizeDayBadgeConditions`, including legacy alias handling for common fields.
- Add `normalizeStyleSizeValue` to support numeric and CSS unit inputs for `size` and `font_size`, and wire normalized badges into the card config and defaults (`day_badges: []`).
- Implement rendering and matching: `getDayBadges` filters rules by matching events, and `renderDayBadges` emits badge HTML with CSS custom properties for background, color, size, and font size; integrate badge rendering into month, week-compact, and week-standard headers.
- Add CSS styles and CSS variables (`--day-badge-size`, `--day-badge-font-size`, `--day-badge-background`, `--day-badge-color`) to style badges consistently.

### Testing
- Added unit tests in `skylight-calendar-card.test.js` covering text badge rendering, icon badge rendering, preference for text over icon, non-matching days, legacy condition aliases, and size/font_size handling; ran the updated test suite and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d349e2f848331a1781aaf2f7fb922)