### PR TITLE
Allow event_styles to hide events but still use them for badges/styles

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1650,7 +1650,12 @@ class SkylightCalendarCard extends HTMLElement {
         if (!rule || typeof rule !== 'object') return null;
 
         const match = rule.match && typeof rule.match === 'object' ? rule.match : null;
-        const style = rule.style && typeof rule.style === 'object' ? rule.style : null;
+        let style = null;
+        if (typeof rule.style === 'string' && rule.style.trim().toLowerCase() === 'hide') {
+          style = { hide: true };
+        } else if (rule.style && typeof rule.style === 'object') {
+          style = rule.style;
+        }
         if (!match || !style) return null;
 
         const numericPriority = Number(rule.priority);
@@ -1983,6 +1988,8 @@ class SkylightCalendarCard extends HTMLElement {
     if (showTime !== null) normalized.show_time = showTime;
     const hideCalendarBubble = this.normalizeBooleanStyleValue(style.hide_event_calendar_bubble);
     if (hideCalendarBubble !== null) normalized.hide_event_calendar_bubble = hideCalendarBubble;
+    const hideEvent = this.normalizeBooleanStyleValue(style.hide);
+    if (hideEvent !== null) normalized.hide = hideEvent;
     if (style.event_title_prefix !== undefined) normalized.event_title_prefix = this.normalizeEventTitlePrefixMode(style.event_title_prefix);
 
     return normalized;
@@ -6202,8 +6209,9 @@ class SkylightCalendarCard extends HTMLElement {
       <div class="week-compact-container">
         ${weekDays.map(date => {
           const isToday = date.toDateString() === today.toDateString();
-          const events = this.sortEventsForDate(this.getEventsForDay(date), date);
-          const dayStyle = this.getDayStyleAttributes(date, events, isToday);
+          const dayEventsForMatching = this.getEventsForDay(date, { includeHiddenStyledEvents: true });
+          const events = this.sortEventsForDate(dayEventsForMatching.filter((event) => !this.isEventHiddenByStyle(event)), date);
+          const dayStyle = this.getDayStyleAttributes(date, dayEventsForMatching, isToday);
           const dayStyleAttr = dayStyle.style ? ` style="${dayStyle.style}"` : '';
 
           return `
@@ -6213,7 +6221,7 @@ class SkylightCalendarCard extends HTMLElement {
                   <div class="week-day-name">${dayNames[date.getDay()]}</div>
                   <div class="week-day-meta-row">
                     <div class="week-day-date">${date.getDate()}</div>
-                    ${this.renderDayBadges(date, events)}
+                    ${this.renderDayBadges(date, dayEventsForMatching)}
                     ${this.renderDayForecast(date, 'week-compact')}
                   </div>
                 </div>
@@ -6285,10 +6293,11 @@ class SkylightCalendarCard extends HTMLElement {
         <!-- Day columns -->
         ${weekDays.map(date => {
           const isToday = date.toDateString() === today.toDateString();
-          const dayEvents = this.sortEventsForDate(this.getEventsForDay(date), date);
+          const dayEventsForMatching = this.getEventsForDay(date, { includeHiddenStyledEvents: true });
+          const dayEvents = this.sortEventsForDate(dayEventsForMatching.filter((event) => !this.isEventHiddenByStyle(event)), date);
           const dateKey = this.getDateKey(date);
           const allDayLanes = allDayLayout.dayLanesByDateKey.get(dateKey) || [];
-          const dayStyle = this.getDayStyleAttributes(date, dayEvents, isToday);
+          const dayStyle = this.getDayStyleAttributes(date, dayEventsForMatching, isToday);
           const dayStyleAttr = dayStyle.style ? ` style="${dayStyle.style}"` : '';
 
           return `
@@ -6298,7 +6307,7 @@ class SkylightCalendarCard extends HTMLElement {
                   <div class="week-standard-day-name">${dayNames[date.getDay()]}</div>
                   <div class="week-day-meta-row">
                     <div class="week-standard-day-date">${date.getDate()}</div>
-                    ${this.renderDayBadges(date, dayEvents)}
+                    ${this.renderDayBadges(date, dayEventsForMatching)}
                     ${this.renderDayForecast(date, 'week-standard')}
                   </div>
                 </div>
@@ -6333,7 +6342,12 @@ class SkylightCalendarCard extends HTMLElement {
     const agendaDayEntries = agendaDays
       .map((date) => ({
         date,
-        events: this.sortEventsForDate(this.getEventsForDay(date), date)
+        matchingEvents: this.getEventsForDay(date, { includeHiddenStyledEvents: true }),
+        events: null
+      }))
+      .map((entry) => ({
+        ...entry,
+        events: this.sortEventsForDate(entry.matchingEvents.filter((event) => !this.isEventHiddenByStyle(event)), entry.date)
       }))
       .filter((entry) => !shouldHideEmptyDays || entry.events.length > 0);
 
@@ -6348,7 +6362,7 @@ class SkylightCalendarCard extends HTMLElement {
       }
 
       const isToday = date.toDateString() === today.toDateString();
-      const dayStyle = this.getDayStyleAttributes(date, events, isToday);
+      const dayStyle = this.getDayStyleAttributes(date, entry.matchingEvents, isToday);
       const dayStyleAttr = dayStyle.style ? ` style="${dayStyle.style}"` : '';
       agendaRows.push(`
         <div class="agenda-day-row ${isToday ? 'today' : ''} ${dayStyle.className}" data-date="${date.toISOString()}"${dayStyleAttr}>
@@ -7361,8 +7375,8 @@ class SkylightCalendarCard extends HTMLElement {
   renderDay(dayNum, date, isOtherMonth) {
     const today = new Date();
     const isToday = date.toDateString() === today.toDateString();
-    let dayEvents = this.getEventsForDay(date);
-
+    const dayEventsForMatching = this.getEventsForDay(date, { includeHiddenStyledEvents: true });
+    let dayEvents = dayEventsForMatching.filter((event) => !this.isEventHiddenByStyle(event));
     dayEvents = this.sortEventsForDate(dayEvents, date);
 
     const maxVisible = this.getMaxVisibleEventsForMonthDay();
@@ -7373,7 +7387,7 @@ class SkylightCalendarCard extends HTMLElement {
     let classes = 'day-cell';
     if (isOtherMonth) classes += ' other-month';
     if (isToday) classes += ' today';
-    const dayStyle = this.getDayStyleAttributes(date, dayEvents, isToday);
+    const dayStyle = this.getDayStyleAttributes(date, dayEventsForMatching, isToday);
     classes += dayStyle.className ? ` ${dayStyle.className}` : '';
     const dayStyleAttr = dayStyle.style ? ` style="${dayStyle.style}"` : '';
 
@@ -7381,7 +7395,7 @@ class SkylightCalendarCard extends HTMLElement {
       <div class="${classes}" data-date="${date.toISOString()}"${dayStyleAttr}>
         <div class="day-header-row">
           <div class="day-number">${dayNum}</div>
-          ${this.renderDayBadges(date, dayEvents)}
+          ${this.renderDayBadges(date, dayEventsForMatching)}
           ${this.renderDayForecast(date, 'month')}
         </div>
         ${dayEvents.slice(0, visibleEvents).map(event => this.renderMonthDayEvent(event, date)).join('')}
@@ -7682,6 +7696,10 @@ class SkylightCalendarCard extends HTMLElement {
     return overrides;
   }
 
+  isEventHiddenByStyle(event) {
+    return this.getEventStyleOverrides(event)?.hide === true;
+  }
+
   createZebraStripeGradient(colors) {
     if (colors.length === 1) {
       return colors[0];
@@ -7959,11 +7977,14 @@ class SkylightCalendarCard extends HTMLElement {
     });
   }
 
-  getEventsForDay(date) {
+  getEventsForDay(date, { includeHiddenStyledEvents = false } = {}) {
     const sourceEvents = this.combineDuplicateCalendarEvents(this._events);
 
     return sourceEvents.filter(event => {
       if (this.getVisibleCalendarColorsForEvent(event).length === 0) {
+        return false;
+      }
+      if (!includeHiddenStyledEvents && this.isEventHiddenByStyle(event)) {
         return false;
       }
 

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -675,6 +675,61 @@ test('event_styles apply rule priority and match logic', () => {
   assert.equal(card.eventMatchesRule(event, { title: 'meeting', not: { title: 'holiday' } }), true);
 });
 
+test('event_styles supports `style: hide` and keeps hidden events available for day_badges matching', () => {
+  const card = makeCard({
+    entities: ['calendar.a'],
+    event_styles: [{ match: { title: 'private' }, style: 'hide' }],
+    day_badges: [{ conditions: { title: 'private' }, text: 'P' }]
+  });
+  card._events = [
+    { entityId: 'calendar.a', color: '#f00', summary: 'Private Meeting', start: { dateTime: '2026-05-01T10:00:00Z' }, end: { dateTime: '2026-05-01T11:00:00Z' } }
+  ];
+
+  const day = new Date('2026-05-01T00:00:00Z');
+  const visibleEvents = card.getEventsForDay(day);
+  const badgeEvents = card.getEventsForDay(day, { includeHiddenStyledEvents: true });
+
+  assert.equal(visibleEvents.length, 0);
+  assert.equal(badgeEvents.length, 1);
+  assert.match(card.renderDayBadges(day, badgeEvents), /day-badge-text">P</);
+});
+
+test('event_styles supports object hide syntax and hidden events still trigger day_styles has_event', () => {
+  const card = makeCard({
+    entities: ['calendar.a'],
+    event_styles: [{ match: { title: 'private' }, style: { hide: true } }],
+    day_styles: [{ condition: 'has_event', calendar: 'calendar.a', title_match: 'private', background: '#123456' }]
+  });
+  card._events = [
+    { entityId: 'calendar.a', color: '#f00', summary: 'Private Meeting', start: { dateTime: '2026-05-01T10:00:00Z' }, end: { dateTime: '2026-05-01T11:00:00Z' } }
+  ];
+
+  const day = new Date('2026-05-01T00:00:00Z');
+  const matchingEvents = card.getEventsForDay(day, { includeHiddenStyledEvents: true });
+  const visibleEvents = matchingEvents.filter((event) => !card.isEventHiddenByStyle(event));
+  const dayStyle = card.getDayStyleAttributes(day, matchingEvents, false);
+
+  assert.equal(visibleEvents.length, 0);
+  assert.match(dayStyle.style, /#123456/);
+});
+
+test('hidden events do not contribute to month overflow counts', () => {
+  const card = makeCard({
+    entities: ['calendar.a'],
+    max_events: 1,
+    event_styles: [{ match: { title: 'private' }, style: 'hide' }]
+  });
+  card._events = [
+    { entityId: 'calendar.a', color: '#0f0', summary: 'Visible Event', start: { dateTime: '2026-05-01T08:00:00Z' }, end: { dateTime: '2026-05-01T09:00:00Z' } },
+    { entityId: 'calendar.a', color: '#f00', summary: 'Private Event', start: { dateTime: '2026-05-01T10:00:00Z' }, end: { dateTime: '2026-05-01T11:00:00Z' } }
+  ];
+
+  const html = card.renderDay(1, new Date('2026-05-01T00:00:00Z'), false);
+  assert.doesNotMatch(html, /more-events/);
+  assert.doesNotMatch(html, /Private Event/);
+  assert.match(html, /Visible Event/);
+});
+
 
 test('day_badges renders text badge when event title matches', () => {
   const card = makeCard({ entities: ['calendar.a'], day_badges: [{ conditions: { title_contains: 'ballet' }, text: 'PL', background_color: '#ff4b2b', color: '#000000' }] });


### PR DESCRIPTION
### Motivation

- Add first-class support for hiding events via `event_styles` while preserving hidden events for matching `day_badges` and `day_styles` logic.

### Description

- Accept `style: 'hide'` shorthand and object `{ hide: true }` when normalizing `event_styles` and propagate `hide` into normalized style blocks via `normalizeEventStyles` and `normalizeEventStyleBlock` usage.
- Introduce `isEventHiddenByStyle(event)` helper and extend `getEventsForDay` with an optional `{ includeHiddenStyledEvents }` flag so callers can request events including hidden-styled ones or only visible events.
- Update rendering paths (`renderWeekCompact`, `renderWeekStandard`, `renderAgenda`, `renderDay`, `renderMonthDayEvent`, badge rendering) to compute day-level style attributes and badges using the full set of matching events while filtering hidden events out of visible event lists and overflow counts.
- Ensure event style resolution still produces overrides (including `hide`) and that hidden events remain available for day-level matching by passing `includeHiddenStyledEvents: true` where appropriate.

### Testing

- Added unit tests `event_styles supports \\`style: hide\\` and keeps hidden events available for day_badges matching`, `event_styles supports object hide syntax and hidden events still trigger day_styles has_event`, and `hidden events do not contribute to month overflow counts` to `skylight-calendar-card.test.js` and ran the test suite with `npm test`.
- All tests in the suite succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f7d1e46e0833183889d5244b84ec5)