### PR TITLE
Add configurable rolling-days mode for agenda view

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1263,6 +1263,7 @@ class SkylightCalendarCard extends HTMLElement {
       week_days: config.week_days || [0, 1, 2, 3, 4, 5, 6], // Which days to show in week view
       rolling_days_week_compact: config.rolling_days_week_compact ?? null, // If set, compact week view shows current day + N days instead of week_days
       rolling_days_schedule: config.rolling_days_schedule ?? null, // If set, schedule week view shows current day + N days instead of week_days
+      rolling_days_agenda: config.rolling_days_agenda ?? null, // If set, agenda view shows current day + N days and navigates by that period
       rolling_weeks: config.rolling_weeks || null, // If set, show current week + N weeks in month view
       show_week_numbers_month: config.show_week_numbers_month || false, // In month view, show ISO 8601 week numbers on the left side
       show_all_events_month: config.show_all_events_month || false, // In month view, show all events and allow week rows to grow while keeping row minimum height
@@ -1354,6 +1355,7 @@ class SkylightCalendarCard extends HTMLElement {
         : null,
       calendar_person_entities: normalizedCalendarPersonEntities,
       agenda_compact_events: config.agenda_compact_events ?? false,
+      rolling_days_agenda: config.rolling_days_agenda ?? null,
       event_styles: normalizedEventStyles,
       day_styles: normalizedDayStyles,
       day_badges: normalizedDayBadges,
@@ -3036,7 +3038,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._agendaStartDate = new Date(today);
 
     const endDate = new Date(today);
-    endDate.setDate(endDate.getDate() + 14);
+    endDate.setDate(endDate.getDate() + this.getAgendaPeriodDaySpan());
     endDate.setHours(23, 59, 59, 999);
     this._agendaEndDate = endDate;
     this._agendaVisibleStartDate = new Date(today);
@@ -3176,6 +3178,19 @@ class SkylightCalendarCard extends HTMLElement {
     }
 
     return Math.max(1, dayCount || this._agendaDaysPerScrollLoad);
+  }
+
+  getAgendaRollingDays() {
+    if (this._config?.rolling_days_agenda !== null && this._config?.rolling_days_agenda !== undefined) {
+      return this._config.rolling_days_agenda;
+    }
+
+    return null;
+  }
+
+  getAgendaPeriodDaySpan() {
+    const rollingDays = this.getAgendaRollingDays();
+    return rollingDays !== null ? rollingDays : 14;
   }
 
   getRollingDaysForView(viewMode = this._viewMode) {
@@ -8100,7 +8115,9 @@ class SkylightCalendarCard extends HTMLElement {
       const nearBottom = agendaContainer.scrollTop + agendaContainer.clientHeight >= agendaContainer.scrollHeight - threshold;
       const nearTop = agendaContainer.scrollTop <= threshold;
       const canLoadPastAgendaDays = this.canNavigateToPreviousPeriod();
+      const isRollingAgendaMode = this.getAgendaRollingDays() !== null;
 
+      if (isRollingAgendaMode) return;
       if (!nearBottom && !(nearTop && canLoadPastAgendaDays)) return;
 
       this._agendaScrollLoadLock = true;
@@ -8276,7 +8293,10 @@ class SkylightCalendarCard extends HTMLElement {
 
     if (this._viewMode === 'agenda') {
       this.ensureAgendaWindowInitialized();
-      const backwardDays = this.getAgendaViewportDayCapacity();
+      const rollingDays = this.getAgendaRollingDays();
+      const backwardDays = rollingDays !== null
+        ? rollingDays + 1
+        : this.getAgendaViewportDayCapacity();
       this._agendaStartDate.setDate(this._agendaStartDate.getDate() - backwardDays);
       this._agendaStartDate.setHours(0, 0, 0, 0);
       this._agendaEndDate.setDate(this._agendaEndDate.getDate() - backwardDays);
@@ -8320,8 +8340,11 @@ class SkylightCalendarCard extends HTMLElement {
   navigateToNextPeriod() {
     if (this._viewMode === 'agenda') {
       this.ensureAgendaWindowInitialized();
+      const rollingDays = this.getAgendaRollingDays();
       const dayMs = 24 * 60 * 60 * 1000;
-      const windowSpanDays = Math.max(0, Math.round((this._agendaEndDate.getTime() - this._agendaStartDate.getTime()) / dayMs));
+      const windowSpanDays = rollingDays !== null
+        ? rollingDays
+        : Math.max(0, Math.round((this._agendaEndDate.getTime() - this._agendaStartDate.getTime()) / dayMs));
       const visibleRangeFromDom = this.getAgendaVisibleDateRangeFromDom();
       const visibleRangeFromCache = this._agendaVisibleStartDate && this._agendaVisibleEndDate
         ? { startDate: this._agendaVisibleStartDate, endDate: this._agendaVisibleEndDate }
@@ -8329,8 +8352,13 @@ class SkylightCalendarCard extends HTMLElement {
       const visibleRange = visibleRangeFromDom || (
         this.isAgendaRangeWithinCurrentWindow(visibleRangeFromCache) ? visibleRangeFromCache : null
       );
-      const targetStart = visibleRange ? new Date(visibleRange.endDate) : new Date(this._agendaEndDate);
+      const targetStart = rollingDays !== null
+        ? new Date(this._agendaStartDate)
+        : (visibleRange ? new Date(visibleRange.endDate) : new Date(this._agendaEndDate));
       targetStart.setHours(0, 0, 0, 0);
+      if (rollingDays !== null) {
+        targetStart.setDate(targetStart.getDate() + rollingDays + 1);
+      }
 
       const targetEnd = new Date(targetStart);
       targetEnd.setDate(targetEnd.getDate() + windowSpanDays);
@@ -11791,6 +11819,12 @@ class SkylightCalendarCardEditor extends HTMLElement {
         <div class="field field-inline">
           <label for="rolling_days_schedule">Rolling days (schedule view)</label>
           <input id="rolling_days_schedule" data-field="rolling_days_schedule" data-type="nullable-number" type="number" min="1" value="${this._config.rolling_days_schedule ?? ''}" placeholder="Disabled">
+        </div>
+      </div>
+      <div class="field-row">
+        <div class="field field-inline">
+          <label for="rolling_days_agenda">Rolling days (agenda view)</label>
+          <input id="rolling_days_agenda" data-field="rolling_days_agenda" data-type="nullable-number" type="number" min="1" value="${this._config.rolling_days_agenda ?? ''}" placeholder="Disabled">
         </div>
       </div>
       <div class="field-row">

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -541,7 +541,7 @@ test('header button listeners invoke expected actions', () => {
     'view-mode-select': { value: 'month', addEventListener: (evt, cb) => { handlers['view-mode-select:'+evt] = cb; } }
   };
   card.getRootElementById = (id) => elements[id] || null;
-  card._root = { querySelector: () => null, querySelectorAll: () => [] };
+  card._root = { querySelector: () => null, querySelectorAll: (sel) => (sel === '.agenda-day-row' ? [] : []) };
   let prev=0,next=0,add=0,nav=0;
   card.observeModalVisibility = () => {};
   card.navigateToPreviousPeriod = () => { prev++; };
@@ -558,6 +558,65 @@ test('header button listeners invoke expected actions', () => {
   handlers['add-event-btn:click']();
   handlers['header-dashboard-btn:click']();
   assert.equal(prev,1);assert.equal(next,1);assert.equal(add,1);assert.equal(nav,1);
+});
+
+test('agenda rolling days are configurable and include current day + N days', () => {
+  const card = makeCard({ entities: ['calendar.family'], rolling_days_agenda: 4 });
+
+  card.resetAgendaWindowToToday();
+
+  const dayMs = 24 * 60 * 60 * 1000;
+  const spanDays = Math.round((card._agendaEndDate.getTime() - card._agendaStartDate.getTime()) / dayMs);
+  assert.equal(spanDays, 5);
+  assert.equal(card.getAgendaDays().length, 5);
+});
+
+test('agenda vertical scroll loading is disabled in rolling-days mode', async () => {
+  const card = makeCard({ entities: ['calendar.family'], rolling_days_agenda: 2 });
+  const handlers = {};
+  const mkEl = (id) => ({ id, addEventListener: (evt, cb) => { handlers[id + ':' + evt] = cb; } });
+  const agendaContainer = {
+    ...mkEl('agenda-container'),
+    scrollTop: 500,
+    clientHeight: 300,
+    scrollHeight: 780,
+    getBoundingClientRect: () => ({ top: 0, bottom: 300 }),
+    querySelectorAll: () => []
+  };
+  const elements = {
+    'prev-period': mkEl('prev-period'),
+    'next-period': mkEl('next-period'),
+    'today': mkEl('today'),
+    'add-event-btn': mkEl('add-event-btn'),
+    'theme-toggle': mkEl('theme-toggle'),
+    'header-dashboard-btn': mkEl('header-dashboard-btn'),
+    'event-modal': mkEl('event-modal'),
+    'agenda-container': agendaContainer,
+    'view-mode-select': { value: 'agenda', addEventListener: (evt, cb) => { handlers['view-mode-select:'+evt] = cb; } }
+  };
+  card.getRootElementById = (id) => elements[id] || null;
+  card._root = { querySelector: () => null, querySelectorAll: (sel) => (sel === '.agenda-day-row' ? [] : []) };
+  card.observeModalVisibility = () => {};
+  card.navigateToPreviousPeriod = () => {};
+  card.navigateToNextPeriod = () => {};
+  card.showCreateEventModal = () => {};
+  card.navigateToConfiguredDashboard = () => {};
+  card.applyThemeMode = () => {};
+  card.persistPreferences = () => {};
+  card.render = () => {};
+  card._viewMode = 'agenda';
+  card.resetAgendaWindowToToday();
+  const originalStart = new Date(card._agendaStartDate);
+  const originalEnd = new Date(card._agendaEndDate);
+  let ensureCalls = 0;
+  card.ensureEventsForCurrentRange = async () => { ensureCalls += 1; };
+
+  card.attachEventListeners();
+  await handlers['agenda-container:scroll']();
+
+  assert.equal(ensureCalls, 0);
+  assert.equal(card._agendaStartDate.toISOString(), originalStart.toISOString());
+  assert.equal(card._agendaEndDate.toISOString(), originalEnd.toISOString());
 });
 
 test('editor renders key controls and updates config on change', () => {


### PR DESCRIPTION
### Motivation

- Provide an independently configurable rolling-days mode for the agenda view that matches the existing +1 semantics used by other rolling modes. 
- Prevent the agenda from automatically extending its day window via vertical scrolling when the agenda is configured to a fixed rolling window. 
- Preserve normal intra-window vertical scrolling for events while keeping header prev/next buttons working to move between configured windows.

### Description

- Added a new config key `rolling_days_agenda` and wired it into config normalization and the editor UI as `Rolling days (agenda view)`. 
- Introduced `getAgendaRollingDays()` and `getAgendaPeriodDaySpan()` helpers and used them to initialize the agenda window in `resetAgendaWindowToToday()` so the agenda window becomes `current day + N days` when configured. 
- Disabled the scroll-driven extension of the agenda period when `rolling_days_agenda` is set by early-returning in the agenda scroll handler, while leaving event-level scrolling intact. 
- Updated `navigateToPreviousPeriod()` and `navigateToNextPeriod()` to advance the agenda by `rolling_days_agenda + 1` days when in rolling agenda mode and preserved legacy behavior when unset. 

### Testing

- Added two unit tests: one verifying the agenda rolling window size and one ensuring vertical scroll loading is disabled when `rolling_days_agenda` is set. 
- Ran the full test suite with `npm test -- --runInBand`, which completed successfully with all tests passing (including the two new tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fe415b9248331aa5654df86754358)