### PR TITLE
Add `hide_header` option to fully remove header strip

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1282,6 +1282,7 @@ class SkylightCalendarCard extends HTMLElement {
       compact_header: config.compact_header || false, // Compact header layout
       hide_year: config.hide_year || false, // Hide year in header period label
       hide_calendars: config.hide_calendars || false, // Hide calendar badges from header area
+      hide_header: config.hide_header || false, // Hide entire header area (including background strip)
       hide_calendar_names: config.hide_calendar_names || false, // Header calendar badges: show icons only
       hide_controls: config.hide_controls || false, // Hide all header controls (add/view/theme/navigation)
       hide_navigation_buttons: config.hide_navigation_buttons || false, // Hide previous/next/today header navigation buttons
@@ -5912,7 +5913,7 @@ class SkylightCalendarCard extends HTMLElement {
       ` : ''}
 
       <div class="calendar-container ${this._isDarkMode ? 'dark-mode' : ''} ${hasCustomBackground ? 'custom-background' : ''} ${this._config.hide_year ? 'hide-year' : ''} ${this._config.agenda_compact_events ? 'agenda-compact-events' : ''}" style="${containerStyle}">
-        ${this._config.compact_header ? this.renderCompactHeader() : this.renderStandardHeader()}
+        ${this._config.hide_header ? '' : (this._config.compact_header ? this.renderCompactHeader() : this.renderStandardHeader())}
         <div class="calendar-body">
           ${this.renderCalendarView()}
 
@@ -11156,6 +11157,7 @@ class SkylightCalendarCard extends HTMLElement {
       event_color_bar_width: 18,
       day_badges: [],
       hide_calendars: false,
+      hide_header: false,
       hide_year: false,
       hide_controls: false,
       hide_navigation_buttons: false,
@@ -11842,6 +11844,7 @@ class SkylightCalendarCardEditor extends HTMLElement {
         <label><input type="checkbox" data-field="compact_header" ${this._config.compact_header ? 'checked' : ''}> Compact header</label>
         <label><input type="checkbox" data-field="hide_year" ${this._config.hide_year ? 'checked' : ''}> Hide year in header period label</label>
         <label><input type="checkbox" data-field="hide_calendars" ${this._config.hide_calendars ? 'checked' : ''}> Hide calendar badges</label>
+        <label><input type="checkbox" data-field="hide_header" ${this._config.hide_header ? 'checked' : ''}> Hide entire header</label>
         <label><input type="checkbox" data-field="hide_calendar_names" ${this._config.hide_calendar_names ? 'checked' : ''}> Header badges: hide calendar names</label>
         <label><input type="checkbox" data-field="hide_controls" ${this._config.hide_controls ? 'checked' : ''}> Hide all header controls</label>
         <label><input type="checkbox" data-field="hide_navigation_buttons" ${this._config.hide_navigation_buttons ? 'checked' : ''}> Hide previous/next and today buttons</label>

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -110,7 +110,7 @@ test('getStubConfig includes key configuration defaults', () => {
     'show_current_time_bar', 'show_event_location', 'use_short_location',
     'event_calendar_friendly_name', 'event_title_prefix', 'past_event_mode', 'event_color_mode',
     'event_neutral_background', 'event_tint_opacity', 'event_color_bar_width', 'combine_style',
-    'combine_background', 'hide_calendars', 'hide_year', 'hide_controls',
+    'combine_background', 'hide_calendars', 'hide_header', 'hide_year', 'hide_controls',
     'hide_navigation_buttons', 'hide_add_event_button', 'hide_view_selector',
     'hide_dark_mode_toggle', 'show_dashboard_nav_button', 'header_dashboard_path',
     'header_weather_sensor', 'calendar_person_entities', 'color_scheme', 'enable_event_management'
@@ -127,6 +127,7 @@ test('setConfig applies visual layout and styling options', () => {
     compact_header: true,
     hide_year: true,
     hide_calendars: true,
+    hide_header: true,
     hide_calendar_names: true,
     hide_controls: true,
     hide_navigation_buttons: true,
@@ -177,6 +178,7 @@ test('setConfig applies visual layout and styling options', () => {
   assert.equal(card._config.compact_header, true);
   assert.equal(card._config.hide_year, true);
   assert.equal(card._config.hide_calendars, true);
+  assert.equal(card._config.hide_header, true);
   assert.equal(card._config.hide_calendar_names, true);
   assert.equal(card._config.hide_controls, true);
   assert.equal(card._config.hide_navigation_buttons, true);
@@ -377,6 +379,16 @@ test('calendar render includes header controls and modal container', () => {
   assert.match(html, /id="next-period"/);
   assert.match(html, /id="today"/);
   assert.match(html, /id="event-modal"/);
+});
+
+test('hide_header removes the header wrapper entirely', () => {
+  const card = new Card();
+  card._hass = { states: {}, locale: { language: 'en' }, language: 'en', themes: { darkMode: false } };
+  card.setConfig({ entities: ['calendar.family'], hide_header: true });
+  originalCardRender.call(card);
+  const html = card._root.innerHTML;
+  assert.doesNotMatch(html, /class="header/);
+  assert.match(html, /class="calendar-body"/);
 });
 
 


### PR DESCRIPTION
### Motivation
- Users can already hide individual header elements but a thin header background strip could remain; provide a single toggle to remove the header markup and background entirely.
- Keep visual editor parity and default config behavior by exposing the option in the editor and stub defaults.

### Description
- Added a new boolean config option `hide_header` to runtime normalization so it is available via `setConfig` and stored on `this._config` (in `skylight-calendar-card.js`).
- Updated rendering to skip header markup when `hide_header` is true by removing the header render call from the container template.
- Added `hide_header: false` to the stub defaults and exposed a checkbox in the visual editor labeled `Hide entire header`.
- Updated tests in `skylight-calendar-card.test.js` to assert the new stub key, `setConfig` behavior, and that rendering with `hide_header: true` removes the header wrapper.

### Testing
- Ran the unit test suite with `npm test -- --runInBand`; all automated tests passed (`91` tests, `0` failures).
- Added test `hide_header removes the header wrapper entirely` which passed as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10f8c24a70833194aeb75d48e897e0)