### PR TITLE
Scope day_badge CSS vars to prevent header wrapping (fix #321)

### DIFF
--- a/playwright/visual.spec.js
+++ b/playwright/visual.spec.js
@@ -338,34 +338,3 @@ test('regression: month compact-height view selector stays clickable without dev
   await expect(card.locator('.calendar-grid')).toBeVisible();
   await expect(selector).toBeEnabled();
 });
-
-test('regression #321: header does not wrap when day_badges is empty', async ({ page }) => {
-  await page.setViewportSize({ width: 1135, height: 800 });
-
-  const fixtureUrl = `file://${path.join(process.cwd(), 'playwright', 'ha-fixture.html')}`;
-  await page.goto(fixtureUrl);
-  await page.evaluate((params) => window.renderCalendarCard(params), {
-    config: {
-      entities: ['calendar.family', 'calendar.work'],
-      title: 'Header Wrap Regression',
-      default_view: 'week-compact',
-      compact_header: false,
-      compact_height: false,
-      hide_dark_mode_toggle: true,
-      show_dashboard_nav_button: true,
-      enable_event_management: true,
-      hide_view_selector: false,
-      header_weather_sensor: 'weather.mock',
-      day_badges: [],
-      font_family: 'Arial Black, Arial, sans-serif'
-    },
-    events: baseEvents,
-    weather: { condition: 'sunny', temperature: 72 },
-    darkMode: false
-  });
-
-  const card = page.locator('skylight-calendar-card');
-  const header = card.locator('.header').first();
-  await expect(header).toBeVisible();
-  await expect(header).not.toHaveClass(/is-wrapped/);
-});

--- a/playwright/visual.spec.js
+++ b/playwright/visual.spec.js
@@ -338,3 +338,34 @@ test('regression: month compact-height view selector stays clickable without dev
   await expect(card.locator('.calendar-grid')).toBeVisible();
   await expect(selector).toBeEnabled();
 });
+
+test('regression #321: header does not wrap when day_badges is empty', async ({ page }) => {
+  await page.setViewportSize({ width: 1135, height: 800 });
+
+  const fixtureUrl = `file://${path.join(process.cwd(), 'playwright', 'ha-fixture.html')}`;
+  await page.goto(fixtureUrl);
+  await page.evaluate((params) => window.renderCalendarCard(params), {
+    config: {
+      entities: ['calendar.family', 'calendar.work'],
+      title: 'Header Wrap Regression',
+      default_view: 'week-compact',
+      compact_header: false,
+      compact_height: false,
+      hide_dark_mode_toggle: true,
+      show_dashboard_nav_button: true,
+      enable_event_management: true,
+      hide_view_selector: false,
+      header_weather_sensor: 'weather.mock',
+      day_badges: [],
+      font_family: 'Arial Black, Arial, sans-serif'
+    },
+    events: baseEvents,
+    weather: { condition: 'sunny', temperature: 72 },
+    darkMode: false
+  });
+
+  const card = page.locator('skylight-calendar-card');
+  const header = card.locator('.header').first();
+  await expect(header).toBeVisible();
+  await expect(header).not.toHaveClass(/is-wrapped/);
+});

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3315,7 +3315,7 @@ class SkylightCalendarCard extends HTMLElement {
         display: flex;
         justify-content: space-between;
         align-items: center;
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
         gap: 12px;
       }
 
@@ -3347,6 +3347,8 @@ class SkylightCalendarCard extends HTMLElement {
         display: flex;
         align-items: center;
         gap: 16px;
+        flex: 1 1 auto;
+        min-width: 0;
       }
 
       .compact-header-left {
@@ -5777,9 +5779,11 @@ class SkylightCalendarCard extends HTMLElement {
         .header {
           flex-direction: column;
           align-items: stretch;
+          flex-wrap: wrap;
         }
 
         .header-controls {
+          flex-wrap: wrap;
           justify-content: space-between;
         }
 

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3394,7 +3394,7 @@ class SkylightCalendarCard extends HTMLElement {
       }
 
       .calendar-badge-inline .calendar-badge-name {
-        font-size: var(--day-badge-font-size, 12px);
+        font-size: 12px;
       }
 
       .calendar-badge-inline .calendar-badge-person-state {
@@ -3735,7 +3735,7 @@ class SkylightCalendarCard extends HTMLElement {
         padding: 12px 8px;
         text-align: center;
         font-weight: 600;
-        font-size: var(--day-badge-font-size, 12px);
+        font-size: 12px;
         text-transform: uppercase;
         color: #6b7280;
         letter-spacing: 0.5px;
@@ -3821,22 +3821,22 @@ class SkylightCalendarCard extends HTMLElement {
       }
 
       .day-badge {
-        width: var(--day-badge-size, 30px);
-        height: var(--day-badge-size, 30px);
-        min-width: var(--day-badge-size, 30px);
+        width: var(--dcc-day-badge-size, 30px);
+        height: var(--dcc-day-badge-size, 30px);
+        min-width: var(--dcc-day-badge-size, 30px);
         border-radius: 999px;
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        font-size: var(--day-badge-font-size, 12px);
+        font-size: var(--dcc-day-badge-font-size, 12px);
         font-weight: 700;
         line-height: 1;
-        background: var(--day-badge-background, var(--primary-color));
-        color: var(--day-badge-color, var(--text-primary-color, #fff));
+        background: var(--dcc-day-badge-background, var(--primary-color));
+        color: var(--dcc-day-badge-color, var(--text-primary-color, #fff));
       }
 
       .day-badge ha-icon {
-        --mdc-icon-size: calc(var(--day-badge-size, 30px) * 0.53);
+        --mdc-icon-size: calc(var(--dcc-day-badge-size, 30px) * 0.53);
         color: inherit;
       }
 
@@ -3868,7 +3868,7 @@ class SkylightCalendarCard extends HTMLElement {
       }
 
       .month-day-forecast .forecast-temperatures {
-        font-size: var(--day-badge-font-size, 12px);
+        font-size: 12px;
         gap: 2px;
       }
 
@@ -4011,7 +4011,7 @@ class SkylightCalendarCard extends HTMLElement {
       }
 
       .week-day-name {
-        font-size: var(--day-badge-font-size, 12px);
+        font-size: 12px;
         font-weight: 600;
         text-transform: uppercase;
         color: #6b7280;
@@ -4174,7 +4174,7 @@ class SkylightCalendarCard extends HTMLElement {
       }
 
       .agenda-day-weekday {
-        font-size: var(--day-badge-font-size, 12px);
+        font-size: 12px;
         font-weight: 600;
         text-transform: uppercase;
         color: #6b7280;
@@ -4303,7 +4303,7 @@ class SkylightCalendarCard extends HTMLElement {
 
       .agenda-empty-day {
         color: #9ca3af;
-        font-size: var(--day-badge-font-size, 12px);
+        font-size: 12px;
         padding: 8px 0;
       }
 
@@ -4562,7 +4562,7 @@ class SkylightCalendarCard extends HTMLElement {
       }
 
       .week-standard-day-name {
-        font-size: var(--day-badge-font-size, 12px);
+        font-size: 12px;
         font-weight: 600;
         text-transform: uppercase;
         color: #6b7280;
@@ -7377,10 +7377,10 @@ class SkylightCalendarCard extends HTMLElement {
 
     const badgesHtml = badges.map((badge) => {
       const style = [
-        badge.background_color ? `--day-badge-background: ${badge.background_color};` : '',
-        badge.color ? `--day-badge-color: ${badge.color};` : '',
-        badge.size ? `--day-badge-size: ${badge.size};` : '',
-        badge.font_size ? `--day-badge-font-size: ${badge.font_size};` : ''
+        badge.background_color ? `--dcc-day-badge-background: ${badge.background_color};` : '',
+        badge.color ? `--dcc-day-badge-color: ${badge.color};` : '',
+        badge.size ? `--dcc-day-badge-size: ${badge.size};` : '',
+        badge.font_size ? `--dcc-day-badge-font-size: ${badge.font_size};` : ''
       ].join(' ');
       const content = badge.text
         ? `<span class="day-badge-text">${this.escapeHtml(badge.text)}</span>`

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3315,7 +3315,7 @@ class SkylightCalendarCard extends HTMLElement {
         display: flex;
         justify-content: space-between;
         align-items: center;
-        flex-wrap: nowrap;
+        flex-wrap: wrap;
         gap: 12px;
       }
 
@@ -3347,8 +3347,6 @@ class SkylightCalendarCard extends HTMLElement {
         display: flex;
         align-items: center;
         gap: 16px;
-        flex: 1 1 auto;
-        min-width: 0;
       }
 
       .compact-header-left {
@@ -3501,8 +3499,7 @@ class SkylightCalendarCard extends HTMLElement {
         display: flex;
         gap: 12px;
         align-items: center;
-        flex-wrap: nowrap;
-        min-width: 0;
+        flex-wrap: wrap;
       }
 
       .compact-header-controls {
@@ -3514,8 +3511,7 @@ class SkylightCalendarCard extends HTMLElement {
         display: flex;
         align-items: center;
         gap: 12px;
-        flex: 1 1 auto;
-        min-width: 0;
+        flex: 0 1 auto;
         margin-left: auto;
       }
 
@@ -5779,11 +5775,9 @@ class SkylightCalendarCard extends HTMLElement {
         .header {
           flex-direction: column;
           align-items: stretch;
-          flex-wrap: wrap;
         }
 
         .header-controls {
-          flex-wrap: wrap;
           justify-content: space-between;
         }
 

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3499,7 +3499,8 @@ class SkylightCalendarCard extends HTMLElement {
         display: flex;
         gap: 12px;
         align-items: center;
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
+        min-width: 0;
       }
 
       .compact-header-controls {
@@ -3511,7 +3512,8 @@ class SkylightCalendarCard extends HTMLElement {
         display: flex;
         align-items: center;
         gap: 12px;
-        flex: 0 1 auto;
+        flex: 1 1 auto;
+        min-width: 0;
         margin-left: auto;
       }
 

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -872,12 +872,32 @@ test('day_badge CSS variables do not leak into non-badge selectors', () => {
   ];
 
   for (const selector of leakingSelectors) {
-    const selectorIndex = styles.indexOf(selector);
-    assert.notEqual(selectorIndex, -1);
-    const blockEnd = styles.indexOf('}', selectorIndex);
-    const block = styles.slice(selectorIndex, blockEnd + 1);
-    assert.doesNotMatch(block, /var\(--dcc-day-badge-/);
+    let start = 0;
+    let foundAny = false;
+
+    while ((start = styles.indexOf(selector, start)) !== -1) {
+      foundAny = true;
+      const end = styles.indexOf('}', start);
+      const block = styles.slice(start, end + 1);
+
+      assert.doesNotMatch(block, /var\(--day-badge-/);
+      assert.doesNotMatch(block, /var\(--dcc-day-badge-/);
+
+      start = end;
+    }
+
+    assert.equal(foundAny, true);
   }
+});
+
+test('legacy day_badge CSS variables are fully removed from styles', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const styles = card.getStyles();
+
+  assert.doesNotMatch(styles, /--day-badge-size/);
+  assert.doesNotMatch(styles, /--day-badge-font-size/);
+  assert.doesNotMatch(styles, /--day-badge-background/);
+  assert.doesNotMatch(styles, /--day-badge-color/);
 });
 
 test('empty day_badges config does not emit badge variables', () => {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -852,8 +852,41 @@ test('day_badges supports configurable size and font_size', () => {
   const card = makeCard({ entities: ['calendar.a'], day_badges: [{ conditions: { title: 'ballet' }, text: 'PL', size: 32, font_size: '14px' }] });
   const events = [{ entityId: 'calendar.a', summary: 'Ballet Practice', start: { dateTime: '2026-05-01T10:00:00Z' }, end: { dateTime: '2026-05-01T11:00:00Z' } }];
   const html = card.renderDayBadges(new Date('2026-05-01T00:00:00Z'), events);
-  assert.match(html, /--day-badge-size: 32px;/);
-  assert.match(html, /--day-badge-font-size: 14px;/);
+  assert.match(html, /--dcc-day-badge-size: 32px;/);
+  assert.match(html, /--dcc-day-badge-font-size: 14px;/);
+  assert.doesNotMatch(html, /--day-badge-size:/);
+  assert.doesNotMatch(html, /--day-badge-font-size:/);
+});
+
+test('day_badge CSS variables do not leak into non-badge selectors', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const styles = card.getStyles();
+  const leakingSelectors = [
+    '.day-header',
+    '.week-day-name',
+    '.agenda-day-weekday',
+    '.agenda-empty-day',
+    '.calendar-badge-name',
+    '.week-standard-day-name',
+    '.forecast-temperatures'
+  ];
+
+  for (const selector of leakingSelectors) {
+    const selectorIndex = styles.indexOf(selector);
+    assert.notEqual(selectorIndex, -1);
+    const blockEnd = styles.indexOf('}', selectorIndex);
+    const block = styles.slice(selectorIndex, blockEnd + 1);
+    assert.doesNotMatch(block, /var\(--dcc-day-badge-/);
+  }
+});
+
+test('empty day_badges config does not emit badge variables', () => {
+  const card = makeCard({ entities: ['calendar.a'], day_badges: [] });
+  const events = [{ entityId: 'calendar.a', summary: 'Ballet Practice', start: { dateTime: '2026-05-01T10:00:00Z' }, end: { dateTime: '2026-05-01T11:00:00Z' } }];
+  const html = card.renderDayBadges(new Date('2026-05-01T00:00:00Z'), events);
+  assert.equal(html, '');
+  assert.doesNotMatch(html, /--dcc-day-badge-/);
+  assert.doesNotMatch(html, /--day-badge-/);
 });
 test('day_styles evaluate today/weekend/has_event rules and auto background', () => {
   const card = makeCard({


### PR DESCRIPTION
### Motivation
- Prevent badge-specific CSS variables from leaking into unrelated layout/font rules which caused the header to wrap when `day_badges: []` (regression introduced in v4.3.0). 
- Keep `day_badges` behavior identical for users while isolating internal styling so empty/unused badges do not affect layout.

### Description
- Renamed internal CSS custom properties from `--day-badge-*` to `--dcc-day-badge-*` and updated all inline style emission in `renderDayBadges()` to emit the new names so badge styles remain internal to badge elements (`skylight-calendar-card.js`).
- Removed badge-var references from non-badge selectors and restored fixed sizing (12px) for header/day labels/forecast/week labels/etc., ensuring unrelated selectors no longer reference badge variables (`skylight-calendar-card.js`).
- Updated unit tests to assert the new variables are emitted, legacy names are absent, badge variables do not leak into non-badge selectors, and empty `day_badges: []` emits no badge variables (`skylight-calendar-card.test.js`).
- Added a Playwright visual regression test reproducing issue #321 (1135x800, `day_badges: []`, weather + dashboard nav button enabled) that asserts the header is not wrapped (`playwright/visual.spec.js`).

### Testing
- Ran unit tests with `node --test skylight-calendar-card.test.js` and all tests passed (`95` tests, `0` failures).
- Attempted to run the isolated Playwright regression with `npx playwright test playwright/visual.spec.js -g "regression #321"` but the browser binaries were not available in this environment (Playwright reports `npx playwright install` is required), so the visual test is added but could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1123f922548331a99632bc31436e0e)