### PR TITLE
Fix header wrap detection for compact/standard headers and add regression tests (issue 321)

### DIFF
--- a/playwright/visual.spec.js
+++ b/playwright/visual.spec.js
@@ -338,3 +338,83 @@ test('regression: month compact-height view selector stays clickable without dev
   await expect(card.locator('.calendar-grid')).toBeVisible();
   await expect(selector).toBeEnabled();
 });
+
+test('regression issue 321: compact header stays single-row in wide layout when naturally unwrapped', async ({ page }) => {
+  await page.setViewportSize({ width: 1360, height: 820 });
+  const fixtureUrl = `file://${path.join(process.cwd(), 'playwright', 'ha-fixture.html')}`;
+  await page.goto(fixtureUrl);
+  await page.evaluate((params) => window.renderCalendarCard(params), {
+    config: {
+      entities: ['calendar.family', 'calendar.work'],
+      title: 'Issue 321 Compact',
+      default_view: 'week-compact',
+      compact_header: true,
+      compact_height: false,
+      hide_dark_mode_toggle: true,
+      show_dashboard_nav_button: true,
+      header_weather_sensor: 'weather.mock',
+      enable_event_management: true,
+      hide_view_selector: false,
+      day_badges: [],
+      uix: { style: '.nav-button,.today-button,.add-event-button,.view-mode-select{font-size:18px!important;}' }
+    },
+    events: baseEvents,
+    weather: { 'weather.mock': { temperature: 72, condition: 'sunny' } },
+    darkMode: false
+  });
+
+  const card = page.locator('skylight-calendar-card');
+  await expect(card).toBeVisible();
+  await expect(card.locator('.header-compact')).toBeVisible();
+
+  await expect.poll(async () => {
+    return await card.evaluate((host) => {
+      const root = host.shadowRoot;
+      const left = root.querySelector('.compact-header-left');
+      const controls = root.querySelector('.compact-header-controls');
+      if (!left || !controls) return null;
+      const delta = Math.abs(left.getBoundingClientRect().top - controls.getBoundingClientRect().top);
+      return delta;
+    });
+  }).toBeLessThan(2);
+});
+
+test('regression issue 321: standard header stays single-row in wide layout when naturally unwrapped', async ({ page }) => {
+  await page.setViewportSize({ width: 1360, height: 820 });
+  const fixtureUrl = `file://${path.join(process.cwd(), 'playwright', 'ha-fixture.html')}`;
+  await page.goto(fixtureUrl);
+  await page.evaluate((params) => window.renderCalendarCard(params), {
+    config: {
+      entities: ['calendar.family', 'calendar.work'],
+      title: 'Issue 321 Standard',
+      default_view: 'week-standard',
+      compact_header: false,
+      compact_height: false,
+      hide_dark_mode_toggle: true,
+      show_dashboard_nav_button: true,
+      header_weather_sensor: 'weather.mock',
+      enable_event_management: true,
+      hide_view_selector: false,
+      day_badges: [],
+      uix: { style: '.nav-button,.today-button,.add-event-button,.view-mode-select{font-size:18px!important;}' }
+    },
+    events: baseEvents,
+    weather: { 'weather.mock': { temperature: 72, condition: 'sunny' } },
+    darkMode: false
+  });
+
+  const card = page.locator('skylight-calendar-card');
+  await expect(card).toBeVisible();
+  await expect(card.locator('.header')).toBeVisible();
+
+  await expect.poll(async () => {
+    return await card.evaluate((host) => {
+      const root = host.shadowRoot;
+      const left = root.querySelector('.header-left');
+      const controls = root.querySelector('.header-controls');
+      if (!left || !controls) return null;
+      const delta = Math.abs(left.getBoundingClientRect().top - controls.getBoundingClientRect().top);
+      return delta;
+    });
+  }).toBeLessThan(2);
+});

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -909,6 +909,8 @@ class SkylightCalendarCard extends HTMLElement {
     this._modalVisibilityObserver = null;
     this._monthMeasureRaf = null;
     this._monthMeasureRenderRaf = null;
+    this._wrapMeasureRaf1 = null;
+    this._wrapMeasureRaf2 = null;
     this._monthGridResizeObserver = null;
     this._monthCompactMeasurementDirty = true;
     this._lastCompactMonthViewportHeight = null;
@@ -1127,47 +1129,58 @@ class SkylightCalendarCard extends HTMLElement {
 
   updateCompactHeaderWrapState() {
     if (!this._root) return;
-
-    const headerSelector = this._config.compact_header ? '.header-compact' : '.header';
-    const header = this._root.querySelector(headerSelector);
-    if (header) {
-      const topLevelChildren = Array.from(header.children).filter((child) => child.offsetParent !== null);
-      if (topLevelChildren.length <= 1) {
-        header.classList.remove('is-wrapped');
-      } else {
-        const firstTop = topLevelChildren[0].offsetTop;
-        const headerWrapped = topLevelChildren.some((child) => Math.abs(child.offsetTop - firstTop) > 1);
-        header.classList.toggle('is-wrapped', headerWrapped);
-      }
-    }
-
-    const controlsSelector = this._config.compact_header ? '.compact-header-controls' : '.header-controls';
-    const controls = this._root.querySelector(controlsSelector);
-    if (controls) {
-      const visibleChildren = Array.from(controls.children).filter((child) => child.offsetParent !== null);
-      if (visibleChildren.length <= 1) {
-        controls.classList.remove('is-wrapped');
-      } else {
-        const firstRowTop = visibleChildren[0].offsetTop;
-        const isWrapped = visibleChildren.some((child) => Math.abs(child.offsetTop - firstRowTop) > 1);
-        controls.classList.toggle('is-wrapped', isWrapped);
-      }
-    }
-
-    if (!this._config.compact_header) return;
-
-    const badges = this._root.querySelector('.calendar-badges-inline');
-    if (!badges) return;
-
-    const visibleBadges = Array.from(badges.children).filter((child) => child.offsetParent !== null);
-    if (visibleBadges.length <= 1) {
-      badges.classList.remove('is-wrapped');
+    if (typeof window.requestAnimationFrame !== 'function') {
+      this.measureAndApplyHeaderWrapState();
       return;
     }
+    if (this._wrapMeasureRaf1 !== null) window.cancelAnimationFrame(this._wrapMeasureRaf1);
+    if (this._wrapMeasureRaf2 !== null) window.cancelAnimationFrame(this._wrapMeasureRaf2);
+    this._wrapMeasureRaf1 = window.requestAnimationFrame(() => {
+      this._wrapMeasureRaf1 = null;
+      this._wrapMeasureRaf2 = window.requestAnimationFrame(() => {
+        this._wrapMeasureRaf2 = null;
+        this.measureAndApplyHeaderWrapState();
+      });
+    });
+  }
 
-    const firstBadgeTop = visibleBadges[0].offsetTop;
-    const badgesWrapped = visibleBadges.some((child) => Math.abs(child.offsetTop - firstBadgeTop) > 1);
-    badges.classList.toggle('is-wrapped', badgesWrapped);
+  shouldMarkWrappedFromChildren(children) {
+    const visibleChildren = children.filter((child) => child.offsetParent !== null);
+    if (visibleChildren.length <= 1) return false;
+    const firstTop = visibleChildren[0].offsetTop;
+    return visibleChildren.some((child) => Math.abs(child.offsetTop - firstTop) > 1);
+  }
+
+  measureAndApplyHeaderWrapState() {
+    if (!this._root) return;
+
+    const headerSelector = this._config.compact_header ? '.header-compact' : '.header';
+    const controlsSelector = this._config.compact_header ? '.compact-header-controls' : '.header-controls';
+    const header = this._root.querySelector(headerSelector);
+    const controls = this._root.querySelector(controlsSelector);
+    const compactControls = this._root.querySelector('.compact-header-controls');
+    const standardControls = this._root.querySelector('.header-controls');
+    const badges = this._root.querySelector('.calendar-badges-inline');
+
+    header?.classList.remove('is-wrapped');
+    standardControls?.classList.remove('is-wrapped');
+    compactControls?.classList.remove('is-wrapped');
+    badges?.classList.remove('is-wrapped');
+
+    if (header) {
+      const headerChildren = this._config.compact_header
+        ? [header.querySelector('.compact-header-left'), header.querySelector('.compact-header-controls')]
+        : [header.querySelector('.header-left'), header.querySelector('.header-controls')];
+      header.classList.toggle('is-wrapped', this.shouldMarkWrappedFromChildren(headerChildren.filter(Boolean)));
+    }
+
+    if (controls) {
+      controls.classList.toggle('is-wrapped', this.shouldMarkWrappedFromChildren(Array.from(controls.children)));
+    }
+
+    if (this._config.compact_header && badges) {
+      badges.classList.toggle('is-wrapped', this.shouldMarkWrappedFromChildren(Array.from(badges.children)));
+    }
   }
 
 
@@ -2816,6 +2829,14 @@ class SkylightCalendarCard extends HTMLElement {
       this._modalVisibilityObserver.disconnect();
       this._modalVisibilityObserver = null;
     }
+    if (this._wrapMeasureRaf1 !== null) {
+      window.cancelAnimationFrame(this._wrapMeasureRaf1);
+      this._wrapMeasureRaf1 = null;
+    }
+    if (this._wrapMeasureRaf2 !== null) {
+      window.cancelAnimationFrame(this._wrapMeasureRaf2);
+      this._wrapMeasureRaf2 = null;
+    }
   }
 
   getCompactMaxHeight(containerTopInViewport = null) {
@@ -3356,7 +3377,6 @@ class SkylightCalendarCard extends HTMLElement {
 
       .header.is-wrapped .header-left,
       .header.is-wrapped .header-controls {
-        width: 100%;
         justify-content: center;
       }
 

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -908,6 +908,139 @@ test('empty day_badges config does not emit badge variables', () => {
   assert.doesNotMatch(html, /--dcc-day-badge-/);
   assert.doesNotMatch(html, /--day-badge-/);
 });
+
+test('standard header wrapped state does not force header groups to full width', () => {
+  const card = makeCard({ entities: ['calendar.a'], compact_header: false });
+  const styles = card.getStyles();
+  const standardRuleIndex = styles.indexOf('.header.is-wrapped .header-left');
+  assert.notEqual(standardRuleIndex, -1);
+  const standardRuleEnd = styles.indexOf('}', standardRuleIndex);
+  const standardRule = styles.slice(standardRuleIndex, standardRuleEnd + 1);
+
+  assert.doesNotMatch(standardRule, /width:\s*100%/);
+  assert.match(standardRule, /justify-content:\s*center/);
+});
+
+test('compact header wrapped state still forces full-width centered groups', () => {
+  const card = makeCard({ entities: ['calendar.a'], compact_header: true });
+  const styles = card.getStyles();
+
+  const compactRuleIndex = styles.indexOf('.header-compact.is-wrapped .compact-header-left');
+  assert.notEqual(compactRuleIndex, -1);
+
+  const compactRuleEnd = styles.indexOf('}', compactRuleIndex);
+  const compactRule = styles.slice(compactRuleIndex, compactRuleEnd + 1);
+
+  assert.match(compactRule, /width:\s*100%/);
+  assert.match(compactRule, /justify-content:\s*center/);
+});
+
+test('issue 321 standard header wrapped state does not force full-width rows', () => {
+  const card = makeCard({
+    entities: ['calendar.a'],
+    compact_header: false,
+    day_badges: [],
+    hide_dark_mode_toggle: true,
+    show_dashboard_nav_button: true,
+    header_weather_sensor: 'weather.home',
+    enable_event_management: true
+  });
+
+  const styles = card.getStyles();
+
+  const standardRuleIndex = styles.indexOf('.header.is-wrapped .header-left');
+  assert.notEqual(standardRuleIndex, -1);
+  const standardRuleEnd = styles.indexOf('}', standardRuleIndex);
+  const standardRule = styles.slice(standardRuleIndex, standardRuleEnd + 1);
+  assert.doesNotMatch(standardRule, /width:\s*100%/);
+});
+
+test('shouldMarkWrappedFromChildren only marks wrapped when visible children occupy different rows', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const sameRowChildren = [
+    { offsetParent: {}, offsetTop: 10 },
+    { offsetParent: {}, offsetTop: 10 }
+  ];
+  const wrappedChildren = [
+    { offsetParent: {}, offsetTop: 10 },
+    { offsetParent: {}, offsetTop: 26 }
+  ];
+  const hiddenChildren = [
+    { offsetParent: null, offsetTop: 10 },
+    { offsetParent: null, offsetTop: 26 }
+  ];
+
+  assert.equal(card.shouldMarkWrappedFromChildren(sameRowChildren), false);
+  assert.equal(card.shouldMarkWrappedFromChildren(wrappedChildren), true);
+  assert.equal(card.shouldMarkWrappedFromChildren(hiddenChildren), false);
+});
+
+test('updateCompactHeaderWrapState uses natural unwrapped layout for compact header measurement', () => {
+  const card = makeCard({ entities: ['calendar.a'], compact_header: true });
+  const header = {
+    classList: {
+      _set: new Set(['is-wrapped']),
+      remove(name) { this._set.delete(name); },
+      toggle(name, force) { if (force) this._set.add(name); else this._set.delete(name); },
+      contains(name) { return this._set.has(name); }
+    },
+    querySelector(sel) {
+      if (sel === '.compact-header-left') return { offsetParent: {}, offsetTop: 20 };
+      if (sel === '.compact-header-controls') return { offsetParent: {}, offsetTop: 20 };
+      return null;
+    }
+  };
+  const compactControls = {
+    children: [{ offsetParent: {}, offsetTop: 20 }, { offsetParent: {}, offsetTop: 20 }],
+    classList: { remove() {}, toggle() {} }
+  };
+  const badges = { children: [], classList: { remove() {}, toggle() {} } };
+  card._root = {
+    querySelector(sel) {
+      if (sel === '.header-compact') return header;
+      if (sel === '.compact-header-controls') return compactControls;
+      if (sel === '.calendar-badges-inline') return badges;
+      if (sel === '.header-controls') return null;
+      return null;
+    }
+  };
+
+  card.measureAndApplyHeaderWrapState();
+  assert.equal(header.classList.contains('is-wrapped'), false);
+});
+
+test('repeated updateCompactHeaderWrapState calls cancel previous pending RAFs', () => {
+  const card = makeCard({ entities: ['calendar.a'], compact_header: false });
+  const callbacks = new Map();
+  let rafId = 0;
+  const cancelled = [];
+  const originalRaf = window.requestAnimationFrame;
+  const originalCancel = window.cancelAnimationFrame;
+  try {
+    window.requestAnimationFrame = (cb) => {
+      rafId += 1;
+      callbacks.set(rafId, cb);
+      return rafId;
+    };
+    window.cancelAnimationFrame = (id) => {
+      cancelled.push(id);
+      callbacks.delete(id);
+    };
+
+    card.updateCompactHeaderWrapState();
+    const firstId = card._wrapMeasureRaf1;
+    card.updateCompactHeaderWrapState();
+    const secondId = card._wrapMeasureRaf1;
+
+    assert.notEqual(firstId, null);
+    assert.notEqual(secondId, null);
+    assert.notEqual(firstId, secondId);
+    assert.ok(cancelled.includes(firstId));
+  } finally {
+    window.requestAnimationFrame = originalRaf;
+    window.cancelAnimationFrame = originalCancel;
+  }
+});
 test('day_styles evaluate today/weekend/has_event rules and auto background', () => {
   const card = makeCard({
     entities: ['calendar.a'],


### PR DESCRIPTION
### Motivation
- Prevent headers from appearing as multi-row when they naturally fit on a single row in wide viewports, addressing regression `issue 321` observed in both compact and standard header modes.
- Avoid forcing full-width layout for standard header groups when the header is marked as wrapped.
- Make wrap detection more robust and resilient to async layout by measuring after paint frames and cancelling stale measurements on teardown.

### Description
- Implemented a double `requestAnimationFrame` scheduling strategy in `updateCompactHeaderWrapState` using `_wrapMeasureRaf1` and `_wrapMeasureRaf2` to measure header layout after paints and avoid flicker, with cancellation of previous RAFs.
- Added `measureAndApplyHeaderWrapState` to centralize header wrap measurement and to clear `is-wrapped` before measuring, and added `shouldMarkWrappedFromChildren` helper to determine wrapping only from visible children whose `offsetTop` differs.
- Adjusted DOM class toggling so compact and standard header controls and inline badges are handled separately, and removed the forced `width: 100%` behavior for the standard header wrapped rule while preserving it for compact header styling.
- Cleaned up RAFs in `disconnectedCallback` to cancel pending measurements when the element is torn down.
- Added unit tests in `skylight-calendar-card.test.js` and visual regression Playwright tests in `playwright/visual.spec.js` to cover wrap detection, CSS rule expectations, RAF cancellation, and visual single-row assertions for both compact and standard headers.

### Testing
- Ran unit tests in `skylight-calendar-card.test.js`, including `shouldMarkWrappedFromChildren`, `updateCompactHeaderWrapState` behavior, CSS rule checks, and RAF cancellation tests; all unit tests passed.
- Executed Playwright visual regression tests (new tests for compact and standard header single-row behavior under wide viewport); visual tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a126c8e965c8331bb9a06547f3e8104)