### PR TITLE
Fix issue #321 Playwright regression tests to use locator geometry checks

### DIFF
--- a/playwright/visual.spec.js
+++ b/playwright/visual.spec.js
@@ -365,17 +365,20 @@ test('regression issue 321: compact header stays single-row in wide layout when 
 
   const card = page.locator('skylight-calendar-card');
   await expect(card).toBeVisible();
-  await expect(card.locator('.header-compact')).toBeVisible();
+
+  const header = card.locator('.header-compact');
+  const left = card.locator('.compact-header-left');
+  const controls = card.locator('.compact-header-controls');
+
+  await expect(header).toBeVisible();
+  await expect(left).toBeVisible();
+  await expect(controls).toBeVisible();
 
   await expect.poll(async () => {
-    return await card.evaluate((host) => {
-      const root = host.shadowRoot;
-      const left = root.querySelector('.compact-header-left');
-      const controls = root.querySelector('.compact-header-controls');
-      if (!left || !controls) return null;
-      const delta = Math.abs(left.getBoundingClientRect().top - controls.getBoundingClientRect().top);
-      return delta;
-    });
+    const leftBox = await left.boundingBox();
+    const controlsBox = await controls.boundingBox();
+    if (!leftBox || !controlsBox) return 999;
+    return Math.abs(leftBox.y - controlsBox.y);
   }).toBeLessThan(2);
 });
 
@@ -405,16 +408,19 @@ test('regression issue 321: standard header stays single-row in wide layout when
 
   const card = page.locator('skylight-calendar-card');
   await expect(card).toBeVisible();
-  await expect(card.locator('.header')).toBeVisible();
+
+  const header = card.locator('.header');
+  const left = card.locator('.header-left');
+  const controls = card.locator('.header-controls');
+
+  await expect(header).toBeVisible();
+  await expect(left).toBeVisible();
+  await expect(controls).toBeVisible();
 
   await expect.poll(async () => {
-    return await card.evaluate((host) => {
-      const root = host.shadowRoot;
-      const left = root.querySelector('.header-left');
-      const controls = root.querySelector('.header-controls');
-      if (!left || !controls) return null;
-      const delta = Math.abs(left.getBoundingClientRect().top - controls.getBoundingClientRect().top);
-      return delta;
-    });
+    const leftBox = await left.boundingBox();
+    const controlsBox = await controls.boundingBox();
+    if (!leftBox || !controlsBox) return 999;
+    return Math.abs(leftBox.y - controlsBox.y);
   }).toBeLessThan(2);
 });


### PR DESCRIPTION
### Motivation
- Two new Playwright regression tests for issue #321 were failing with `TypeError: Cannot read properties of null (reading 'querySelector')` because they accessed `host.shadowRoot` in the test fixture where `shadowRoot` is `null`, so tests need to use Playwright locators instead of direct shadow-root DOM access.

### Description
- Rewrote the two failing tests in `playwright/visual.spec.js` to replace `card.evaluate(... host.shadowRoot.querySelector ...)` polling with locator-based checks that query `skylight-calendar-card` and scoped locators (`.header-compact`/`.compact-header-left`/`.compact-header-controls` and `.header`/`.header-left`/`.header-controls`) and compare their vertical positions using `boundingBox()` inside `expect.poll()` to assert single-row alignment (`|y diff| < 2`).

### Testing
- Ran `npm run test:visual`, which attempted to execute the Playwright suite but failed to launch browsers in this environment due to missing Playwright binaries (`Executable doesn't exist ... please run npx playwright install`), so automated tests could not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a128886e6888331b052178a5e7e663d)