### PR TITLE
Detect header wrap by natural widths and center compact wrapped header groups

### DIFF
--- a/playwright/visual.spec.js
+++ b/playwright/visual.spec.js
@@ -235,6 +235,17 @@ async function headerGroupsShareRow(left, controls) {
   );
 }
 
+
+async function centerOffsetWithinTolerance(container, child, tolerance = 12) {
+  const containerBox = await container.boundingBox();
+  const childBox = await child.boundingBox();
+  if (!containerBox || !childBox) return false;
+
+  const containerCenter = containerBox.x + containerBox.width / 2;
+  const childCenter = childBox.x + childBox.width / 2;
+  return Math.abs(containerCenter - childCenter) <= tolerance;
+}
+
 test.beforeEach(async ({ page }) => {
   await page.addInitScript((now) => {
     const OriginalDate = Date;
@@ -394,6 +405,50 @@ test('regression issue 321: compact header stays single-row', async ({ page }) =
   await expect.poll(async () => {
     return headerGroupsShareRow(left, controls);
   }).toBe(true);
+});
+
+
+test('regression issue 321: compact wrapped header rows stay centered at medium width', async ({ page }) => {
+  await page.setViewportSize({ width: 980, height: 820 });
+  const fixtureUrl = `file://${path.join(process.cwd(), 'playwright', 'ha-fixture.html')}`;
+  await page.goto(fixtureUrl);
+  await page.evaluate((params) => window.renderCalendarCard(params), {
+    config: {
+      entities: ['calendar.family', 'calendar.work'],
+      title: 'Issue 321 Compact Wrapped',
+      default_view: 'week-compact',
+      compact_header: true,
+      compact_height: false,
+      hide_dark_mode_toggle: true,
+      show_dashboard_nav_button: true,
+      header_weather_sensor: 'weather.mock',
+      enable_event_management: true,
+      hide_view_selector: false,
+      day_badges: [],
+      uix: { style: '.nav-button,.today-button,.add-event-button,.view-mode-select{font-size:18px!important;}' }
+    },
+    events: baseEvents,
+    weather: { 'weather.mock': { temperature: 72, condition: 'sunny' } },
+    darkMode: false
+  });
+
+  const card = page.locator('skylight-calendar-card');
+  const header = card.locator('.header-compact');
+  const left = card.locator('.compact-header-left').first();
+  const controls = card.locator('.compact-header-controls').first();
+
+  await expect(header).toBeVisible();
+  await expect(left).toBeVisible();
+  await expect(controls).toBeVisible();
+
+  await expect.poll(async () => {
+    const wrapped = await header.evaluate((el) => el.classList.contains('is-wrapped'));
+    return wrapped;
+  }).toBe(true);
+
+  await expect.poll(async () => headerGroupsShareRow(left, controls)).toBe(false);
+  await expect.poll(async () => centerOffsetWithinTolerance(header, left)).toBe(true);
+  await expect.poll(async () => centerOffsetWithinTolerance(header, controls)).toBe(true);
 });
 
 test('regression issue 321: standard header stays single-row', async ({ page }) => {

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3482,7 +3482,7 @@ class SkylightCalendarCard extends HTMLElement {
       }
 
       .header-compact.is-wrapped .today-button,
-      .header-compact.is-wrapped .add-event-button,
+      .header-compact.is-wrapped .compact-add-event-button,
       .header-compact.is-wrapped .view-mode-select,
       .header-compact.is-wrapped .nav-button {
         padding-left: 12px;

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1151,6 +1151,57 @@ class SkylightCalendarCard extends HTMLElement {
     return visibleChildren.some((child) => Math.abs(child.offsetTop - firstTop) > 1);
   }
 
+
+  measureNaturalGroupWidth(group) {
+    if (!group) return 0;
+
+    const computed = window.getComputedStyle(group);
+    const children = Array.from(group.children || [])
+      .filter((child) => child.offsetParent !== null);
+
+    if (!children.length) {
+      return Math.ceil(group.scrollWidth || 0);
+    }
+
+    const childWidths = children.reduce((sum, child) => {
+      const rect = child.getBoundingClientRect();
+      return sum + rect.width;
+    }, 0);
+
+    const internalGap = parseFloat(computed.columnGap)
+      || parseFloat(computed.gap)
+      || 0;
+
+    return Math.ceil(childWidths + internalGap * Math.max(children.length - 1, 0));
+  }
+
+  shouldMarkHeaderWrappedFromWidth(header, leftGroup, controlsGroup) {
+    if (!header || !leftGroup || !controlsGroup) return false;
+
+    const computedStyle = window.getComputedStyle(header);
+    const gap = parseFloat(computedStyle.columnGap)
+      || parseFloat(computedStyle.gap)
+      || 0;
+    const requiredWidth = this.measureNaturalGroupWidth(leftGroup)
+      + this.measureNaturalGroupWidth(controlsGroup)
+      + gap;
+    const availableWidth = header.clientWidth;
+    const tolerance = 2;
+
+    return requiredWidth > (availableWidth + tolerance);
+  }
+
+
+  shouldMarkGroupWrappedFromWidth(group) {
+    if (!group) return false;
+
+    const requiredWidth = this.measureNaturalGroupWidth(group);
+    const availableWidth = group.clientWidth;
+    const tolerance = 2;
+
+    return requiredWidth > (availableWidth + tolerance);
+  }
+
   measureAndApplyHeaderWrapState() {
     if (!this._root) return;
 
@@ -1168,14 +1219,17 @@ class SkylightCalendarCard extends HTMLElement {
     badges?.classList.remove('is-wrapped');
 
     if (header) {
-      const headerChildren = this._config.compact_header
-        ? [header.querySelector('.compact-header-left'), header.querySelector('.compact-header-controls')]
-        : [header.querySelector('.header-left'), header.querySelector('.header-controls')];
-      header.classList.toggle('is-wrapped', this.shouldMarkWrappedFromChildren(headerChildren.filter(Boolean)));
+      const leftGroup = this._config.compact_header
+        ? header.querySelector('.compact-header-left')
+        : header.querySelector('.header-left');
+      const controlsGroup = this._config.compact_header
+        ? header.querySelector('.compact-header-controls')
+        : header.querySelector('.header-controls');
+      header.classList.toggle('is-wrapped', this.shouldMarkHeaderWrappedFromWidth(header, leftGroup, controlsGroup));
     }
 
     if (controls) {
-      controls.classList.toggle('is-wrapped', this.shouldMarkWrappedFromChildren(Array.from(controls.children)));
+      controls.classList.toggle('is-wrapped', this.shouldMarkGroupWrappedFromWidth(controls));
     }
 
     if (this._config.compact_header && badges) {
@@ -3373,7 +3427,47 @@ class SkylightCalendarCard extends HTMLElement {
       .header-compact.is-wrapped .compact-header-controls {
         width: 100%;
         justify-content: center;
+        align-items: center;
       }
+
+      .header-compact.is-wrapped {
+        align-items: center;
+        justify-content: center;
+      }
+
+      .header-compact.is-wrapped .compact-header-left {
+        justify-content: center;
+        text-align: center;
+        flex-wrap: wrap;
+      }
+
+      .header-compact.is-wrapped .header-title-wrap {
+        justify-content: center;
+        text-align: center;
+      }
+
+      .header-compact.is-wrapped .compact-header-controls {
+        justify-content: center;
+        flex-wrap: wrap;
+        row-gap: 12px;
+        column-gap: 12px;
+      }
+
+      .header-compact.is-wrapped .compact-period-controls {
+        margin-left: 0;
+        justify-content: center;
+        flex-wrap: wrap;
+        width: auto;
+      }
+
+      .header-compact.is-wrapped .today-button,
+      .header-compact.is-wrapped .add-event-button,
+      .header-compact.is-wrapped .view-mode-select,
+      .header-compact.is-wrapped .nav-button {
+        padding-left: 12px;
+        padding-right: 12px;
+      }
+
 
       .header.is-wrapped .header-left,
       .header.is-wrapped .header-controls {

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1152,6 +1152,28 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
 
+
+  getElementContentWidth(element) {
+    if (!element) return 0;
+
+    const computed = window.getComputedStyle(element);
+    const paddingLeft = parseFloat(computed.paddingLeft) || 0;
+    const paddingRight = parseFloat(computed.paddingRight) || 0;
+
+    return Math.max(0, element.clientWidth - paddingLeft - paddingRight);
+  }
+
+  getOuterWidth(element) {
+    if (!element) return 0;
+
+    const rect = element.getBoundingClientRect();
+    const computed = window.getComputedStyle(element);
+    const marginLeft = parseFloat(computed.marginLeft) || 0;
+    const marginRight = parseFloat(computed.marginRight) || 0;
+
+    return rect.width + marginLeft + marginRight;
+  }
+
   measureNaturalGroupWidth(group) {
     if (!group) return 0;
 
@@ -1164,8 +1186,7 @@ class SkylightCalendarCard extends HTMLElement {
     }
 
     const childWidths = children.reduce((sum, child) => {
-      const rect = child.getBoundingClientRect();
-      return sum + rect.width;
+      return sum + this.getOuterWidth(child);
     }, 0);
 
     const internalGap = parseFloat(computed.columnGap)
@@ -1185,7 +1206,7 @@ class SkylightCalendarCard extends HTMLElement {
     const requiredWidth = this.measureNaturalGroupWidth(leftGroup)
       + this.measureNaturalGroupWidth(controlsGroup)
       + gap;
-    const availableWidth = header.clientWidth;
+    const availableWidth = this.getElementContentWidth(header);
     const tolerance = 2;
 
     return requiredWidth > (availableWidth + tolerance);
@@ -1196,7 +1217,7 @@ class SkylightCalendarCard extends HTMLElement {
     if (!group) return false;
 
     const requiredWidth = this.measureNaturalGroupWidth(group);
-    const availableWidth = group.clientWidth;
+    const availableWidth = this.getElementContentWidth(group);
     const tolerance = 2;
 
     return requiredWidth > (availableWidth + tolerance);

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -933,6 +933,16 @@ test('compact header wrapped state still forces full-width centered groups', () 
 
   assert.match(compactRule, /width:\s*100%/);
   assert.match(compactRule, /justify-content:\s*center/);
+
+  assert.match(styles, /\.header-compact\.is-wrapped\s*\{[^}]*align-items:\s*center/);
+  assert.match(styles, /\.header-compact\.is-wrapped\s*\{[^}]*justify-content:\s*center/);
+  assert.match(styles, /\.header-compact\.is-wrapped \.compact-header-left\s*\{[^}]*text-align:\s*center/);
+  assert.match(styles, /\.header-compact\.is-wrapped \.compact-header-left\s*\{[^}]*flex-wrap:\s*wrap/);
+  assert.match(styles, /\.header-compact\.is-wrapped \.header-title-wrap\s*\{[^}]*text-align:\s*center/);
+  assert.match(styles, /\.header-compact\.is-wrapped \.compact-header-controls\s*\{[^}]*row-gap:\s*12px/);
+  assert.match(styles, /\.header-compact\.is-wrapped \.compact-header-controls\s*\{[^}]*column-gap:\s*12px/);
+  assert.match(styles, /\.header-compact\.is-wrapped \.compact-period-controls\s*\{[^}]*flex-wrap:\s*wrap/);
+  assert.match(styles, /\.header-compact\.is-wrapped \.today-button,\s*\n\s*\.header-compact\.is-wrapped \.add-event-button/);
 });
 
 test('issue 321 standard header wrapped state does not force full-width rows', () => {
@@ -955,27 +965,115 @@ test('issue 321 standard header wrapped state does not force full-width rows', (
   assert.doesNotMatch(standardRule, /width:\s*100%/);
 });
 
-test('shouldMarkWrappedFromChildren only marks wrapped when visible children occupy different rows', () => {
-  const card = makeCard({ entities: ['calendar.a'] });
-  const sameRowChildren = [
-    { offsetParent: {}, offsetTop: 10 },
-    { offsetParent: {}, offsetTop: 10 }
-  ];
-  const wrappedChildren = [
-    { offsetParent: {}, offsetTop: 10 },
-    { offsetParent: {}, offsetTop: 26 }
-  ];
-  const hiddenChildren = [
-    { offsetParent: null, offsetTop: 10 },
-    { offsetParent: null, offsetTop: 26 }
-  ];
+test('issue321 compact header width detection is deterministic', () => {
+  const card = makeCard({ entities: ['calendar.a'], compact_header: true });
+  const header = document.createElement('div');
+  const left = document.createElement('div');
+  const controls = document.createElement('div');
 
-  assert.equal(card.shouldMarkWrappedFromChildren(sameRowChildren), false);
-  assert.equal(card.shouldMarkWrappedFromChildren(wrappedChildren), true);
-  assert.equal(card.shouldMarkWrappedFromChildren(hiddenChildren), false);
+  Object.defineProperty(header, 'clientWidth', { configurable: true, value: 1000 });
+
+  const originalMeasure = card.measureNaturalGroupWidth;
+  const originalGetComputedStyle = window.getComputedStyle;
+  try {
+    card.measureNaturalGroupWidth = (group) => (group === left ? 300 : 400);
+    window.getComputedStyle = () => ({ columnGap: '16px', gap: '16px' });
+    assert.equal(card.shouldMarkHeaderWrappedFromWidth(header, left, controls), false);
+
+    Object.defineProperty(header, 'clientWidth', { configurable: true, value: 600 });
+    assert.equal(card.shouldMarkHeaderWrappedFromWidth(header, left, controls), true);
+  } finally {
+    card.measureNaturalGroupWidth = originalMeasure;
+    window.getComputedStyle = originalGetComputedStyle;
+  }
 });
 
-test('updateCompactHeaderWrapState uses natural unwrapped layout for compact header measurement', () => {
+test('issue321 standard header width detection is deterministic', () => {
+  const card = makeCard({ entities: ['calendar.a'], compact_header: false });
+  const header = document.createElement('div');
+  const left = document.createElement('div');
+  const controls = document.createElement('div');
+
+  Object.defineProperty(header, 'clientWidth', { configurable: true, value: 920 });
+
+  const originalMeasure = card.measureNaturalGroupWidth;
+  const originalGetComputedStyle = window.getComputedStyle;
+  try {
+    card.measureNaturalGroupWidth = (group) => (group === left ? 320 : 500);
+    window.getComputedStyle = () => ({ columnGap: '16px', gap: '16px' });
+    assert.equal(card.shouldMarkHeaderWrappedFromWidth(header, left, controls), false);
+
+    Object.defineProperty(header, 'clientWidth', { configurable: true, value: 780 });
+    assert.equal(card.shouldMarkHeaderWrappedFromWidth(header, left, controls), true);
+  } finally {
+    card.measureNaturalGroupWidth = originalMeasure;
+    window.getComputedStyle = originalGetComputedStyle;
+  }
+});
+
+
+test('issue321 controls wrap detection uses width-based helper', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const group = document.createElement('div');
+
+  Object.defineProperty(group, 'clientWidth', { configurable: true, value: 800 });
+
+  const originalMeasure = card.measureNaturalGroupWidth;
+  try {
+    card.measureNaturalGroupWidth = () => 616;
+    assert.equal(card.shouldMarkGroupWrappedFromWidth(group), false);
+
+    Object.defineProperty(group, 'clientWidth', { configurable: true, value: 500 });
+    assert.equal(card.shouldMarkGroupWrappedFromWidth(group), true);
+  } finally {
+    card.measureNaturalGroupWidth = originalMeasure;
+  }
+});
+
+test('issue321 header width detection uses 2px tolerance to avoid flicker', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const header = document.createElement('div');
+  const left = document.createElement('div');
+  const controls = document.createElement('div');
+
+  Object.defineProperty(header, 'clientWidth', { configurable: true, value: 800 });
+
+  const originalMeasure = card.measureNaturalGroupWidth;
+  const originalGetComputedStyle = window.getComputedStyle;
+  try {
+    let leftWidth = 400;
+    let controlsWidth = 385;
+    card.measureNaturalGroupWidth = (group) => (group === left ? leftWidth : controlsWidth);
+    window.getComputedStyle = () => ({ columnGap: '16px', gap: '16px' });
+
+    assert.equal(card.shouldMarkHeaderWrappedFromWidth(header, left, controls), false);
+
+    controlsWidth = 389;
+    assert.equal(card.shouldMarkHeaderWrappedFromWidth(header, left, controls), true);
+  } finally {
+    card.measureNaturalGroupWidth = originalMeasure;
+    window.getComputedStyle = originalGetComputedStyle;
+  }
+});
+
+test('measureNaturalGroupWidth estimates one-line width when flex children are wrapped', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const childOne = { offsetParent: {}, getBoundingClientRect: () => ({ width: 90 }) };
+  const childTwo = { offsetParent: {}, getBoundingClientRect: () => ({ width: 85 }) };
+  const group = { children: [childOne, childTwo], scrollWidth: 120 };
+
+  const originalGetComputedStyle = window.getComputedStyle;
+  try {
+    window.getComputedStyle = () => ({ columnGap: '10px', gap: '10px' });
+    const measured = card.measureNaturalGroupWidth(group);
+    assert.equal(measured, 185);
+    assert.ok(measured > group.scrollWidth);
+  } finally {
+    window.getComputedStyle = originalGetComputedStyle;
+  }
+});
+
+test('updateCompactHeaderWrapState keeps header single-row after delayed updates when widths fit', () => {
   const card = makeCard({ entities: ['calendar.a'], compact_header: true });
   const header = {
     classList: {
@@ -985,28 +1083,59 @@ test('updateCompactHeaderWrapState uses natural unwrapped layout for compact hea
       contains(name) { return this._set.has(name); }
     },
     querySelector(sel) {
-      if (sel === '.compact-header-left') return { offsetParent: {}, offsetTop: 20 };
-      if (sel === '.compact-header-controls') return { offsetParent: {}, offsetTop: 20 };
+      if (sel === '.compact-header-left') return left;
+      if (sel === '.compact-header-controls') return controls;
       return null;
     }
   };
-  const compactControls = {
+  const left = { scrollWidth: 300 };
+  const controls = {
+    scrollWidth: 400,
     children: [{ offsetParent: {}, offsetTop: 20 }, { offsetParent: {}, offsetTop: 20 }],
     classList: { remove() {}, toggle() {} }
   };
+  Object.defineProperty(header, 'clientWidth', { configurable: true, value: 1000 });
+
   const badges = { children: [], classList: { remove() {}, toggle() {} } };
   card._root = {
     querySelector(sel) {
       if (sel === '.header-compact') return header;
-      if (sel === '.compact-header-controls') return compactControls;
+      if (sel === '.compact-header-controls') return controls;
       if (sel === '.calendar-badges-inline') return badges;
       if (sel === '.header-controls') return null;
       return null;
     }
   };
 
-  card.measureAndApplyHeaderWrapState();
-  assert.equal(header.classList.contains('is-wrapped'), false);
+  const callbacks = new Map();
+  let rafId = 0;
+  const originalRaf = window.requestAnimationFrame;
+  const originalCancel = window.cancelAnimationFrame;
+  const originalGetComputedStyle = window.getComputedStyle;
+  const originalMeasure = card.measureNaturalGroupWidth;
+  try {
+    card.measureNaturalGroupWidth = (group) => (group === left ? 300 : 400);
+    window.getComputedStyle = () => ({ columnGap: '16px', gap: '16px' });
+    window.requestAnimationFrame = (cb) => {
+      rafId += 1;
+      callbacks.set(rafId, cb);
+      return rafId;
+    };
+    window.cancelAnimationFrame = (id) => { callbacks.delete(id); };
+
+    card.updateCompactHeaderWrapState();
+    const first = callbacks.get(1);
+    first();
+    const second = callbacks.get(2);
+    second();
+
+    assert.equal(header.classList.contains('is-wrapped'), false);
+  } finally {
+    window.requestAnimationFrame = originalRaf;
+    window.cancelAnimationFrame = originalCancel;
+    window.getComputedStyle = originalGetComputedStyle;
+    card.measureNaturalGroupWidth = originalMeasure;
+  }
 });
 
 test('repeated updateCompactHeaderWrapState calls cancel previous pending RAFs', () => {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -1030,6 +1030,43 @@ test('issue321 controls wrap detection uses width-based helper', () => {
   }
 });
 
+test('header width detection uses content-box width excluding padding', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const header = document.createElement('div');
+  const left = document.createElement('div');
+  const controls = document.createElement('div');
+
+  Object.defineProperty(header, 'clientWidth', { configurable: true, value: 1000 });
+
+  const originalMeasure = card.measureNaturalGroupWidth;
+  const originalGetComputedStyle = window.getComputedStyle;
+  try {
+    card.measureNaturalGroupWidth = (group) => (group === left ? 480 : 460);
+    window.getComputedStyle = (element) => {
+      if (element === header) {
+        return {
+          columnGap: '16px',
+          gap: '16px',
+          paddingLeft: '24px',
+          paddingRight: '24px'
+        };
+      }
+
+      return {
+        columnGap: '0px',
+        gap: '0px',
+        paddingLeft: '0px',
+        paddingRight: '0px'
+      };
+    };
+
+    assert.equal(card.shouldMarkHeaderWrappedFromWidth(header, left, controls), true);
+  } finally {
+    card.measureNaturalGroupWidth = originalMeasure;
+    window.getComputedStyle = originalGetComputedStyle;
+  }
+});
+
 test('issue321 header width detection uses 2px tolerance to avoid flicker', () => {
   const card = makeCard({ entities: ['calendar.a'] });
   const header = document.createElement('div');
@@ -1056,18 +1093,57 @@ test('issue321 header width detection uses 2px tolerance to avoid flicker', () =
   }
 });
 
-test('measureNaturalGroupWidth estimates one-line width when flex children are wrapped', () => {
+test('measureNaturalGroupWidth includes child horizontal margins', () => {
   const card = makeCard({ entities: ['calendar.a'] });
-  const childOne = { offsetParent: {}, getBoundingClientRect: () => ({ width: 90 }) };
-  const childTwo = { offsetParent: {}, getBoundingClientRect: () => ({ width: 85 }) };
-  const group = { children: [childOne, childTwo], scrollWidth: 120 };
+
+  const childOne = {
+    offsetParent: {},
+    getBoundingClientRect: () => ({ width: 90 })
+  };
+
+  const childTwo = {
+    offsetParent: {},
+    getBoundingClientRect: () => ({ width: 85 })
+  };
+
+  const group = {
+    children: [childOne, childTwo],
+    scrollWidth: 120
+  };
 
   const originalGetComputedStyle = window.getComputedStyle;
   try {
-    window.getComputedStyle = () => ({ columnGap: '10px', gap: '10px' });
-    const measured = card.measureNaturalGroupWidth(group);
-    assert.equal(measured, 185);
-    assert.ok(measured > group.scrollWidth);
+    window.getComputedStyle = (element) => {
+      if (element === group) {
+        return {
+          columnGap: '10px',
+          gap: '10px',
+          marginLeft: '0px',
+          marginRight: '0px'
+        };
+      }
+
+      if (element === childOne) {
+        return {
+          marginLeft: '4px',
+          marginRight: '6px'
+        };
+      }
+
+      if (element === childTwo) {
+        return {
+          marginLeft: '8px',
+          marginRight: '2px'
+        };
+      }
+
+      return {
+        marginLeft: '0px',
+        marginRight: '0px'
+      };
+    };
+
+    assert.equal(card.measureNaturalGroupWidth(group), 205);
   } finally {
     window.getComputedStyle = originalGetComputedStyle;
   }

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -942,7 +942,7 @@ test('compact header wrapped state still forces full-width centered groups', () 
   assert.match(styles, /\.header-compact\.is-wrapped \.compact-header-controls\s*\{[^}]*row-gap:\s*12px/);
   assert.match(styles, /\.header-compact\.is-wrapped \.compact-header-controls\s*\{[^}]*column-gap:\s*12px/);
   assert.match(styles, /\.header-compact\.is-wrapped \.compact-period-controls\s*\{[^}]*flex-wrap:\s*wrap/);
-  assert.match(styles, /\.header-compact\.is-wrapped \.today-button,\s*\n\s*\.header-compact\.is-wrapped \.add-event-button/);
+  assert.match(styles, /\.header-compact\.is-wrapped \.today-button,\s*\n\s*\.header-compact\.is-wrapped \.compact-add-event-button/);
 });
 
 test('issue 321 standard header wrapped state does not force full-width rows', () => {


### PR DESCRIPTION
### Motivation
- Improve reliability of header wrap detection to avoid flicker and row-based flakiness and ensure compact header groups remain visually centered when wrapping.

### Description
- Add `measureNaturalGroupWidth`, `shouldMarkHeaderWrappedFromWidth`, and `shouldMarkGroupWrappedFromWidth` helpers and use them in `measureAndApplyHeaderWrapState` to determine wrapping by comparing natural group widths to available space.
- Introduce a 2px tolerance in the width-based wrap check to avoid jitter around tight boundaries and keep existing RAF batching in `updateCompactHeaderWrapState` for deferred measurements.
- Update styles for `.header-compact.is-wrapped` to center the left group, controls and title, and adjust gaps/padding for wrapped control buttons.
- Update tests by adding deterministic unit tests in `skylight-calendar-card.test.js` for `measureNaturalGroupWidth`, width-based wrap detection, tolerance behavior and RAF cancellation, and add a Playwright visual test and helper in `playwright/visual.spec.js` to assert wrapped compact header centering.

### Testing
- Ran the unit test suite (`skylight-calendar-card.test.js`) which validated the new width-measurement helpers, tolerance behavior, RAF handling, and passed.
- Ran Playwright visual tests including the new `compact wrapped header rows stay centered at medium width` scenario and they passed.
- Existing header wrapping/regression tests were re-run and remained green after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13172c437c8331b524eddc26f15b8f)