### PR TITLE
Add header ResizeObserver to recalculate wrap state on layout width changes

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -912,6 +912,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._wrapMeasureRaf1 = null;
     this._wrapMeasureRaf2 = null;
     this._monthGridResizeObserver = null;
+    this._headerResizeObserver = null;
     this._monthCompactMeasurementDirty = true;
     this._lastCompactMonthViewportHeight = null;
     this._handleViewportResize = () => {
@@ -2898,6 +2899,10 @@ class SkylightCalendarCard extends HTMLElement {
       this._monthGridResizeObserver.disconnect();
       this._monthGridResizeObserver = null;
     }
+    if (this._headerResizeObserver) {
+      this._headerResizeObserver.disconnect();
+      this._headerResizeObserver = null;
+    }
     this.detachSystemThemeListener();
     this.teardownWeatherForecastSubscription();
     if (this._modalVisibilityObserver) {
@@ -3017,6 +3022,25 @@ class SkylightCalendarCard extends HTMLElement {
       this.updateMonthContainerTopInViewportFromDom();
       this._monthCompactMeasurementDirty = false;
     });
+  }
+
+
+  observeHeaderResize() {
+    if (!this._root || typeof window.ResizeObserver !== 'function') return;
+
+    if (this._headerResizeObserver) {
+      this._headerResizeObserver.disconnect();
+      this._headerResizeObserver = null;
+    }
+
+    const headerSelector = this._config.compact_header ? '.header-compact' : '.header';
+    const header = this._root.querySelector(headerSelector);
+    if (!header) return;
+
+    this._headerResizeObserver = new window.ResizeObserver(() => {
+      this.updateCompactHeaderWrapState();
+    });
+    this._headerResizeObserver.observe(header);
   }
 
   observeMonthGridResize() {
@@ -6059,6 +6083,7 @@ class SkylightCalendarCard extends HTMLElement {
     this.updateCompactHeaderWrapState();
     this.updateCalendarBadgesScrollState();
     this.updateWeekStandardFixedOffsetHeightFromDom();
+    this.observeHeaderResize();
     this.observeMonthGridResize();
     if (this._viewMode === 'month' && this._config.compact_height && !this.shouldShowAllEventsInMonth()) {
       if (this._monthContainerTopInViewport === null) {


### PR DESCRIPTION
### Motivation
- Header wrap state (`.header-compact.is-wrapped`) was not recalculated when the card’s containing layout changed without a full window resize, causing misaligned wrapped compact headers after sidebar/dashboard resizing.
- The goal is to trigger `updateCompactHeaderWrapState()` when the header element’s width changes so wrapping is detected even when only the card container is resized.

### Description
- Added a `_headerResizeObserver` instance field initialized to `null` to track the header-specific `ResizeObserver` state.
- Implemented `observeHeaderResize()` which disconnects any previous header observer, selects the active header selector (`.header-compact` when `compact_header` is enabled, otherwise `.header`), and observes it with `ResizeObserver` to call `updateCompactHeaderWrapState()` on size changes.
- Hooked `observeHeaderResize()` into the post-render flow so the observer always tracks the current header DOM node, and disconnected/nulled the observer in `disconnectedCallback()`.
- Kept the existing width-measurement and double-`requestAnimationFrame` measurement logic intact to avoid layout thrashing or infinite loops.

### Testing
- Ran the unit test suite with `npm test`, which executed 107 tests and all tests passed (107/107).
- The change preserves existing wrap-detection behavior covered by the issue #321 tests included in the suite; Playwright visual tests were not executed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a137ac8b25083319698583314884a85)