### PR TITLE
Inject and expose Daylight Calendar Card version; add diagnostics and workflow step

### DIFF
--- a/.github/workflows/upload-release-asset.yml
+++ b/.github/workflows/upload-release-asset.yml
@@ -17,7 +17,8 @@ jobs:
       - name: Inject card version
         run: |
           VERSION="${GITHUB_REF_NAME}"
-          sed -i "s/__DAYLIGHT_CALENDAR_CARD_VERSION__/${VERSION}/g" skylight-calendar-card.js
+          ESCAPED_VERSION="$(printf '%s' "$VERSION" | sed -e 's/[\/&]/\\&/g')"
+          sed -i "s/__DAYLIGHT_CALENDAR_CARD_VERSION__/${ESCAPED_VERSION}/g" skylight-calendar-card.js
 
       - name: Upload skylight-calendar-card.js to release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/upload-release-asset.yml
+++ b/.github/workflows/upload-release-asset.yml
@@ -14,6 +14,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Inject card version
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          sed -i "s/__DAYLIGHT_CALENDAR_CARD_VERSION__/${VERSION}/g" skylight-calendar-card.js
+
       - name: Upload skylight-calendar-card.js to release
         uses: softprops/action-gh-release@v2
         with:

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -7,6 +7,16 @@
 // 3. Copy the strings from 'en' and translate each value
 // ============================================================================
 
+const DAYLIGHT_CALENDAR_CARD_VERSION = '__DAYLIGHT_CALENDAR_CARD_VERSION__';
+
+function getDaylightCalendarCardVersion() {
+  return DAYLIGHT_CALENDAR_CARD_VERSION.includes('__')
+    ? 'dev'
+    : DAYLIGHT_CALENDAR_CARD_VERSION;
+}
+
+console.info(`Daylight Calendar Card ${getDaylightCalendarCardVersion()} loaded from skylight-calendar-card.js`);
+
 const TRANSLATIONS = {
   en: {
     locale: 'en-US',
@@ -12251,6 +12261,13 @@ class SkylightCalendarCardEditor extends HTMLElement {
       </div>
     `);
 
+    const diagnosticsSection = this.renderSection('About / Diagnostics', `
+      <p class="helper">Daylight Calendar Card</p>
+      <p class="helper">Loaded version: ${this.escapeHtml(getDaylightCalendarCardVersion())}</p>
+      <p class="helper">Resource file: skylight-calendar-card.js</p>
+      <p class="helper">If this version does not match the version shown in HACS, Home Assistant may be loading a cached or stale resource.</p>
+    `);
+
     this.innerHTML = `
       <style>
         .card-config {
@@ -12625,6 +12642,7 @@ class SkylightCalendarCardEditor extends HTMLElement {
         ${eventSection}
         ${managementSection}
         ${localeSection}
+        ${diagnosticsSection}
       </div>
       ${this.renderColorPickerDialog()}
     `;


### PR DESCRIPTION
### Motivation
- Embed the released version into the distributed `skylight-calendar-card.js` so the runtime can report what build is loaded.
- Surface the loaded version in the browser console and the editor UI to help diagnose stale/cached resource issues.
- Inject the release tag into the resource during GitHub Actions release publishing so the distributed file matches the release.

### Description
- Added a `__DAYLIGHT_CALENDAR_CARD_VERSION__` placeholder constant and a `getDaylightCalendarCardVersion()` helper that returns `dev` when the placeholder is unchanged.
- Logged the card version to the console with `console.info` when the script loads.
- Added an "About / Diagnostics" section to the editor UI that displays the loaded version, resource filename, and a note about cached/stale resources.
- Updated the release workflow `upload-release-asset.yml` to run an `Inject card version` step that replaces the placeholder in `skylight-calendar-card.js` with the release ref name using `VERSION="${GITHUB_REF_NAME}"` and `sed` prior to uploading via `softprops/action-gh-release@v2`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1394c30eb88331897b51fe17d9dba9)