### PR TITLE
Remove version-inject step and add AI-assisted Publish HACS Release workflow

### DIFF
--- a/.github/workflows/publish-hacs-release.yml
+++ b/.github/workflows/publish-hacs-release.yml
@@ -33,8 +33,8 @@ jobs:
             exit 1
           fi
 
-          if ! echo "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "ERROR: Version must look like v1.2.3"
+          if ! echo "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$'; then
+            echo "ERROR: Version must look like v1.2.3 or v1.2.3-beta0"
             exit 1
           fi
 
@@ -115,8 +115,14 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           TITLE="$(cat release-title.txt)"
 
+          PRERELEASE_ARGS=()
+          if [[ "$VERSION" == *-* ]]; then
+            PRERELEASE_ARGS+=(--prerelease)
+          fi
+
           gh release create "$VERSION" \
             --target main \
             --title "$TITLE" \
             --notes-file RELEASE_NOTES.md \
-            --draft
+            --draft \
+            "${PRERELEASE_ARGS[@]}"

--- a/.github/workflows/publish-hacs-release.yml
+++ b/.github/workflows/publish-hacs-release.yml
@@ -1,5 +1,10 @@
 name: Publish HACS Release
 
+# Release process:
+# - DAYLIGHT_CALENDAR_CARD_VERSION must be committed in skylight-calendar-card.js before release.
+# - Open a release-prep PR that bumps the version, merge it to protected main,
+#   then run this manual workflow from main.
+# - This workflow intentionally fails if the source still contains the version placeholder.
 on:
   workflow_dispatch:
 

--- a/.github/workflows/publish-hacs-release.yml
+++ b/.github/workflows/publish-hacs-release.yml
@@ -1,0 +1,117 @@
+name: Publish HACS Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  models: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Read card version
+        id: version
+        run: |
+          VERSION="$(grep -oE "DAYLIGHT_CALENDAR_CARD_VERSION = '[^']+'" skylight-calendar-card.js | sed -E "s/.*'([^']+)'.*/\1/")"
+
+          echo "Detected version: $VERSION"
+
+          if [ -z "$VERSION" ] || [ "$VERSION" = "dev" ] || echo "$VERSION" | grep -q "__"; then
+            echo "ERROR: Invalid DAYLIGHT_CALENDAR_CARD_VERSION"
+            exit 1
+          fi
+
+          if ! echo "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "ERROR: Version must look like v1.2.3"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Verify tag does not already exist
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          if git ls-remote --tags origin "refs/tags/$VERSION" | grep -q "$VERSION"; then
+            echo "ERROR: Tag $VERSION already exists"
+            exit 1
+          fi
+
+      - name: Generate GitHub release notes
+        id: generated_notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/releases/generate-notes" \
+            -f tag_name="$VERSION" \
+            -f target_commitish="main" \
+            > generated-release-notes.json
+
+          jq -r '.name' generated-release-notes.json > release-title.txt
+          jq -r '.body' generated-release-notes.json > generated-release-notes.md
+
+      - name: Build AI prompt
+        run: |
+          cat > ai-release-prompt.md <<'EOF_PROMPT'
+          Rewrite the following GitHub generated release notes for a Home Assistant HACS custom dashboard card called daylight-calendar-card.
+
+          Requirements:
+          - Keep it accurate. Do not invent features, bug fixes, breaking changes, or links.
+          - Preserve PR numbers, contributor mentions, and important configuration keys.
+          - Make it more user-friendly for HACS users.
+          - Call out breaking changes or migration notes if the generated notes clearly imply them.
+          - Use concise Markdown.
+          - Prefer headings like:
+            ## Highlights
+            ## Fixes
+            ## Maintenance
+            ## Full changelog
+          - If there are only a few changes, keep the notes short.
+          - Do not include marketing fluff.
+          - Do not mention that AI rewrote the notes.
+
+          Generated release notes:
+          EOF_PROMPT
+
+          cat generated-release-notes.md >> ai-release-prompt.md
+
+      - name: Spiffy release notes with AI
+        id: ai_notes
+        uses: actions/ai-inference@v1
+        with:
+          model: openai/gpt-4o
+          prompt-file: ai-release-prompt.md
+          max-completion-tokens: 2000
+
+      - name: Save AI release notes
+        run: |
+          cat "${{ steps.ai_notes.outputs.response-file }}" > RELEASE_NOTES.md
+          echo "" >> RELEASE_NOTES.md
+          echo "---" >> RELEASE_NOTES.md
+          echo "" >> RELEASE_NOTES.md
+          echo "_Generated from GitHub release notes. Please verify before publishing if this is a draft._" >> RELEASE_NOTES.md
+
+      - name: Create draft GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TITLE="$(cat release-title.txt)"
+
+          gh release create "$VERSION" \
+            --target main \
+            --title "$TITLE" \
+            --notes-file RELEASE_NOTES.md \
+            --draft

--- a/.github/workflows/upload-release-asset.yml
+++ b/.github/workflows/upload-release-asset.yml
@@ -14,12 +14,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Inject card version
-        run: |
-          VERSION="${GITHUB_REF_NAME}"
-          ESCAPED_VERSION="$(printf '%s' "$VERSION" | sed -e 's/[\/&]/\\&/g')"
-          sed -i "s/__DAYLIGHT_CALENDAR_CARD_VERSION__/${ESCAPED_VERSION}/g" skylight-calendar-card.js
-
       - name: Upload skylight-calendar-card.js to release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/upload-release-asset.yml
+++ b/.github/workflows/upload-release-asset.yml
@@ -1,4 +1,4 @@
-name: Upload release asset
+name: Attach JS release asset for download metrics
 
 on:
   release:
@@ -13,6 +13,26 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Validate release asset version
+        run: |
+          if grep -q "__DAYLIGHT_CALENDAR_CARD_VERSION__" skylight-calendar-card.js; then
+            echo "ERROR: skylight-calendar-card.js still contains the version placeholder"
+            exit 1
+          fi
+
+          VERSION="$(grep -oE "DAYLIGHT_CALENDAR_CARD_VERSION = '[^']+'" skylight-calendar-card.js | sed -E "s/.*'([^']+)'.*/\1/")"
+          echo "Detected version: $VERSION"
+
+          if [ -z "$VERSION" ] || [ "$VERSION" = "dev" ]; then
+            echo "ERROR: Invalid DAYLIGHT_CALENDAR_CARD_VERSION"
+            exit 1
+          fi
+
+          if ! echo "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "ERROR: Version must look like v1.2.3"
+            exit 1
+          fi
 
       - name: Upload skylight-calendar-card.js to release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/upload-release-asset.yml
+++ b/.github/workflows/upload-release-asset.yml
@@ -14,24 +14,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Validate release asset version
+      - name: Report release asset version
         run: |
           if grep -q "__DAYLIGHT_CALENDAR_CARD_VERSION__" skylight-calendar-card.js; then
-            echo "ERROR: skylight-calendar-card.js still contains the version placeholder"
-            exit 1
+            echo "::warning::skylight-calendar-card.js still contains the version placeholder"
           fi
 
           VERSION="$(grep -oE "DAYLIGHT_CALENDAR_CARD_VERSION = '[^']+'" skylight-calendar-card.js | sed -E "s/.*'([^']+)'.*/\1/")"
           echo "Detected version: $VERSION"
 
           if [ -z "$VERSION" ] || [ "$VERSION" = "dev" ]; then
-            echo "ERROR: Invalid DAYLIGHT_CALENDAR_CARD_VERSION"
-            exit 1
-          fi
-
-          if ! echo "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "ERROR: Version must look like v1.2.3"
-            exit 1
+            echo "::warning::Invalid DAYLIGHT_CALENDAR_CARD_VERSION"
+          elif ! echo "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$'; then
+            echo "::warning::Version should look like v1.2.3 or v1.2.3-beta0"
           fi
 
       - name: Upload skylight-calendar-card.js to release


### PR DESCRIPTION
### Motivation
- Stop modifying `skylight-calendar-card.js` during release asset upload and move version validation and release creation to a dedicated manual workflow.
- Provide an AI-assisted HACS release flow that validates the card version, prevents duplicate tags, and produces user-friendly HACS release notes.

### Description
- Removed the `Inject card version` step from `.github/workflows/upload-release-asset.yml` so the asset is uploaded without in-place substitution.
- Added `.github/workflows/publish-hacs-release.yml` which is triggered by `workflow_dispatch` and has `contents: write` and `models: read` permissions.
- Implemented steps in the new workflow to read and validate `DAYLIGHT_CALENDAR_CARD_VERSION` from `skylight-calendar-card.js`, verify the tag does not already exist, and generate GitHub release notes via the `gh api` call.
- The workflow builds an AI prompt, calls `actions/ai-inference@v1` with `openai/gpt-4o` to rewrite the notes, saves them to `RELEASE_NOTES.md`, and creates a draft release with `gh release create`.

### Testing
- Parsed both workflow YAML files with a Ruby `YAML.load_file` script which reported the `name` fields successfully.
- Attempted to parse with a Python `PyYAML` script which failed because `PyYAML` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a190b2ec7fc8331852ea7b777811631)