### PR TITLE
Add `past` matcher to event_styles and support safe opacity/filter styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,15 +120,6 @@ Some advanced features are supported by the card but must be configured in YAML.
 If you do not see an option in the visual editor, open the card in YAML mode. YAML-only features include:
 
 - `event_styles` — conditionally style individual events
-  ```yaml
-  event_styles:
-    - id: custom-past-muted
-      match:
-        past: true
-      style:
-        opacity: 0.35
-        filter: grayscale(80%)
-  ```
 - `day_styles` — conditionally style days
 - `virtual_calendars` — group multiple calendars into a single virtual calendar
 - Advanced UIX/Card Mod styling

--- a/README.md
+++ b/README.md
@@ -120,6 +120,15 @@ Some advanced features are supported by the card but must be configured in YAML.
 If you do not see an option in the visual editor, open the card in YAML mode. YAML-only features include:
 
 - `event_styles` — conditionally style individual events
+  ```yaml
+  event_styles:
+    - id: custom-past-muted
+      match:
+        past: true
+      style:
+        opacity: 0.35
+        filter: grayscale(80%)
+  ```
 - `day_styles` — conditionally style days
 - `virtual_calendars` — group multiple calendars into a single virtual calendar
 - Advanced UIX/Card Mod styling

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -2151,7 +2151,7 @@ class SkylightCalendarCard extends HTMLElement {
     if (filterValue === undefined || filterValue === null) return null;
     const normalized = String(filterValue).trim();
     if (!normalized) return null;
-    if (/[;{}<>]/.test(normalized)) return null;
+    if (/[;{}<>\"']/.test(normalized)) return null;
     return normalized;
   }
 

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -2113,6 +2113,12 @@ class SkylightCalendarCard extends HTMLElement {
     const normalizedFontColor = this.normalizeSingleColor(style.event_font_color ?? style.font_color);
     if (normalizedFontColor) normalized.event_font_color = normalizedFontColor;
 
+    const normalizedOpacity = this.normalizeEventStyleOpacity(style.opacity);
+    if (normalizedOpacity !== null) normalized.opacity = normalizedOpacity;
+
+    const normalizedFilter = this.normalizeEventStyleFilter(style.filter);
+    if (normalizedFilter !== null) normalized.filter = normalizedFilter;
+
     setIfDefined('event_font_size', style.event_font_size);
     setIfDefined('event_time_font_size', style.event_time_font_size);
     setIfDefined('event_location_font_size', style.event_location_font_size);
@@ -2131,6 +2137,21 @@ class SkylightCalendarCard extends HTMLElement {
     if (hideEvent !== null) normalized.hide = hideEvent;
     if (style.event_title_prefix !== undefined) normalized.event_title_prefix = this.normalizeEventTitlePrefixMode(style.event_title_prefix);
 
+    return normalized;
+  }
+
+  normalizeEventStyleOpacity(opacityValue) {
+    if (opacityValue === undefined || opacityValue === null || opacityValue === '') return null;
+    const numericOpacity = Number(opacityValue);
+    if (!Number.isFinite(numericOpacity)) return null;
+    return Math.max(0, Math.min(1, numericOpacity));
+  }
+
+  normalizeEventStyleFilter(filterValue) {
+    if (filterValue === undefined || filterValue === null) return null;
+    const normalized = String(filterValue).trim();
+    if (!normalized) return null;
+    if (/[;{}<>]/.test(normalized)) return null;
     return normalized;
   }
 
@@ -2199,6 +2220,10 @@ class SkylightCalendarCard extends HTMLElement {
     if (fieldName === 'all_day') {
       const { isAllDay } = this.getEventDateTimeInfo(event);
       return this.matchPrimitiveCondition(isAllDay, condition);
+    }
+
+    if (fieldName === 'past') {
+      return this.matchPrimitiveCondition(this.isPastEvent(event), condition);
     }
 
     if (fieldName === 'calendar') {
@@ -8041,10 +8066,22 @@ class SkylightCalendarCard extends HTMLElement {
     const borderStyle = shouldShowBorderAccent
       ? `border-left: 4px solid ${primaryColor};`
       : 'border-left: none;';
-    const mutedStyle = this._config?.past_event_mode === 'muted' && this.isPastEvent(event)
-      ? 'opacity: 0.55; filter: grayscale(70%) saturate(45%);'
-      : '';
-    const finalizeStyle = (style) => `${style} ${mutedStyle}`.trim();
+    const extraStyleParts = [];
+    const isMutedPastEvent = this._config?.past_event_mode === 'muted' && this.isPastEvent(event);
+    if (isMutedPastEvent && styleOverrides?.opacity === undefined) {
+      extraStyleParts.push('opacity: 0.55;');
+    }
+    if (isMutedPastEvent && styleOverrides?.filter === undefined) {
+      extraStyleParts.push('filter: grayscale(70%) saturate(45%);');
+    }
+    if (styleOverrides?.opacity !== undefined) {
+      extraStyleParts.push(`opacity: ${styleOverrides.opacity};`);
+    }
+    if (styleOverrides?.filter !== undefined) {
+      extraStyleParts.push(`filter: ${styleOverrides.filter};`);
+    }
+    const extraStyle = extraStyleParts.join(' ');
+    const finalizeStyle = (style) => `${style} ${extraStyle}`.trim();
 
     const eventColorMode = this.normalizeEventColorMode(this._config?.event_color_mode);
     if (visibleColors.length <= 1) {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -854,17 +854,25 @@ test('event_styles ignores invalid opacity and filter values', () => {
     event_styles: [
       { match: { title: 'bad opacity' }, style: { opacity: 'opaque', filter: 'blur(2px); color: red' } },
       { match: { title: 'bad filter' }, style: { opacity: 0.4, filter: '<script>' } },
+      { match: { title: 'double quote attack' }, style: { opacity: 0.5, filter: 'blur(1px)" onmouseover="alert(1)' } },
+      { match: { title: 'single quoted filter' }, style: { opacity: 0.6, filter: "blur(1px)' onmouseover='alert(1)" } },
       { match: { title: 'empty filter' }, style: { filter: '   ' } }
     ]
   });
   const badOpacityEvent = { entityId: 'calendar.a', color: '#f00', summary: 'Bad Opacity', start: { dateTime: '2999-05-01T10:00:00Z' }, end: { dateTime: '2999-05-01T11:00:00Z' } };
   const badFilterEvent = { entityId: 'calendar.a', color: '#0f0', summary: 'Bad Filter', start: { dateTime: '2999-05-02T10:00:00Z' }, end: { dateTime: '2999-05-02T11:00:00Z' } };
-  const emptyFilterEvent = { entityId: 'calendar.a', color: '#00f', summary: 'Empty Filter', start: { dateTime: '2999-05-03T10:00:00Z' }, end: { dateTime: '2999-05-03T11:00:00Z' } };
+  const quotedFilterEvent = { entityId: 'calendar.a', color: '#00f', summary: 'Double Quote Attack', start: { dateTime: '2999-05-03T10:00:00Z' }, end: { dateTime: '2999-05-03T11:00:00Z' } };
+  const singleQuotedFilterEvent = { entityId: 'calendar.a', color: '#ff0', summary: 'Single Quoted Filter', start: { dateTime: '2999-05-04T10:00:00Z' }, end: { dateTime: '2999-05-04T11:00:00Z' } };
+  const emptyFilterEvent = { entityId: 'calendar.a', color: '#0ff', summary: 'Empty Filter', start: { dateTime: '2999-05-05T10:00:00Z' }, end: { dateTime: '2999-05-05T11:00:00Z' } };
 
   assert.doesNotMatch(card.getEventStyle(badOpacityEvent), /opacity:/);
   assert.doesNotMatch(card.getEventStyle(badOpacityEvent), /filter:/);
   assert.match(card.getEventStyle(badFilterEvent), /opacity: 0\.4/);
   assert.doesNotMatch(card.getEventStyle(badFilterEvent), /filter:/);
+  assert.match(card.getEventStyle(quotedFilterEvent), /opacity: 0\.5/);
+  assert.doesNotMatch(card.getEventStyle(quotedFilterEvent), /filter:/);
+  assert.match(card.getEventStyle(singleQuotedFilterEvent), /opacity: 0\.6/);
+  assert.doesNotMatch(card.getEventStyle(singleQuotedFilterEvent), /filter:/);
   assert.doesNotMatch(card.getEventStyle(emptyFilterEvent), /filter:/);
 });
 

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -796,6 +796,97 @@ test('event_styles apply rule priority and match logic', () => {
   assert.equal(card.eventMatchesRule(event, { title: 'meeting', not: { title: 'holiday' } }), true);
 });
 
+test('event_styles supports past matcher for past and future events', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const pastEvent = { entityId: 'calendar.a', color: '#f00', summary: 'Past Event', start: { dateTime: '2000-05-01T10:00:00Z' }, end: { dateTime: '2000-05-01T11:00:00Z' } };
+  const futureEvent = { entityId: 'calendar.a', color: '#0f0', summary: 'Future Event', start: { dateTime: '2999-05-01T10:00:00Z' }, end: { dateTime: '2999-05-01T11:00:00Z' } };
+
+  assert.equal(card.eventMatchesRule(pastEvent, { past: true }), true);
+  assert.equal(card.eventMatchesRule(futureEvent, { past: true }), false);
+  assert.equal(card.eventMatchesRule(futureEvent, { past: false }), true);
+  assert.equal(card.eventMatchesRule(pastEvent, { past: 'true' }), true);
+  assert.equal(card.eventMatchesRule(futureEvent, { past: 'false' }), true);
+});
+
+test('event_styles supports past matcher inside logical all and not wrappers', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const pastEvent = { entityId: 'calendar.a', color: '#f00', summary: 'Past Meeting', start: { dateTime: '2000-05-01T10:00:00Z' }, end: { dateTime: '2000-05-01T11:00:00Z' } };
+  const futureEvent = { entityId: 'calendar.a', color: '#0f0', summary: 'Future Meeting', start: { dateTime: '2999-05-01T10:00:00Z' }, end: { dateTime: '2999-05-01T11:00:00Z' } };
+
+  assert.equal(card.eventMatchesRule(pastEvent, { all: [{ past: true }, { title: 'meeting' }] }), true);
+  assert.equal(card.eventMatchesRule(futureEvent, { all: [{ past: true }, { title: 'meeting' }] }), false);
+  assert.equal(card.eventMatchesRule(futureEvent, { not: { past: true } }), true);
+  assert.equal(card.eventMatchesRule(pastEvent, { not: { past: true } }), false);
+});
+
+test('event_styles applies custom opacity and filter to past events only', () => {
+  const card = makeCard({
+    entities: ['calendar.a'],
+    event_styles: [{ match: { past: true }, style: { opacity: 0.35, filter: ' grayscale(80%) ' } }]
+  });
+  const pastEvent = { entityId: 'calendar.a', color: '#f00', summary: 'Past Event', start: { dateTime: '2000-05-01T10:00:00Z' }, end: { dateTime: '2000-05-01T11:00:00Z' } };
+  const futureEvent = { entityId: 'calendar.a', color: '#0f0', summary: 'Future Event', start: { dateTime: '2999-05-01T10:00:00Z' }, end: { dateTime: '2999-05-01T11:00:00Z' } };
+
+  assert.match(card.getEventStyle(pastEvent), /opacity: 0\.35/);
+  assert.match(card.getEventStyle(pastEvent), /filter: grayscale\(80%\)/);
+  assert.doesNotMatch(card.getEventStyle(futureEvent), /opacity: 0\.35/);
+  assert.doesNotMatch(card.getEventStyle(futureEvent), /filter: grayscale\(80%\)/);
+});
+
+test('event_styles custom opacity and filter override muted past event defaults', () => {
+  const card = makeCard({
+    entities: ['calendar.a'],
+    past_event_mode: 'muted',
+    event_styles: [{ match: { past: true }, style: { opacity: '0.35', filter: 'grayscale(80%)' } }]
+  });
+  const pastEvent = { entityId: 'calendar.a', color: '#f00', summary: 'Past Event', start: { dateTime: '2000-05-01T10:00:00Z' }, end: { dateTime: '2000-05-01T11:00:00Z' } };
+  const style = card.getEventStyle(pastEvent);
+
+  assert.match(style, /opacity: 0\.35/);
+  assert.match(style, /filter: grayscale\(80%\)/);
+  assert.doesNotMatch(style, /opacity: 0\.55/);
+  assert.doesNotMatch(style, /filter: grayscale\(70%\) saturate\(45%\)/);
+});
+
+test('event_styles ignores invalid opacity and filter values', () => {
+  const card = makeCard({
+    entities: ['calendar.a'],
+    event_styles: [
+      { match: { title: 'bad opacity' }, style: { opacity: 'opaque', filter: 'blur(2px); color: red' } },
+      { match: { title: 'bad filter' }, style: { opacity: 0.4, filter: '<script>' } },
+      { match: { title: 'empty filter' }, style: { filter: '   ' } }
+    ]
+  });
+  const badOpacityEvent = { entityId: 'calendar.a', color: '#f00', summary: 'Bad Opacity', start: { dateTime: '2999-05-01T10:00:00Z' }, end: { dateTime: '2999-05-01T11:00:00Z' } };
+  const badFilterEvent = { entityId: 'calendar.a', color: '#0f0', summary: 'Bad Filter', start: { dateTime: '2999-05-02T10:00:00Z' }, end: { dateTime: '2999-05-02T11:00:00Z' } };
+  const emptyFilterEvent = { entityId: 'calendar.a', color: '#00f', summary: 'Empty Filter', start: { dateTime: '2999-05-03T10:00:00Z' }, end: { dateTime: '2999-05-03T11:00:00Z' } };
+
+  assert.doesNotMatch(card.getEventStyle(badOpacityEvent), /opacity:/);
+  assert.doesNotMatch(card.getEventStyle(badOpacityEvent), /filter:/);
+  assert.match(card.getEventStyle(badFilterEvent), /opacity: 0\.4/);
+  assert.doesNotMatch(card.getEventStyle(badFilterEvent), /filter:/);
+  assert.doesNotMatch(card.getEventStyle(emptyFilterEvent), /filter:/);
+});
+
+test('event_styles style hide with past matcher hides normally but keeps includeHiddenStyledEvents access', () => {
+  const card = makeCard({
+    entities: ['calendar.a'],
+    event_styles: [{ match: { past: true }, style: 'hide' }]
+  });
+  card._events = [
+    { entityId: 'calendar.a', color: '#f00', summary: 'Past Hidden Event', start: { dateTime: '2000-05-01T10:00:00Z' }, end: { dateTime: '2000-05-01T11:00:00Z' } },
+    { entityId: 'calendar.a', color: '#0f0', summary: 'Future Visible Event', start: { dateTime: '2999-05-01T10:00:00Z' }, end: { dateTime: '2999-05-01T11:00:00Z' } }
+  ];
+
+  const pastDay = new Date('2000-05-01T00:00:00Z');
+  const visibleEvents = card.getEventsForDay(pastDay);
+  const styledEvents = card.getEventsForDay(pastDay, { includeHiddenStyledEvents: true });
+
+  assert.equal(visibleEvents.length, 0);
+  assert.equal(styledEvents.length, 1);
+  assert.equal(styledEvents[0].summary, 'Past Hidden Event');
+});
+
 test('event_styles supports `style: hide` and keeps hidden events available for day_badges matching', () => {
   const card = makeCard({
     entities: ['calendar.a'],


### PR DESCRIPTION
### Motivation
- Allow styling rules in `event_styles` to target past events using the existing `isPastEvent(event)` semantics without introducing a separate engine.
- Let `event_styles` define concise visual overrides for opacity and CSS `filter`, while keeping past-event global behaviors (`past_event_mode`) intact.

### Description
- Added `past` field support to `eventFieldMatches(...)` so `match: { past: true }` uses `isPastEvent(event)` via `matchPrimitiveCondition(...)`, and supports `true`/`false`, string `'true'`/`'false'`, and logical wrappers like `all`, `any`, and `not` (changes in `eventFieldMatches`).
- Added normalization helpers `normalizeEventStyleOpacity(...)` and `normalizeEventStyleFilter(...)`, and applied them in `normalizeEventStyleBlock(...)` to accept numeric opacities clamped to `0..1` and trimmed safe filter strings while rejecting empty or unsafe values containing `;`, `{`, `}`, `<`, or `>`.
- Extended `getEventStyle()` to apply `opacity` and `filter` inline alongside existing generated styles, preserving `past_event_mode` behavior (`none`, `hide`, `muted`) and ensuring explicit `event_styles` opacity/filter override the default `muted` values rather than duplicating them.
- Kept existing `event_styles` semantics intact (including `style: hide`, rule priority, combined calendars, and hidden-event availability to `day_badges`/`day_styles` when `includeHiddenStyledEvents: true`) and added a README YAML example demonstrating styling past events.

### Testing
- Added focused tests in `skylight-calendar-card.test.js` covering: `past: true`/`past: false` matching, `past` inside `all`/`not`, custom opacity/filter application, override of `past_event_mode: muted`, invalid value handling, and `style: hide` with `includeHiddenStyledEvents` (stable dates used: year 2000 for past and 2999 for future).
- Ran the automated test suite with `npm test` and all tests passed (`node --test skylight-calendar-card.test.js` completed successfully with all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a54a2f09083319ee258dc7bc6cb16)