### PR TITLE
Fix Sections grid height handling and grid-aware compact sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Full documentation is available in the wiki:
 * Use multiple calendars for a shared family dashboard
 * Pair with wall-mounted tablets for a Daylight-style experience
 * Combine with UIX/Card Mod for advanced styling
+* In Home Assistant Sections view, put `grid_options.rows` directly on the `custom:daylight-calendar-card` / `custom:skylight-calendar-card` card for reliable row sizing. Stacked layouts such as `vertical-stack` may also need the stack or wrapper card to participate in height distribution before children can fill the allocated rows.
 
 ---
 

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3034,18 +3034,15 @@ class SkylightCalendarCard extends HTMLElement {
     if (parentSize.height <= 0) return false;
 
     const parentStyle = typeof window.getComputedStyle === 'function' ? window.getComputedStyle(parent) : null;
-    const parentComputedHeight = parentStyle?.height || '';
     const parentMaxHeight = parentStyle?.maxHeight || '';
     const parentDisplay = parentStyle?.display || '';
     const parentOverflowY = parentStyle?.overflowY || parentStyle?.overflow || '';
     const inlineStyle = parent.getAttribute?.('style') || '';
-    const hasComputedCssHeight = /^\d*\.?\d+px$/.test(parentComputedHeight) && parentComputedHeight !== '0px';
     const hasExplicitCssHeight = Boolean(
       parent.style?.height ||
       parent.style?.minHeight ||
       parent.style?.maxHeight ||
       /(?:^|;)\s*(?:height|min-height|max-height)\s*:/i.test(inlineStyle) ||
-      hasComputedCssHeight ||
       (parentMaxHeight && parentMaxHeight !== 'none' && parentMaxHeight !== '0px')
     );
     const looksLikeGridAllocation = /grid/i.test(parentDisplay) || parent.hasAttribute?.('grid_options') || parent.classList?.contains('grid-cell');

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -923,6 +923,10 @@ class SkylightCalendarCard extends HTMLElement {
     this._wrapMeasureRaf2 = null;
     this._monthGridResizeObserver = null;
     this._headerResizeObserver = null;
+    this._hostResizeObserver = null;
+    this._hostResizeRaf = null;
+    this._observedResizeParent = null;
+    this._lastObservedHostSize = null;
     this._monthCompactMeasurementDirty = true;
     this._lastCompactMonthViewportHeight = null;
     this._handleViewportResize = () => {
@@ -2957,6 +2961,7 @@ class SkylightCalendarCard extends HTMLElement {
     window.addEventListener('resize', this._handleViewportResize);
     window.visualViewport?.addEventListener('resize', this._handleViewportResize);
     this.attachSystemThemeListener();
+    this.observeHostAndParentResize();
     this.render();
   }
 
@@ -2971,6 +2976,16 @@ class SkylightCalendarCard extends HTMLElement {
     if (this._headerResizeObserver) {
       this._headerResizeObserver.disconnect();
       this._headerResizeObserver = null;
+    }
+    if (this._hostResizeObserver) {
+      this._hostResizeObserver.disconnect();
+      this._hostResizeObserver = null;
+    }
+    this._observedResizeParent = null;
+    this._lastObservedHostSize = null;
+    if (this._hostResizeRaf !== null) {
+      window.cancelAnimationFrame(this._hostResizeRaf);
+      this._hostResizeRaf = null;
     }
     this.detachSystemThemeListener();
     this.teardownWeatherForecastSubscription();
@@ -3002,8 +3017,65 @@ class SkylightCalendarCard extends HTMLElement {
     return Math.max(minimumHeight, Math.floor(viewportHeight - containerTop - bottomSpacing));
   }
 
+  getElementSizeForAllocation(element) {
+    if (!element || typeof element.getBoundingClientRect !== 'function') return { width: 0, height: 0 };
+    const rect = element.getBoundingClientRect();
+    return {
+      width: Number.isFinite(rect.width) ? rect.width : 0,
+      height: Number.isFinite(rect.height) ? rect.height : 0
+    };
+  }
+
+  hasFixedHeightParentAllocation() {
+    const parent = this.parentElement;
+    if (!parent || typeof parent.getBoundingClientRect !== 'function') return false;
+
+    const parentSize = this.getElementSizeForAllocation(parent);
+    if (parentSize.height <= 0) return false;
+
+    const parentStyle = typeof window.getComputedStyle === 'function' ? window.getComputedStyle(parent) : null;
+    const parentMaxHeight = parentStyle?.maxHeight || '';
+    const parentDisplay = parentStyle?.display || '';
+    const parentOverflowY = parentStyle?.overflowY || parentStyle?.overflow || '';
+    const inlineStyle = parent.getAttribute?.('style') || '';
+    const hasExplicitCssHeight = Boolean(
+      parent.style?.height ||
+      parent.style?.minHeight ||
+      parent.style?.maxHeight ||
+      /(?:^|;)\s*(?:height|min-height|max-height)\s*:/i.test(inlineStyle) ||
+      (parentMaxHeight && parentMaxHeight !== 'none' && parentMaxHeight !== '0px')
+    );
+    const looksLikeGridAllocation = /grid/i.test(parentDisplay) || parent.hasAttribute?.('grid_options') || parent.classList?.contains('grid-cell');
+    const clipsOrScrollsOverflow = /(auto|hidden|scroll|clip)/.test(parentOverflowY);
+    const hostSize = this.getElementSizeForAllocation(this);
+    const parentHasExtraAllocatedHeight = hostSize.height > 0 && parentSize.height - hostSize.height > 1;
+
+    return hasExplicitCssHeight || looksLikeGridAllocation || clipsOrScrollsOverflow || parentHasExtraAllocatedHeight;
+  }
+
+  getGridAwareCompactContainerStyle() {
+    return 'height: 100%; min-height: 0; overflow-y: auto;';
+  }
+
+  getCompactMonthGridStyle(monthWeekRows, compactMaxHeight = null) {
+    const rowTemplate = `grid-template-rows: auto repeat(${monthWeekRows}, minmax(0, 1fr));`;
+
+    if (this.hasFixedHeightParentAllocation()) {
+      return `height: 100%; min-height: 0; overflow-y: auto; ${rowTemplate}`;
+    }
+
+    const resolvedMaxHeight = compactMaxHeight || this.getCompactMaxHeight(this._monthContainerTopInViewport);
+    return resolvedMaxHeight
+      ? `height: ${resolvedMaxHeight}px; overflow-y: auto; ${rowTemplate}`
+      : '';
+  }
+
   getCompactContainerStyle(maxHeight = null) {
     if (!this._config.compact_height) return '';
+
+    if (this.hasFixedHeightParentAllocation()) {
+      return this.getGridAwareCompactContainerStyle();
+    }
 
     const resolvedMaxHeight = maxHeight || this.getCompactMaxHeight();
     if (!resolvedMaxHeight) return '';
@@ -3093,6 +3165,61 @@ class SkylightCalendarCard extends HTMLElement {
     });
   }
 
+
+  observeHostAndParentResize() {
+    if (typeof window.ResizeObserver !== 'function') return;
+
+    const parent = this.parentElement || null;
+    if (this._hostResizeObserver && this._observedResizeParent === parent) return;
+
+    if (this._hostResizeObserver) {
+      this._hostResizeObserver.disconnect();
+      this._hostResizeObserver = null;
+    }
+
+    this._observedResizeParent = parent;
+    this._lastObservedHostSize = this.measureHostAndParentSize();
+    this._hostResizeObserver = new window.ResizeObserver(() => {
+      this.scheduleHostAndParentResizeHandling();
+    });
+    this._hostResizeObserver.observe(this);
+    if (parent) {
+      this._hostResizeObserver.observe(parent);
+    }
+  }
+
+  measureHostAndParentSize() {
+    const hostSize = this.getElementSizeForAllocation(this);
+    const parentSize = this.getElementSizeForAllocation(this.parentElement);
+    return {
+      hostWidth: Math.round(hostSize.width),
+      hostHeight: Math.round(hostSize.height),
+      parentWidth: Math.round(parentSize.width),
+      parentHeight: Math.round(parentSize.height)
+    };
+  }
+
+  hasObservedHostSizeChanged(nextSize) {
+    const previousSize = this._lastObservedHostSize;
+    if (!previousSize) return true;
+    return Object.keys(nextSize).some((key) => Math.abs(nextSize[key] - previousSize[key]) > 1);
+  }
+
+  scheduleHostAndParentResizeHandling() {
+    if (this._hostResizeRaf !== null) return;
+
+    this._hostResizeRaf = window.requestAnimationFrame(() => {
+      this._hostResizeRaf = null;
+      const nextSize = this.measureHostAndParentSize();
+      if (!this.hasObservedHostSizeChanged(nextSize)) return;
+
+      this._lastObservedHostSize = nextSize;
+      if (this._config.compact_height && this._viewMode === 'month' && !this.shouldShowAllEventsInMonth()) {
+        this._monthCompactMeasurementDirty = true;
+      }
+      this.render();
+    });
+  }
 
   observeHeaderResize() {
     if (!this._root || typeof window.ResizeObserver !== 'function') return;
@@ -3427,6 +3554,8 @@ class SkylightCalendarCard extends HTMLElement {
         display: block;
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
         width: 100%;
+        height: 100%;
+        min-height: 0;
       }
 
       .calendar-container {
@@ -3436,6 +3565,10 @@ class SkylightCalendarCard extends HTMLElement {
         overflow: hidden;
         box-shadow: var(--ha-card-box-shadow, 0 2px 8px rgba(0,0,0,0.1));
         width: 100%;
+        height: 100%;
+        min-height: 100%;
+        display: flex;
+        flex-direction: column;
         color-scheme: light;
         --schedule-hour-line-color: #d1d5db;
       }
@@ -3470,6 +3603,7 @@ class SkylightCalendarCard extends HTMLElement {
       .header,
       .header-compact {
         position: relative;
+        flex: 0 0 auto;
         background: transparent;
         color: var(--header-text-color, white);
       }
@@ -3507,6 +3641,10 @@ class SkylightCalendarCard extends HTMLElement {
       .calendar-body {
         position: relative;
         z-index: 1;
+        flex: 1 1 auto;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
       }
 
       .calendar-body::before {
@@ -3912,6 +4050,9 @@ class SkylightCalendarCard extends HTMLElement {
         gap: 1px;
         background: #e5e7eb;
         border-top: 1px solid #e5e7eb;
+        flex: 1 1 auto;
+        min-height: 0;
+        overflow: auto;
       }
 
       .calendar-grid.month-week-numbers {
@@ -4163,6 +4304,9 @@ class SkylightCalendarCard extends HTMLElement {
         gap: 1px;
         background: #e5e7eb;
         border-top: 1px solid #e5e7eb;
+        flex: 1 1 auto;
+        min-height: 0;
+        overflow: auto;
       }
 
       .week-day-column {
@@ -4359,6 +4503,8 @@ class SkylightCalendarCard extends HTMLElement {
         gap: 8px;
         overflow-y: auto;
         padding-right: 4px;
+        flex: 1 1 auto;
+        min-height: 0;
       }
 
       .agenda-day-row {
@@ -4702,10 +4848,12 @@ class SkylightCalendarCard extends HTMLElement {
         display: flex;
         align-items: flex-start;
         background: #f9fafb;
-        overflow-x: auto;
+        overflow: auto;
         padding: 16px;
         gap: var(--week-standard-column-gap);
         width: 100%;
+        flex: 1 1 auto;
+        min-height: 0;
         box-sizing: border-box;
       }
 
@@ -6148,6 +6296,7 @@ class SkylightCalendarCard extends HTMLElement {
       </div>
     `;
 
+    this.observeHostAndParentResize();
     this.attachEventListeners();
     this.updateCompactHeaderWrapState();
     this.updateCalendarBadgesScrollState();
@@ -6393,12 +6542,10 @@ class SkylightCalendarCard extends HTMLElement {
     if (this._viewMode === 'month') {
       const showAllEventsMonth = this.shouldShowAllEventsInMonth();
       const isCompactMonth = this._config.compact_height && !showAllEventsMonth;
-      const compactMaxHeight = isCompactMonth ? this.getCompactMaxHeight(this._monthContainerTopInViewport) : null;
+      const compactMaxHeight = isCompactMonth && !this.hasFixedHeightParentAllocation() ? this.getCompactMaxHeight(this._monthContainerTopInViewport) : null;
       const monthWeekRows = this.getMonthWeekRowCount();
       const showMonthWeekNumbers = this.shouldShowMonthWeekNumbers();
-      const monthStyle = compactMaxHeight
-        ? `height: ${compactMaxHeight}px; overflow-y: auto; grid-template-rows: auto repeat(${monthWeekRows}, minmax(0, 1fr));`
-        : '';
+      const monthStyle = isCompactMonth ? this.getCompactMonthGridStyle(monthWeekRows, compactMaxHeight) : '';
       const monthClass = [
         'calendar-grid',
         isCompactMonth ? 'compact-month' : '',
@@ -6443,10 +6590,11 @@ class SkylightCalendarCard extends HTMLElement {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
     const dayNames = this.getWeekdayNames('short');
+    const containerStyle = this.getCompactContainerStyle();
 
     return `
       ${!this._config.compact_header && !this._config.hide_calendars ? this.renderCalendarBadges() : ''}
-      <div class="week-compact-container">
+      <div class="week-compact-container" style="${containerStyle}">
         ${weekDays.map(date => {
           const isToday = date.toDateString() === today.toDateString();
           const dayEventsForMatching = this.getEventsForDay(date, { includeHiddenStyledEvents: true });

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3034,15 +3034,18 @@ class SkylightCalendarCard extends HTMLElement {
     if (parentSize.height <= 0) return false;
 
     const parentStyle = typeof window.getComputedStyle === 'function' ? window.getComputedStyle(parent) : null;
+    const parentComputedHeight = parentStyle?.height || '';
     const parentMaxHeight = parentStyle?.maxHeight || '';
     const parentDisplay = parentStyle?.display || '';
     const parentOverflowY = parentStyle?.overflowY || parentStyle?.overflow || '';
     const inlineStyle = parent.getAttribute?.('style') || '';
+    const hasComputedCssHeight = /^\d*\.?\d+px$/.test(parentComputedHeight) && parentComputedHeight !== '0px';
     const hasExplicitCssHeight = Boolean(
       parent.style?.height ||
       parent.style?.minHeight ||
       parent.style?.maxHeight ||
       /(?:^|;)\s*(?:height|min-height|max-height)\s*:/i.test(inlineStyle) ||
+      hasComputedCssHeight ||
       (parentMaxHeight && parentMaxHeight !== 'none' && parentMaxHeight !== '0px')
     );
     const looksLikeGridAllocation = /grid/i.test(parentDisplay) || parent.hasAttribute?.('grid_options') || parent.classList?.contains('grid-cell');

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -1007,6 +1007,110 @@ test('day_badges supports configurable size and font_size', () => {
   assert.doesNotMatch(html, /--day-badge-font-size:/);
 });
 
+
+function extractCssRule(styles, selector) {
+  const start = styles.indexOf(selector);
+  assert.notEqual(start, -1, `${selector} should exist`);
+  const end = styles.indexOf('}', start);
+  return styles.slice(start, end + 1);
+}
+
+test('getStyles includes full-height flex layout contract for HA Sections grids', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const styles = card.getStyles();
+
+  const hostRule = extractCssRule(styles, ':host,');
+  assert.match(hostRule, /height:\s*100%/);
+  assert.match(hostRule, /min-height:\s*0/);
+
+  const containerRule = extractCssRule(styles, '.calendar-container {');
+  assert.match(containerRule, /height:\s*100%/);
+  assert.match(containerRule, /min-height:\s*100%/);
+  assert.match(containerRule, /display:\s*flex/);
+  assert.match(containerRule, /flex-direction:\s*column/);
+
+  const bodyRule = extractCssRule(styles, '.calendar-body {');
+  assert.match(bodyRule, /flex:\s*1 1 auto/);
+  assert.match(bodyRule, /min-height:\s*0/);
+  assert.match(bodyRule, /display:\s*flex/);
+  assert.match(bodyRule, /flex-direction:\s*column/);
+
+  for (const selector of ['.calendar-grid {', '.week-compact-container {', '.week-standard-container {', '.agenda-container {']) {
+    const rule = extractCssRule(styles, selector);
+    assert.match(rule, /flex:\s*1 1 auto/, `${selector} should flex`);
+    assert.match(rule, /min-height:\s*0/, `${selector} should be allowed to shrink`);
+  }
+});
+
+test('getCompactContainerStyle uses grid-aware percentage height inside constrained parent', () => {
+  const card = makeCard({ entities: ['calendar.a'], compact_height: true });
+  const parent = {
+    style: { height: '480px' },
+    getBoundingClientRect: () => ({ width: 320, height: 480 }),
+    hasAttribute: () => false,
+    classList: { contains: () => false }
+  };
+  card.parentElement = parent;
+
+  const originalGetComputedStyle = window.getComputedStyle;
+  try {
+    window.getComputedStyle = (element) => element === parent
+      ? { height: '480px', maxHeight: 'none', display: 'block', overflowY: 'visible', overflow: 'visible' }
+      : originalGetComputedStyle(element);
+
+    assert.equal(card.hasFixedHeightParentAllocation(), true);
+    assert.equal(card.getCompactContainerStyle(720), 'height: 100%; min-height: 0; overflow-y: auto;');
+  } finally {
+    window.getComputedStyle = originalGetComputedStyle;
+  }
+});
+
+test('getCompactContainerStyle preserves viewport fallback without constrained parent', () => {
+  const card = makeCard({ entities: ['calendar.a'], compact_height: true });
+  card.parentElement = null;
+  card.getBoundingClientRect = () => ({ top: 120 });
+  const originalInnerHeight = window.innerHeight;
+  const originalVisualViewport = window.visualViewport;
+  try {
+    window.innerHeight = 900;
+    delete window.visualViewport;
+    assert.equal(card.hasFixedHeightParentAllocation(), false);
+    assert.equal(card.getCompactContainerStyle(), 'height: 780px; max-height: 780px; overflow-y: auto;');
+  } finally {
+    window.innerHeight = originalInnerHeight;
+    window.visualViewport = originalVisualViewport;
+  }
+});
+
+test('disconnectedCallback disconnects host ResizeObserver', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  let disconnectCount = 0;
+  const originalResizeObserver = window.ResizeObserver;
+  const originalCancelAnimationFrame = window.cancelAnimationFrame;
+  const originalRemoveEventListener = window.removeEventListener;
+  try {
+    window.ResizeObserver = class ResizeObserverMock {
+      observe() {}
+      disconnect() { disconnectCount += 1; }
+    };
+    window.cancelAnimationFrame = () => {};
+    window.removeEventListener = () => {};
+    card.parentElement = { getBoundingClientRect: () => ({ width: 320, height: 480 }) };
+
+    card.observeHostAndParentResize();
+    assert.ok(card._hostResizeObserver);
+
+    card.disconnectedCallback();
+
+    assert.equal(disconnectCount, 1);
+    assert.equal(card._hostResizeObserver, null);
+  } finally {
+    window.ResizeObserver = originalResizeObserver;
+    window.cancelAnimationFrame = originalCancelAnimationFrame;
+    window.removeEventListener = originalRemoveEventListener;
+  }
+});
+
 test('day_badge CSS variables do not leak into non-badge selectors', () => {
   const card = makeCard({ entities: ['calendar.a'] });
   const styles = card.getStyles();

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -1065,6 +1065,32 @@ test('getCompactContainerStyle uses grid-aware percentage height inside constrai
   }
 });
 
+
+test('getCompactContainerStyle honors stylesheet-defined parent height', () => {
+  const card = makeCard({ entities: ['calendar.a'], compact_height: true });
+  const parent = {
+    style: {},
+    getAttribute: () => '',
+    getBoundingClientRect: () => ({ width: 320, height: 480 }),
+    hasAttribute: () => false,
+    classList: { contains: () => false }
+  };
+  card.parentElement = parent;
+  card.getBoundingClientRect = () => ({ width: 320, height: 480 });
+
+  const originalGetComputedStyle = window.getComputedStyle;
+  try {
+    window.getComputedStyle = (element) => element === parent
+      ? { height: '480px', maxHeight: 'none', display: 'block', overflowY: 'visible', overflow: 'visible' }
+      : originalGetComputedStyle(element);
+
+    assert.equal(card.hasFixedHeightParentAllocation(), true);
+    assert.equal(card.getCompactContainerStyle(720), 'height: 100%; min-height: 0; overflow-y: auto;');
+  } finally {
+    window.getComputedStyle = originalGetComputedStyle;
+  }
+});
+
 test('getCompactContainerStyle preserves viewport fallback without constrained parent', () => {
   const card = makeCard({ entities: ['calendar.a'], compact_height: true });
   card.parentElement = null;

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -1066,7 +1066,7 @@ test('getCompactContainerStyle uses grid-aware percentage height inside constrai
 });
 
 
-test('getCompactContainerStyle honors stylesheet-defined parent height', () => {
+test('getCompactContainerStyle preserves viewport fallback for auto-height parent with computed height', () => {
   const card = makeCard({ entities: ['calendar.a'], compact_height: true });
   const parent = {
     style: {},
@@ -1076,7 +1076,37 @@ test('getCompactContainerStyle honors stylesheet-defined parent height', () => {
     classList: { contains: () => false }
   };
   card.parentElement = parent;
-  card.getBoundingClientRect = () => ({ width: 320, height: 480 });
+  card.getBoundingClientRect = () => ({ width: 320, height: 480, top: 120 });
+
+  const originalGetComputedStyle = window.getComputedStyle;
+  const originalInnerHeight = window.innerHeight;
+  const originalVisualViewport = window.visualViewport;
+  try {
+    window.innerHeight = 900;
+    delete window.visualViewport;
+    window.getComputedStyle = (element) => element === parent
+      ? { height: '480px', maxHeight: 'none', display: 'block', overflowY: 'visible', overflow: 'visible' }
+      : originalGetComputedStyle(element);
+
+    assert.equal(card.hasFixedHeightParentAllocation(), false);
+    assert.equal(card.getCompactContainerStyle(), 'height: 780px; max-height: 780px; overflow-y: auto;');
+  } finally {
+    window.getComputedStyle = originalGetComputedStyle;
+    window.innerHeight = originalInnerHeight;
+    window.visualViewport = originalVisualViewport;
+  }
+});
+
+test('getCompactContainerStyle uses grid-aware percentage height inside grid-like parent', () => {
+  const card = makeCard({ entities: ['calendar.a'], compact_height: true });
+  const parent = {
+    style: {},
+    getAttribute: () => '',
+    getBoundingClientRect: () => ({ width: 320, height: 480 }),
+    hasAttribute: () => false,
+    classList: { contains: (className) => className === 'grid-cell' }
+  };
+  card.parentElement = parent;
 
   const originalGetComputedStyle = window.getComputedStyle;
   try {


### PR DESCRIPTION
### Motivation
- Sections grid cells in Home Assistant can allocate a fixed row height which the card previously did not inherit, causing initial render height/overflow issues for `week-compact` and `agenda` when `grid_options.rows` is used. 
- `compact_height` used viewport pixel math by default which is incorrect when the card is inside a fixed-height parent/grid allocation. 
- The card needed a host/parent-aware resize strategy to measure the settled HA layout without relying on an external window resize event.

### Description
- Add a full-height flex layout contract by updating `:host`, `daylight-calendar-card`/`skylight-calendar-card`, `.calendar-container`, and `.calendar-body` with `height: 100%`/`min-height: 0` and by making view containers (`.calendar-grid`, `.week-compact-container`, `.week-standard-container`, `.agenda-container`) flex-fill with `flex: 1 1 auto` and `min-height: 0` so they can fill HA Sections rows without forcing overflow. 
- Make `compact_height` parent/grid-aware by adding `hasFixedHeightParentAllocation()` and `getGridAwareCompactContainerStyle()` and returning a percentage/flex-compatible style when a constrained parent is detected while preserving the existing viewport pixel fallback. 
- Add host/parent `ResizeObserver` handling (`observeHostAndParentResize`, `measureHostAndParentSize`, `scheduleHostAndParentResizeHandling`) that caches sizes, throttles via `requestAnimationFrame`, and triggers measured renders; clean up observer and RAF in `disconnectedCallback()`. 
- Apply grid-aware compact sizing to compact month rendering and `week-compact` so compact views inside Sections use flexible 100% height rather than viewport pixels, and ensure `week-standard`/`agenda` continue to use compact logic with proper container awareness. 
- Add unit tests asserting the full-height CSS contract is present, that `getCompactContainerStyle()` returns the grid-aware percentage style for constrained parents and preserves viewport fallback, and that `disconnectedCallback()` disconnects the host `ResizeObserver`. 
- Document the recommendation to place `grid_options.rows` on the calendar card (and the caveat for stacked wrappers) in `README.md`.

### Testing
- Ran `npm test` (unit suite) and all tests passed (`120` tests, all green). 
- Ran `node --check skylight-calendar-card.js` to ensure syntax correctness and it returned clean. 
- Visual Playwright snapshot tests were attempted but are blocked in this environment because the Playwright browser binary is not installed (`npx playwright install` required); visual tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a6822dbfc8331b7d9de45b5ecdbf0)