### PR TITLE
Add configurable shortened event time labels (`shorten_event_times`)

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -7491,6 +7491,12 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   formatLocalizedHour(date) {
+    const formatter = new Intl.DateTimeFormat(this.getLocale(), this.getTimeFormatOptions());
+    const hourPart = formatter.formatToParts(date).find((part) => part.type === 'hour');
+    if (hourPart) {
+      return hourPart.value;
+    }
+
     return new Intl.NumberFormat(this.getLocale(), { useGrouping: false }).format(date.getHours());
   }
 

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -7127,7 +7127,7 @@ class SkylightCalendarCard extends HTMLElement {
              style="top: ${top}px; height: ${height}px; width: ${width}; left: ${left}; ${eventStyle} --event-bubble-font-size: ${this.getEventBubbleFontSize(event)}; --event-time-font-size: ${this.getEventTimeFontSize(event)}; --event-location-font-size: ${this.getEventLocationFontSize(event)}; --event-bubble-text-color: ${this.getEventBubbleFontColor(event)};"
              data-event='${JSON.stringify(event).replace(/'/g, "&#39;")}'>
           <div class="week-standard-event-title">${this.renderEventTitleWithPrefix(event, displayTitle || event.summary || this.t('untitledEvent'))}</div>
-          ${this.shouldShowEventTime(event) ? `<div class="week-standard-event-time">${this.formatEventTimeRange(eventStart, eventEnd)}</div>` : ''}
+          ${this.shouldShowEventTime(event) ? `<div class="week-standard-event-time">${this.formatEventTimeRange(eventStart, eventEnd, { schedule: true })}</div>` : ''}
           ${this.shouldShowEventLocation(event) ? `<div class="week-standard-event-location">📍 ${this.escapeHtml(this.getDisplayLocation(event.location, event))}</div>` : ''}
           ${this.renderEventIcon(event)}
           ${this.renderCombinedCornerBubbles(event)}
@@ -7500,9 +7500,9 @@ class SkylightCalendarCard extends HTMLElement {
     return new Intl.NumberFormat(this.getLocale(), { useGrouping: false }).format(date.getHours());
   }
 
-  formatShort12HourEventTime(date) {
+  formatShort12HourEventTime(date, options = {}) {
     if (!this.isWholeHour(date)) {
-      return this.formatTime(date);
+      return this.formatBaseEventTime(date, options);
     }
 
     const formatter = new Intl.DateTimeFormat(this.getLocale(), this.getTimeFormatOptions());
@@ -7515,42 +7515,46 @@ class SkylightCalendarCard extends HTMLElement {
     return shortenedParts.map((part) => part.value).join('').replace(/\s+/g, ' ').trim();
   }
 
-  formatShort24HourEventTime(date, { appendHourSuffix = true, omitWholeHourMinutes = true } = {}) {
+  formatShort24HourEventTime(date, { appendHourSuffix = true, omitWholeHourMinutes = true, schedule = false } = {}) {
     if (this.isWholeHour(date) && omitWholeHourMinutes) {
       return `${this.formatLocalizedHour(date)}${appendHourSuffix ? 'h' : ''}`;
     }
 
-    return this.formatTime(date);
+    return this.formatBaseEventTime(date, { schedule });
   }
 
-  formatEventTime(date) {
+  formatBaseEventTime(date, { schedule = false } = {}) {
+    return schedule ? this.formatScheduleTime(date) : this.formatTime(date);
+  }
+
+  formatEventTime(date, options = {}) {
     if (!this._config?.shorten_event_times) {
-      return this.formatTime(date);
+      return this.formatBaseEventTime(date, options);
     }
 
     if (this.uses24HourEventTime()) {
-      return this.formatShort24HourEventTime(date);
+      return this.formatShort24HourEventTime(date, options);
     }
 
-    return this.formatShort12HourEventTime(date);
+    return this.formatShort12HourEventTime(date, options);
   }
 
-  formatEventTimeRange(startDate, endDate) {
+  formatEventTimeRange(startDate, endDate, options = {}) {
     if (!this._config?.shorten_event_times) {
-      return `${this.formatTime(startDate)} - ${this.formatTime(endDate)}`;
+      return `${this.formatBaseEventTime(startDate, options)} - ${this.formatBaseEventTime(endDate, options)}`;
     }
 
     if (!this.uses24HourEventTime()) {
-      return `${this.formatShort12HourEventTime(startDate)} - ${this.formatShort12HourEventTime(endDate)}`;
+      return `${this.formatShort12HourEventTime(startDate, options)} - ${this.formatShort12HourEventTime(endDate, options)}`;
     }
 
     const startWholeHour = this.isWholeHour(startDate);
     const endWholeHour = this.isWholeHour(endDate);
     if (startWholeHour && endWholeHour) {
-      return `${this.formatShort24HourEventTime(startDate, { appendHourSuffix: false })}-${this.formatShort24HourEventTime(endDate)}`;
+      return `${this.formatShort24HourEventTime(startDate, { ...options, appendHourSuffix: false })}-${this.formatShort24HourEventTime(endDate, options)}`;
     }
 
-    return `${this.formatShort24HourEventTime(startDate, { appendHourSuffix: false })}-${this.formatShort24HourEventTime(endDate, { appendHourSuffix: endWholeHour })}`;
+    return `${this.formatShort24HourEventTime(startDate, { ...options, appendHourSuffix: false })}-${this.formatShort24HourEventTime(endDate, { ...options, appendHourSuffix: endWholeHour })}`;
   }
 
   getMonthWeekRowCount() {
@@ -8394,7 +8398,7 @@ class SkylightCalendarCard extends HTMLElement {
       displayTitle: shouldIncludeStartTime
         ? this.t('eventTitleWithStartTime', {
             title: displayTitle,
-            time: this.formatEventTime(eventStart)
+            time: this.formatEventTime(eventStart, { schedule: true })
           })
         : displayTitle
     };

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1409,6 +1409,7 @@ class SkylightCalendarCard extends HTMLElement {
       past_event_mode: normalizedPastEventMode, // Past-ended event handling: none, hide, or muted
       hide_empty_days: config.hide_empty_days || false, // Agenda view: hide day rows that do not contain any visible events
       agenda_compact_events: config.agenda_compact_events ?? false, // Agenda view: render title + time on one row with compact spacing
+      shorten_event_times: config.shorten_event_times ?? false, // Shorten event time labels in calendar views
       disable_swipe_controls: config.disable_swipe_controls ?? false, // Disable left/right swipe period navigation
       week_start_hour: normalizedWeekStartHour, // Start hour for week-standard view
       week_end_hour: normalizedWeekEndHour, // End hour for week-standard view
@@ -6766,7 +6767,7 @@ class SkylightCalendarCard extends HTMLElement {
               const { segmentStart, segmentEnd, isAllDaySegment } = daySegment;
               const timeLabel = isAllDaySegment
                 ? this.t('allDay')
-                : `${this.formatTime(segmentStart)} - ${this.formatTime(segmentEnd)}`;
+                : this.formatEventTimeRange(segmentStart, segmentEnd);
               const eventStyle = this.getEventStyle(event);
               const eventAgendaMinHeight = this.shouldShowCombinedCornerBubbles(event)
                 ? `calc(${agendaEventMinHeight} + 16px)`
@@ -7126,7 +7127,7 @@ class SkylightCalendarCard extends HTMLElement {
              style="top: ${top}px; height: ${height}px; width: ${width}; left: ${left}; ${eventStyle} --event-bubble-font-size: ${this.getEventBubbleFontSize(event)}; --event-time-font-size: ${this.getEventTimeFontSize(event)}; --event-location-font-size: ${this.getEventLocationFontSize(event)}; --event-bubble-text-color: ${this.getEventBubbleFontColor(event)};"
              data-event='${JSON.stringify(event).replace(/'/g, "&#39;")}'>
           <div class="week-standard-event-title">${this.renderEventTitleWithPrefix(event, displayTitle || event.summary || this.t('untitledEvent'))}</div>
-          ${this.shouldShowEventTime(event) ? `<div class="week-standard-event-time">${this.formatScheduleTime(eventStart)} - ${this.formatScheduleTime(eventEnd)}</div>` : ''}
+          ${this.shouldShowEventTime(event) ? `<div class="week-standard-event-time">${this.formatEventTimeRange(eventStart, eventEnd)}</div>` : ''}
           ${this.shouldShowEventLocation(event) ? `<div class="week-standard-event-location">📍 ${this.escapeHtml(this.getDisplayLocation(event.location, event))}</div>` : ''}
           ${this.renderEventIcon(event)}
           ${this.renderCombinedCornerBubbles(event)}
@@ -7480,6 +7481,72 @@ class SkylightCalendarCard extends HTMLElement {
     return new Intl.DateTimeFormat(this.getLocale(), this.getTimeFormatOptions()).format(date);
   }
 
+  uses24HourEventTime() {
+    const formatter = new Intl.DateTimeFormat(this.getLocale(), this.getTimeFormatOptions());
+    return formatter.resolvedOptions().hour12 === false;
+  }
+
+  isWholeHour(date) {
+    return date.getMinutes() === 0 && date.getSeconds() === 0 && date.getMilliseconds() === 0;
+  }
+
+  formatLocalizedHour(date) {
+    return new Intl.NumberFormat(this.getLocale(), { useGrouping: false }).format(date.getHours());
+  }
+
+  formatShort12HourEventTime(date) {
+    if (!this.isWholeHour(date)) {
+      return this.formatTime(date);
+    }
+
+    const formatter = new Intl.DateTimeFormat(this.getLocale(), this.getTimeFormatOptions());
+    const parts = formatter.formatToParts(date);
+    const minuteIndex = parts.findIndex((part) => part.type === 'minute');
+    const shortenedParts = parts.filter((part, index) => {
+      if (part.type === 'minute') return false;
+      return !(part.type === 'literal' && index === minuteIndex - 1);
+    });
+    return shortenedParts.map((part) => part.value).join('').replace(/\s+/g, ' ').trim();
+  }
+
+  formatShort24HourEventTime(date, { appendHourSuffix = true, omitWholeHourMinutes = true } = {}) {
+    if (this.isWholeHour(date) && omitWholeHourMinutes) {
+      return `${this.formatLocalizedHour(date)}${appendHourSuffix ? 'h' : ''}`;
+    }
+
+    return this.formatTime(date);
+  }
+
+  formatEventTime(date) {
+    if (!this._config?.shorten_event_times) {
+      return this.formatTime(date);
+    }
+
+    if (this.uses24HourEventTime()) {
+      return this.formatShort24HourEventTime(date);
+    }
+
+    return this.formatShort12HourEventTime(date);
+  }
+
+  formatEventTimeRange(startDate, endDate) {
+    if (!this._config?.shorten_event_times) {
+      return `${this.formatTime(startDate)} - ${this.formatTime(endDate)}`;
+    }
+
+    if (!this.uses24HourEventTime()) {
+      return `${this.formatShort12HourEventTime(startDate)} - ${this.formatShort12HourEventTime(endDate)}`;
+    }
+
+    const startWholeHour = this.isWholeHour(startDate);
+    const endWholeHour = this.isWholeHour(endDate);
+    if (startWholeHour && endWholeHour) {
+      return `${this.formatShort24HourEventTime(startDate, { appendHourSuffix: false })}-${this.formatShort24HourEventTime(endDate)}`;
+    }
+
+    return `${this.formatShort24HourEventTime(startDate, { appendHourSuffix: false })}-${this.formatShort24HourEventTime(endDate, { appendHourSuffix: endWholeHour })}`;
+  }
+
   getMonthWeekRowCount() {
     if (this._config.rolling_weeks !== null && this._viewMode === 'month') {
       return this._config.rolling_weeks + 1;
@@ -7806,7 +7873,7 @@ class SkylightCalendarCard extends HTMLElement {
     const { segmentStart, segmentEnd, isAllDaySegment } = daySegment;
     const timeLabel = isAllDaySegment
       ? this.t('allDay')
-      : `${this.formatTime(segmentStart)} - ${this.formatTime(segmentEnd)}`;
+      : this.formatEventTimeRange(segmentStart, segmentEnd);
     const eventStyle = this.getEventStyle(event);
 
     return `
@@ -7827,7 +7894,7 @@ class SkylightCalendarCard extends HTMLElement {
 
     return `
       <div class="event" style="${eventStyle}; --event-bubble-font-size: ${this.getEventBubbleFontSize(event)}; --event-time-font-size: ${this.getEventTimeFontSize(event)}; --event-bubble-text-color: ${this.getEventBubbleFontColor(event)};" data-event='${JSON.stringify(event).replace(/'/g, "&#39;")}'>
-        ${!isAllDaySegment && this.shouldShowEventTime(event) ? `<span class="event-time">${this.formatTime(segmentStart)}</span>` : ''}
+        ${!isAllDaySegment && this.shouldShowEventTime(event) ? `<span class="event-time">${this.formatEventTime(segmentStart)}</span>` : ''}
         ${this.renderEventTitleWithPrefix(event, event.summary || this.t('untitledEvent'))}
         ${this.renderCombinedCornerBubbles(event)}
       </div>
@@ -8321,7 +8388,7 @@ class SkylightCalendarCard extends HTMLElement {
       displayTitle: shouldIncludeStartTime
         ? this.t('eventTitleWithStartTime', {
             title: displayTitle,
-            time: this.formatScheduleTime(eventStart)
+            time: this.formatEventTime(eventStart)
           })
         : displayTitle
     };
@@ -10625,13 +10692,13 @@ class SkylightCalendarCard extends HTMLElement {
         <div class="modal-row">
           <div class="modal-label">📅 ${this.t('start')}</div>
           <div class="modal-value">
-            ${this.formatDate(startDate)}${!isAllDay ? ` ${this.t('at')} ${this.formatTime(startDate)}` : ` (${this.t('allDay')})`}
+            ${this.formatDate(startDate)}${!isAllDay ? ` ${this.t('at')} ${this.formatEventTime(startDate)}` : ` (${this.t('allDay')})`}
           </div>
         </div>
         <div class="modal-row">
           <div class="modal-label">🏁 ${this.t('end')}</div>
           <div class="modal-value">
-            ${this.formatDate(endDate)}${!isAllDay ? ` ${this.t('at')} ${this.formatTime(endDate)}` : ` (${this.t('allDay')})`}
+            ${this.formatDate(endDate)}${!isAllDay ? ` ${this.t('at')} ${this.formatEventTime(endDate)}` : ` (${this.t('allDay')})`}
           </div>
         </div>
         ${!isAllDay ? `
@@ -10760,7 +10827,7 @@ class SkylightCalendarCard extends HTMLElement {
               const daySegment = this.getEventDaySegment(event, date);
               if (!daySegment) return '';
               const { segmentStart, isAllDaySegment } = daySegment;
-              const timeLabel = isAllDaySegment ? this.t('allDay') : this.formatTime(segmentStart);
+              const timeLabel = isAllDaySegment ? this.t('allDay') : this.formatEventTime(segmentStart);
               const eventStyle = this.getEventStyle(event);
               return `
                 <div class="week-compact-event" style="${eventStyle} --event-bubble-font-size: ${this.getEventBubbleFontSize(event)}; --event-time-font-size: ${this.getEventTimeFontSize(event)}; --event-location-font-size: ${this.getEventLocationFontSize(event)}; --event-bubble-text-color: ${this.getEventBubbleFontColor(event)};" data-event='${JSON.stringify(event).replace(/'/g, "&#39;")}'>
@@ -10814,7 +10881,7 @@ class SkylightCalendarCard extends HTMLElement {
           return `
             <div class="day-event day-modal-event" style="${eventStyle} --event-bubble-font-size: ${this.getEventBubbleFontSize(event)}; --event-time-font-size: ${this.getEventTimeFontSize(event)}; --event-location-font-size: ${this.getEventLocationFontSize(event)}; --event-bubble-text-color: ${this.getEventBubbleFontColor(event)};" data-event='${JSON.stringify(event).replace(/'/g, "&#39;")}'>
               <div class="day-modal-event-title">${this.renderEventTitleWithPrefix(event, event.summary || this.t('untitledEvent'))}</div>
-              ${this.shouldShowEventTime(event) ? `<div class="day-modal-event-meta">${isAllDaySegment ? this.t('allDay') : `${this.formatTime(segmentStart)} - ${this.formatTime(segmentEnd)}`}</div>` : ''}
+              ${this.shouldShowEventTime(event) ? `<div class="day-modal-event-meta">${isAllDaySegment ? this.t('allDay') : this.formatEventTimeRange(segmentStart, segmentEnd)}</div>` : ''}
               ${this.shouldShowEventLocation(event) ? `<div class="day-modal-event-location">📍 ${this.escapeHtml(this.getDisplayLocation(event.location, event))}</div>` : ''}
               ${this.renderCombinedCornerBubbles(event)}
             </div>
@@ -11524,6 +11591,7 @@ class SkylightCalendarCard extends HTMLElement {
       show_all_details_month: false,
       hide_empty_days: false,
       agenda_compact_events: false,
+      shorten_event_times: false,
       compact_width: false,
       show_current_time_bar: false,
       show_event_location: false,
@@ -12400,6 +12468,7 @@ class SkylightCalendarCardEditor extends HTMLElement {
       <div class="boolean-list">
         <label><input type="checkbox" data-field="show_current_time_bar" ${this._config.show_current_time_bar ? 'checked' : ''}> Show current time bar</label>
         <label><input type="checkbox" data-field="use_24hr_schedule" ${this._config.use_24hr_schedule ? 'checked' : ''}> Use 24-hour schedule time</label>
+        <label><input type="checkbox" data-field="shorten_event_times" ${this._config.shorten_event_times ? 'checked' : ''}> Shorten event times</label>
         <label><input type="checkbox" data-field="show_event_location" ${this._config.show_event_location ? 'checked' : ''}> Show event location</label>
         <label><input type="checkbox" data-field="use_short_location" ${this._config.use_short_location ? 'checked' : ''}> Shorten event location in views</label>
         <label><input type="checkbox" data-field="combine_calendars" ${this._config.combine_calendars ? 'checked' : ''}> Combine duplicate events across calendars</label>

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -259,6 +259,16 @@ test('shorten_event_times compacts whole-hour 24-hour ranges', () => {
   assert.equal(card.formatEventTimeRange(start, end), '10-11h');
 });
 
+test('shorten_event_times preserves h24 midnight hour labels', () => {
+  const card = makeCard({ entities: ['calendar.family'], locale: 'en-US', use_24hr_schedule: true, shorten_event_times: true });
+  const start = new Date('2026-05-14T23:00:00Z');
+  const end = new Date('2026-05-15T00:00:00Z');
+
+  assert.equal(card.formatTime(end), '24:00');
+  assert.equal(card.formatEventTime(end), '24h');
+  assert.equal(card.formatEventTimeRange(start, end), '23-24h');
+});
+
 test('shorten_event_times preserves needed minutes in mixed 24-hour ranges', () => {
   const card = makeCard({ entities: ['calendar.family'], locale: 'en-US', use_24hr_schedule: true, shorten_event_times: true });
 

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -106,7 +106,7 @@ test('getStubConfig includes key configuration defaults', () => {
   const requiredKeys = [
     'default_view', 'week_days', 'week_start_hour', 'week_end_hour',
     'lock_schedule_hours', 'show_all_events_month', 'show_all_details_month',
-    'hide_empty_days', 'agenda_compact_events', 'compact_width',
+    'hide_empty_days', 'agenda_compact_events', 'shorten_event_times', 'compact_width',
     'show_current_time_bar', 'show_event_location', 'use_short_location',
     'event_calendar_friendly_name', 'event_title_prefix', 'past_event_mode', 'event_color_mode',
     'event_neutral_background', 'event_tint_opacity', 'event_color_bar_width', 'combine_style',
@@ -145,6 +145,7 @@ test('setConfig applies visual layout and styling options', () => {
     event_calendar_friendly_name: true,
     event_title_prefix: 'icon',
     show_current_time_bar: true,
+    shorten_event_times: true,
     header_color: '#123456',
     header_text_color: '#ffffff',
     header_background_opacity: 55,
@@ -197,6 +198,7 @@ test('setConfig applies visual layout and styling options', () => {
   assert.equal(card._config.event_calendar_friendly_name, true);
   assert.equal(card._config.event_title_prefix, 'badge_icon');
   assert.equal(card._config.show_current_time_bar, true);
+  assert.equal(card._config.shorten_event_times, true);
   assert.equal(card._config.header_color, '#123456');
   assert.equal(card._config.header_text_color, '#ffffff');
   assert.equal(card._config.header_background_opacity, 55);
@@ -222,6 +224,62 @@ test('setConfig applies visual layout and styling options', () => {
   assert.deepEqual(card._config.default_hidden_calendars, ['calendar.family']);
   assert.equal(card._hiddenCalendars.has('calendar.family'), true);
   assert.equal(card._config.virtual_calendars[0].name, 'home');
+});
+
+test('shorten_event_times defaults to unchanged event time formatting', () => {
+  const card = makeCard({ entities: ['calendar.family'], locale: 'en-US' });
+  const start = new Date('2026-05-14T10:00:00Z');
+  const end = new Date('2026-05-14T11:00:00Z');
+
+  assert.equal(card._config.shorten_event_times, false);
+  assert.equal(card.formatEventTime(start), card.formatTime(start));
+  assert.equal(card.formatEventTimeRange(start, end), `${card.formatTime(start)} - ${card.formatTime(end)}`);
+});
+
+test('shorten_event_times removes minutes from whole-hour 12-hour event times', () => {
+  const card = makeCard({ entities: ['calendar.family'], locale: 'en-US', shorten_event_times: true });
+  const start = new Date('2026-05-14T10:00:00Z');
+  const end = new Date('2026-05-14T11:00:00Z');
+
+  assert.equal(card.formatEventTime(start), '10 AM');
+  assert.equal(card.formatEventTimeRange(start, end), '10 AM - 11 AM');
+});
+
+test('shorten_event_times compacts whole-hour 24-hour event times', () => {
+  const card = makeCard({ entities: ['calendar.family'], locale: 'en-US', use_24hr_schedule: true, shorten_event_times: true });
+
+  assert.equal(card.formatEventTime(new Date('2026-05-14T10:00:00Z')), '10h');
+});
+
+test('shorten_event_times compacts whole-hour 24-hour ranges', () => {
+  const card = makeCard({ entities: ['calendar.family'], locale: 'en-US', use_24hr_schedule: true, shorten_event_times: true });
+  const start = new Date('2026-05-14T10:00:00Z');
+  const end = new Date('2026-05-14T11:00:00Z');
+
+  assert.equal(card.formatEventTimeRange(start, end), '10-11h');
+});
+
+test('shorten_event_times preserves needed minutes in mixed 24-hour ranges', () => {
+  const card = makeCard({ entities: ['calendar.family'], locale: 'en-US', use_24hr_schedule: true, shorten_event_times: true });
+
+  assert.equal(card.formatEventTimeRange(new Date('2026-05-14T10:30:00Z'), new Date('2026-05-14T11:00:00Z')), '10:30-11h');
+  assert.equal(card.formatEventTimeRange(new Date('2026-05-14T10:00:00Z'), new Date('2026-05-14T11:30:00Z')), '10-11:30');
+  assert.equal(card.formatEventTimeRange(new Date('2026-05-14T10:15:00Z'), new Date('2026-05-14T11:45:00Z')), '10:15-11:45');
+});
+
+test('shorten_event_times leaves all-day event labels unaffected', () => {
+  const event = {
+    entityId: 'calendar.family',
+    color: '#3366ff',
+    summary: 'All-day event',
+    start: { date: '2026-05-14' },
+    end: { date: '2026-05-15' }
+  };
+  const card = makeCard({ entities: ['calendar.family'], locale: 'en-US', shorten_event_times: true });
+  const html = card.renderWeekCompactEvent(event, new Date('2026-05-14T00:00:00Z'));
+
+  assert.match(html, /week-compact-event-time">All Day</);
+  assert.doesNotMatch(html, /10 AM|10h/);
 });
 
 test('default_hidden_calendars initializes hidden calendar badges', () => {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -236,6 +236,42 @@ test('shorten_event_times defaults to unchanged event time formatting', () => {
   assert.equal(card.formatEventTimeRange(start, end), `${card.formatTime(start)} - ${card.formatTime(end)}`);
 });
 
+test('shorten_event_times false preserves schedule formatter labels', () => {
+  const card = makeCard({ entities: ['calendar.family'], locale: 'en-US', shorten_event_times: false });
+  const originalFormatTime = card.formatTime.bind(card);
+  const originalFormatScheduleTime = card.formatScheduleTime.bind(card);
+  const formatToken = (prefix, date) => `${prefix}-${date.getUTCHours()}:${String(date.getUTCMinutes()).padStart(2, '0')}`;
+  card.formatTime = (date) => formatToken('plain', date);
+  card.formatScheduleTime = (date) => formatToken('schedule', date);
+
+  try {
+    const event = {
+      entityId: 'calendar.family',
+      color: '#3366ff',
+      summary: 'Schedule event',
+      start: { dateTime: '2026-05-14T09:00:00Z' },
+      end: { dateTime: '2026-05-14T10:30:00Z' }
+    };
+    const weekStandardHtml = card.renderTimedEventsForDay([event], new Date('2026-05-14T00:00:00Z'), 0, 23, 40);
+
+    assert.match(weekStandardHtml, /schedule-9:00 - schedule-10:30/);
+    assert.doesNotMatch(weekStandardHtml, /plain-9:00 - plain-10:30/);
+    assert.equal(card.formatEventTimeRange(new Date('2026-05-14T09:00:00Z'), new Date('2026-05-14T10:30:00Z')), 'plain-9:00 - plain-10:30');
+    assert.equal(card.formatEventTimeRange(new Date('2026-05-14T09:00:00Z'), new Date('2026-05-14T10:30:00Z'), { schedule: true }), 'schedule-9:00 - schedule-10:30');
+
+    const spanningEvent = {
+      ...event,
+      summary: 'Overnight event',
+      start: { dateTime: '2026-05-14T22:00:00Z' },
+      end: { dateTime: '2026-05-16T01:00:00Z' }
+    };
+    assert.equal(card.getScheduleVisualInfo(spanningEvent).displayTitle, 'Overnight event, schedule-22:00');
+  } finally {
+    card.formatTime = originalFormatTime;
+    card.formatScheduleTime = originalFormatScheduleTime;
+  }
+});
+
 test('shorten_event_times removes minutes from whole-hour 12-hour event times', () => {
   const card = makeCard({ entities: ['calendar.family'], locale: 'en-US', shorten_event_times: true });
   const start = new Date('2026-05-14T10:00:00Z');


### PR DESCRIPTION
### Motivation
- Provide an option to display more compact event time labels in various calendar views to improve readability and save space.
- Allow users to opt into shortened formatting for both 12-hour and 24-hour locales while preserving existing behavior by default.

### Description
- Introduces a new configuration option `shorten_event_times` (default `false`) and exposes it in the editor UI and `getStubConfig` via `shorten_event_times` and a checkbox in the editor.
- Adds helper formatting functions: `uses24HourEventTime`, `isWholeHour`, `formatLocalizedHour`, `formatShort12HourEventTime`, `formatShort24HourEventTime`, `formatEventTime`, and `formatEventTimeRange` to implement compact rules for whole-hour and mixed-minute ranges.
- Replaces direct calls to `formatTime` for event time labels across agenda, schedule, week-compact, month, modal, and other render paths with `formatEventTime` or `formatEventTimeRange` to apply the new compacting logic when enabled.
- Updates unit tests to cover default behavior and the new compact formatting in 12-hour and 24-hour modes, range edge cases, and all-day event handling.

### Testing
- Ran the unit test suite (`skylight-calendar-card.test.js`) including new tests for `shorten_event_times`; all tests passed.
- Added tests: `shorten_event_times defaults to unchanged event time formatting`, `shorten_event_times removes minutes from whole-hour 12-hour event times`, `shorten_event_times compacts whole-hour 24-hour event times`, `shorten_event_times compacts whole-hour 24-hour ranges`, `shorten_event_times preserves needed minutes in mixed 24-hour ranges`, and `shorten_event_times leaves all-day event labels unaffected`, and they all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1af199efe48331b479f20ef89624ee)