### PR TITLE
Unify normalization helpers (enums, CSS lengths, font sizes) and add tests

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1003,38 +1003,41 @@ class SkylightCalendarCard extends HTMLElement {
     return !!(this._config?.show_dashboard_nav_button && this.getConfiguredDashboardPath());
   }
 
+  normalizeEnumValue(value, { aliases = {}, allowed = [], fallback }) {
+    const normalizedValue = String(value ?? '').trim().toLowerCase();
+    const mappedValue = aliases[normalizedValue] ?? normalizedValue;
+    return allowed.includes(mappedValue) ? mappedValue : fallback;
+  }
+
   normalizeDefaultDarkMode(value) {
     if (value === true) return 'dark';
     if (value === false || value === undefined || value === null || value === '') return 'auto';
 
-    const normalizedValue = String(value).trim().toLowerCase();
-    if (['auto', 'light', 'dark'].includes(normalizedValue)) {
-      return normalizedValue;
-    }
-
-    return 'auto';
+    return this.normalizeEnumValue(value, {
+      allowed: ['auto', 'light', 'dark'],
+      fallback: 'auto'
+    });
   }
 
   normalizeEventTitlePrefixMode(value) {
-    const normalizedValue = String(value ?? '').trim().toLowerCase();
-    if (['icon', 'badge', 'badgeicon'].includes(normalizedValue)) {
-      return 'badge_icon';
-    }
-    if (['friendly', 'friendlyname'].includes(normalizedValue)) {
-      return 'friendly_name';
-    }
-    if (['friendly_name', 'badge_icon', 'none'].includes(normalizedValue)) {
-      return normalizedValue;
-    }
-    return 'none';
+    return this.normalizeEnumValue(value, {
+      aliases: {
+        icon: 'badge_icon',
+        badge: 'badge_icon',
+        badgeicon: 'badge_icon',
+        friendly: 'friendly_name',
+        friendlyname: 'friendly_name'
+      },
+      allowed: ['friendly_name', 'badge_icon', 'none'],
+      fallback: 'none'
+    });
   }
 
   normalizePastEventMode(value) {
-    const normalizedValue = String(value ?? '').trim().toLowerCase();
-    if (['none', 'hide', 'muted'].includes(normalizedValue)) {
-      return normalizedValue;
-    }
-    return 'none';
+    return this.normalizeEnumValue(value, {
+      allowed: ['none', 'hide', 'muted'],
+      fallback: 'none'
+    });
   }
 
   normalizeEntityStringMap(value) {
@@ -1760,14 +1763,17 @@ class SkylightCalendarCard extends HTMLElement {
 
 
   normalizeCombineStyle(styleValue) {
-    const normalized = String(styleValue || '').trim().toLowerCase();
-    return ['stripes', 'bars', 'dots'].includes(normalized) ? normalized : 'bars';
+    return this.normalizeEnumValue(styleValue, {
+      allowed: ['stripes', 'bars', 'dots'],
+      fallback: 'bars'
+    });
   }
 
   normalizeEventColorMode(modeValue) {
-    const normalized = String(modeValue || '').trim().toLowerCase();
-    if (normalized === 'left-neutral' || normalized === 'left-tint') return normalized;
-    return 'classic';
+    return this.normalizeEnumValue(modeValue, {
+      allowed: ['classic', 'left-neutral', 'left-tint'],
+      fallback: 'classic'
+    });
   }
 
   normalizeCombineBackground(backgroundValue) {
@@ -1993,28 +1999,12 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
 
-  normalizeStyleSizeValue(value) {
-    if (value === undefined || value === null || value === '') return null;
-
-    if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
-      return `${value}px`;
-    }
-
-    const trimmed = String(value).trim();
-    if (!trimmed) return null;
-    if (/^\d*\.?\d+(px|rem|em|%)$/i.test(trimmed)) return trimmed;
-
-    const parsed = Number(trimmed);
-    if (Number.isFinite(parsed) && parsed > 0) return `${parsed}px`;
-    return null;
-  }
-
-  normalizeStyleBorderWidth(value) {
+  normalizeCssLength(value, { allowZero = false } = {}) {
     if (value === undefined || value === null || value === '') return null;
 
     if (typeof value === 'number' && Number.isFinite(value)) {
-      const clamped = Math.max(0, value);
-      return `${clamped}px`;
+      if (allowZero) return `${Math.max(0, value)}px`;
+      return value > 0 ? `${value}px` : null;
     }
 
     const trimmed = String(value).trim();
@@ -2025,11 +2015,19 @@ class SkylightCalendarCard extends HTMLElement {
     }
 
     const parsed = Number(trimmed);
-    if (Number.isFinite(parsed) && parsed >= 0) {
+    if (Number.isFinite(parsed) && (allowZero ? parsed >= 0 : parsed > 0)) {
       return `${parsed}px`;
     }
 
     return null;
+  }
+
+  normalizeStyleSizeValue(value) {
+    return this.normalizeCssLength(value, { allowZero: false });
+  }
+
+  normalizeStyleBorderWidth(value) {
+    return this.normalizeCssLength(value, { allowZero: true });
   }
 
   normalizeDayOfWeekRule(value, localeOverride = null) {
@@ -7298,11 +7296,11 @@ class SkylightCalendarCard extends HTMLElement {
     return `rgb(${nr}, ${ng}, ${nb})`;
   }
 
-  getEventBubbleFontSize(event = null) {
+  getEventFontSize(event = null, configKey = 'event_font_size', fallbackPx = 11) {
     const styleOverrides = event ? this.getEventStyleOverrides(event) : null;
-    const configuredSize = styleOverrides?.event_font_size ?? this._config?.event_font_size;
+    const configuredSize = styleOverrides?.[configKey] ?? this._config?.[configKey];
     if (configuredSize === undefined || configuredSize === null || configuredSize === '') {
-      return '11px';
+      return `${fallbackPx}px`;
     }
 
     if (typeof configuredSize === 'number' && Number.isFinite(configuredSize)) {
@@ -7310,40 +7308,20 @@ class SkylightCalendarCard extends HTMLElement {
     }
 
     const normalized = String(configuredSize).trim();
-    if (!normalized) return '11px';
+    if (!normalized) return `${fallbackPx}px`;
     return /^\d+(\.\d+)?$/.test(normalized) ? `${normalized}px` : normalized;
+  }
+
+  getEventBubbleFontSize(event = null) {
+    return this.getEventFontSize(event, 'event_font_size', 11);
   }
 
   getEventTimeFontSize(event = null) {
-    const styleOverrides = event ? this.getEventStyleOverrides(event) : null;
-    const configuredSize = styleOverrides?.event_time_font_size ?? this._config?.event_time_font_size;
-    if (configuredSize === undefined || configuredSize === null || configuredSize === '') {
-      return '9px';
-    }
-
-    if (typeof configuredSize === 'number' && Number.isFinite(configuredSize)) {
-      return `${configuredSize}px`;
-    }
-
-    const normalized = String(configuredSize).trim();
-    if (!normalized) return '9px';
-    return /^\d+(\.\d+)?$/.test(normalized) ? `${normalized}px` : normalized;
+    return this.getEventFontSize(event, 'event_time_font_size', 9);
   }
 
   getEventLocationFontSize(event = null) {
-    const styleOverrides = event ? this.getEventStyleOverrides(event) : null;
-    const configuredSize = styleOverrides?.event_location_font_size ?? this._config?.event_location_font_size;
-    if (configuredSize === undefined || configuredSize === null || configuredSize === '') {
-      return '9px';
-    }
-
-    if (typeof configuredSize === 'number' && Number.isFinite(configuredSize)) {
-      return `${configuredSize}px`;
-    }
-
-    const normalized = String(configuredSize).trim();
-    if (!normalized) return '9px';
-    return /^\d+(\.\d+)?$/.test(normalized) ? `${normalized}px` : normalized;
+    return this.getEventFontSize(event, 'event_location_font_size', 9);
   }
 
   shouldShowEventLocation(event) {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -393,6 +393,81 @@ test('setConfig normalizes fallback values and aliases', () => {
 });
 
 
+test('normalizes enum helper aliases and fallbacks consistently', () => {
+  const card = makeCard();
+
+  assert.equal(card.normalizeDefaultDarkMode(true), 'dark');
+  assert.equal(card.normalizeDefaultDarkMode(false), 'auto');
+  assert.equal(card.normalizeDefaultDarkMode(' DARK '), 'dark');
+  assert.equal(card.normalizeDefaultDarkMode('light'), 'light');
+  assert.equal(card.normalizeDefaultDarkMode('invalid'), 'auto');
+  assert.equal(card.normalizeEventTitlePrefixMode('icon'), 'badge_icon');
+  assert.equal(card.normalizeEventTitlePrefixMode('badgeicon'), 'badge_icon');
+  assert.equal(card.normalizeEventTitlePrefixMode('badgeIcon'), 'badge_icon');
+  assert.equal(card.normalizeEventTitlePrefixMode('friendlyname'), 'friendly_name');
+  assert.equal(card.normalizeEventTitlePrefixMode('friendlyName'), 'friendly_name');
+  assert.equal(card.normalizeEventTitlePrefixMode('friendly_name'), 'friendly_name');
+  assert.equal(card.normalizeEventTitlePrefixMode('bad-value'), 'none');
+  assert.equal(card.normalizePastEventMode(' muted '), 'muted');
+  assert.equal(card.normalizePastEventMode('bad-value'), 'none');
+  assert.equal(card.normalizeCombineStyle('DOTS'), 'dots');
+  assert.equal(card.normalizeCombineStyle('zebra'), 'bars');
+  assert.equal(card.normalizeEventColorMode('left-neutral'), 'left-neutral');
+  assert.equal(card.normalizeEventColorMode('bad-value'), 'classic');
+});
+
+test('normalizes css length helpers while preserving size and border width rules', () => {
+  const card = makeCard();
+
+  assert.equal(card.normalizeStyleSizeValue(5), '5px');
+  assert.equal(card.normalizeStyleSizeValue(12), '12px');
+  assert.equal(card.normalizeStyleSizeValue('5rem'), '5rem');
+  assert.equal(card.normalizeStyleSizeValue(' 1.25rem '), '1.25rem');
+  assert.equal(card.normalizeStyleSizeValue('50%'), '50%');
+  assert.equal(card.normalizeStyleSizeValue('14'), '14px');
+  assert.equal(card.normalizeStyleSizeValue(0), null);
+  assert.equal(card.normalizeStyleSizeValue('0px'), '0px');
+  assert.equal(card.normalizeStyleSizeValue('bad'), null);
+  assert.equal(card.normalizeStyleBorderWidth(0), '0px');
+  assert.equal(card.normalizeStyleBorderWidth(-5), '0px');
+  assert.equal(card.normalizeStyleBorderWidth(-2), '0px');
+  assert.equal(card.normalizeStyleBorderWidth('0'), '0px');
+  assert.equal(card.normalizeStyleBorderWidth('2em'), '2em');
+  assert.equal(card.normalizeStyleBorderWidth('-2'), null);
+});
+
+test('event font size wrappers share fallback and override behavior', () => {
+  const card = makeCard({
+    entities: ['calendar.family'],
+    event_font_size: 13,
+    event_time_font_size: ' 0.75rem ',
+    event_location_font_size: ''
+  });
+
+  assert.equal(card.getEventBubbleFontSize(), '13px');
+  assert.equal(card.getEventTimeFontSize(), '0.75rem');
+  assert.equal(card.getEventLocationFontSize(), '9px');
+  assert.equal(card.getEventFontSize(), '13px');
+  assert.equal(card.getEventFontSize(null, 'missing_font_size', 14), '14px');
+
+  const originalGetEventStyleOverrides = card.getEventStyleOverrides.bind(card);
+  card.getEventStyleOverrides = () => ({
+    event_font_size: '15',
+    event_time_font_size: 10,
+    event_location_font_size: ' 0.8em '
+  });
+
+  try {
+    const event = { entityId: 'calendar.family', summary: 'Styled' };
+    assert.equal(card.getEventBubbleFontSize(event), '15px');
+    assert.equal(card.getEventTimeFontSize(event), '10px');
+    assert.equal(card.getEventLocationFontSize(event), '0.8em');
+  } finally {
+    card.getEventStyleOverrides = originalGetEventStyleOverrides;
+  }
+});
+
+
 function makeRelativeEvent(summary, startOffsetMs, endOffsetMs) {
   const now = Date.now();
   return {


### PR DESCRIPTION
### Motivation
- Reduce duplicated normalization logic across the card by centralizing enum and CSS length parsing and to support aliases and consistent fallbacks.
- Ensure border widths can accept zero and style size parsing is consistent for numeric and unit-suffixed inputs.
- Consolidate event font-size getters to share fallback/override behavior and simplify style override handling.

### Description
- Introduces `normalizeEnumValue` to handle enum normalization with `aliases`, `allowed` values and `fallback`, and refactors `normalizeDefaultDarkMode`, `normalizeEventTitlePrefixMode`, `normalizePastEventMode`, `normalizeCombineStyle`, and `normalizeEventColorMode` to use it.
- Adds `normalizeCssLength` with an `allowZero` option and replaces previous ad-hoc size/border parsing with `normalizeStyleSizeValue` and `normalizeStyleBorderWidth` wrappers that call the new helper.
- Adds a generic `getEventFontSize` helper used by `getEventBubbleFontSize`, `getEventTimeFontSize`, and `getEventLocationFontSize` to centralize override and fallback logic.
- Minor related cleanups to use unified normalization functions and preserve previous defaults and alias behaviors.
- Adds unit tests covering enum normalization/aliases/fallbacks, CSS length parsing and border width behavior, and the event font-size wrapper behavior.

### Testing
- Ran the existing test suite plus newly added tests in `skylight-calendar-card.test.js` which exercise enum normalization, CSS length helpers, and font size wrappers.
- All tests, including the new `normalizes enum helper aliases and fallbacks consistently`, `normalizes css length helpers while preserving size and border width rules`, and `event font size wrappers share fallback and override behavior`, passed successfully.
- Existing coverage for `setConfig` normalization and legacy behavior tests remain in place and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b1cdfafb48331ad6610ad325ce052)