### PR TITLE
Add today_background_color and today_style convenience options

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,33 +121,9 @@ If you do not see an option in the visual editor, open the card in YAML mode. YA
 
 - `event_styles` — conditionally style individual events
 - `day_styles` — conditionally style days
-- `today_background_color` / `today_style` — convenience options for styling today's date without writing a full `day_styles` rule
 - `virtual_calendars` — group multiple calendars into a single virtual calendar
 - Advanced UIX/Card Mod styling
 
-### Styling today's date
-
-For simple today styling, use `today_background_color`. Internally this is treated like a `day_styles` rule with `condition: today` and the default priority `0`, so explicit higher-priority `day_styles` rules can override it.
-
-```yaml
-type: custom:daylight-calendar-card
-entities:
-  - calendar.family
-today_background_color: var(--primary-color)
-```
-
-For more control, use `today_style` with the same supported style fields as a `day_styles` style block, such as `background_color`, `background_opacity`, `opacity`, `border_color`, and `border_width`. If both today options are configured, `today_style` takes precedence over `today_background_color` for overlapping fields.
-
-```yaml
-type: custom:daylight-calendar-card
-entities:
-  - calendar.family
-today_style:
-  background_color: '#ff0000'
-  background_opacity: 0.35
-  border_color: '#ffffff'
-  border_width: 2
-```
 
 Full documentation is available in the wiki:
 

--- a/README.md
+++ b/README.md
@@ -121,8 +121,33 @@ If you do not see an option in the visual editor, open the card in YAML mode. YA
 
 - `event_styles` — conditionally style individual events
 - `day_styles` — conditionally style days
+- `today_background_color` / `today_style` — convenience options for styling today's date without writing a full `day_styles` rule
 - `virtual_calendars` — group multiple calendars into a single virtual calendar
 - Advanced UIX/Card Mod styling
+
+### Styling today's date
+
+For simple today styling, use `today_background_color`. Internally this is treated like a `day_styles` rule with `condition: today` and the default priority `0`, so explicit higher-priority `day_styles` rules can override it.
+
+```yaml
+type: custom:daylight-calendar-card
+entities:
+  - calendar.family
+today_background_color: var(--primary-color)
+```
+
+For more control, use `today_style` with the same supported style fields as a `day_styles` style block, such as `background_color`, `background_opacity`, `opacity`, `border_color`, and `border_width`. If both today options are configured, `today_style` takes precedence over `today_background_color` for overlapping fields.
+
+```yaml
+type: custom:daylight-calendar-card
+entities:
+  - calendar.family
+today_style:
+  background_color: '#ff0000'
+  background_opacity: 0.35
+  border_color: '#ffffff'
+  border_width: 2
+```
 
 Full documentation is available in the wiki:
 

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1457,7 +1457,10 @@ class SkylightCalendarCard extends HTMLElement {
       normalizedCalendarColors: this.normalizeColorMap(rawConfig.colors || {}),
       normalizedEventFontColors: this.normalizeColorMap(rawConfig.event_font_colors || {}),
       normalizedEventStyles: this.normalizeEventStyles(rawConfig.event_styles || []),
-      normalizedDayStyles: this.normalizeDayStyles(rawConfig.day_styles || [], resolveLanguage(rawConfig.locale || rawConfig.language || this._hass?.locale?.language || this._hass?.language)),
+      normalizedDayStyles: this.normalizeDayStyles(
+        this.buildDayStyleRules(rawConfig),
+        resolveLanguage(rawConfig.locale || rawConfig.language || this._hass?.locale?.language || this._hass?.language)
+      ),
       normalizedDayBadges: this.normalizeDayBadges(rawConfig.day_badges || []),
       normalizedHeaderColor: this.normalizeSingleColor(rawConfig.header_color),
       normalizedHeaderTextColor: this.normalizeSingleColor(rawConfig.header_text_color),
@@ -1861,26 +1864,14 @@ class SkylightCalendarCard extends HTMLElement {
           normalized.day_of_week = dayOfWeek;
         }
 
-        const normalizedBackground = String(rule.background || '').trim().toLowerCase() === 'auto'
-          ? 'auto'
-          : this.normalizeSingleColor(rule.background);
+        const style = this.normalizeDayStyleBlock(rule.style && typeof rule.style === 'object' ? rule.style : rule);
+        const normalizedBackground = style.background;
         if (normalizedBackground) normalized.background = normalizedBackground;
 
-        const numericOpacity = Number(rule.opacity);
-        if (Number.isFinite(numericOpacity)) {
-          normalized.opacity = Math.max(0, Math.min(1, numericOpacity));
-        }
-
-        const numericBackgroundOpacity = Number(rule.background_opacity);
-        if (Number.isFinite(numericBackgroundOpacity)) {
-          normalized.background_opacity = Math.max(0, Math.min(1, numericBackgroundOpacity));
-        }
-
-        const normalizedBorderColor = this.normalizeSingleColor(rule.border_color);
-        if (normalizedBorderColor) normalized.border_color = normalizedBorderColor;
-
-        const normalizedBorderWidth = this.normalizeStyleBorderWidth(rule.border_width);
-        if (normalizedBorderWidth) normalized.border_width = normalizedBorderWidth;
+        if (style.opacity !== undefined) normalized.opacity = style.opacity;
+        if (style.background_opacity !== undefined) normalized.background_opacity = style.background_opacity;
+        if (style.border_color !== undefined) normalized.border_color = style.border_color;
+        if (style.border_width !== undefined) normalized.border_width = style.border_width;
 
         if (condition === 'has_event') {
           normalized.calendar = String(rule.calendar).trim();
@@ -1899,6 +1890,57 @@ class SkylightCalendarCard extends HTMLElement {
         return normalized;
       })
       .filter(Boolean);
+  }
+
+  buildDayStyleRules(rawConfig = {}) {
+    const rules = Array.isArray(rawConfig.day_styles) ? [...rawConfig.day_styles] : [];
+    const todayStyle = this.buildTodayDayStyleRule(rawConfig);
+    if (todayStyle) rules.push(todayStyle);
+    return rules;
+  }
+
+  buildTodayDayStyleRule(rawConfig = {}) {
+    const hasTodayBackgroundColor = rawConfig.today_background_color !== undefined && rawConfig.today_background_color !== null && rawConfig.today_background_color !== '';
+    const hasTodayStyle = rawConfig.today_style && typeof rawConfig.today_style === 'object' && !Array.isArray(rawConfig.today_style);
+    if (!hasTodayBackgroundColor && !hasTodayStyle) return null;
+
+    const style = {
+      ...(hasTodayBackgroundColor ? { background_color: rawConfig.today_background_color } : {}),
+      ...(hasTodayStyle ? rawConfig.today_style : {})
+    };
+
+    return {
+      condition: 'today',
+      priority: 0,
+      style
+    };
+  }
+
+  normalizeDayStyleBlock(style = {}) {
+    const normalized = {};
+    const backgroundValue = style.background !== undefined ? style.background : (style.background_color !== undefined ? style.background_color : style.color);
+    const normalizedBackground = String(backgroundValue || '').trim().toLowerCase() === 'auto'
+      ? 'auto'
+      : this.normalizeSingleColor(backgroundValue);
+    if (normalizedBackground) normalized.background = normalizedBackground;
+
+    const numericOpacity = Number(style.opacity);
+    if (Number.isFinite(numericOpacity)) {
+      normalized.opacity = Math.max(0, Math.min(1, numericOpacity));
+    }
+
+    const numericBackgroundOpacity = Number(style.background_opacity);
+    if (Number.isFinite(numericBackgroundOpacity)) {
+      normalized.background_opacity = Math.max(0, Math.min(1, numericBackgroundOpacity));
+    }
+
+    const normalizedBorderColor = this.normalizeSingleColor(style.border_color);
+    if (normalizedBorderColor) normalized.border_color = normalizedBorderColor;
+
+    const normalizedBorderWidth = this.normalizeStyleBorderWidth(style.border_width);
+    if (normalizedBorderWidth) normalized.border_width = normalizedBorderWidth;
+
+    return normalized;
   }
 
 

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -2192,6 +2192,104 @@ test('day_styles evaluate today/weekend/has_event rules and auto background', ()
   assert.equal(style.border_width, '2px');
 });
 
+test('day_styles remain empty by default without today convenience options', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+
+  assert.deepEqual(card._config.day_styles, []);
+  assert.equal(card.getDayStyleConfig(new Date(), [], true), null);
+});
+
+test('today_background_color styles only today through day_styles', () => {
+  const card = makeCard({
+    entities: ['calendar.a'],
+    today_background_color: 'red'
+  });
+
+  assert.equal(card._config.day_styles.length, 1);
+  assert.equal(card._config.day_styles[0].condition, 'today');
+  assert.equal(card._config.day_styles[0].background, '#FF0000');
+  assert.equal(card.getDayStyleConfig(new Date(), [], true).background, '#FF0000');
+  assert.equal(card.getDayStyleConfig(new Date('2026-05-01T00:00:00Z'), [], false), null);
+});
+
+test('today_style styles only today using day style fields', () => {
+  const card = makeCard({
+    entities: ['calendar.a'],
+    today_style: {
+      background_color: 'var(--primary-color)',
+      background_opacity: 0.4,
+      opacity: 0.75,
+      border_color: 'blue',
+      border_width: 3
+    }
+  });
+
+  const style = card.getDayStyleConfig(new Date(), [], true);
+  assert.equal(style.background, 'var(--primary-color)');
+  assert.equal(style.background_opacity, 0.4);
+  assert.equal(style.opacity, 0.75);
+  assert.equal(style.border_color, '#0000FF');
+  assert.equal(style.border_width, '3px');
+  assert.equal(card.getDayStyleConfig(new Date('2026-05-01T00:00:00Z'), [], false), null);
+});
+
+test('today_style overrides today_background_color for overlapping fields', () => {
+  const card = makeCard({
+    entities: ['calendar.a'],
+    today_background_color: '#ff0000',
+    today_style: {
+      background_color: '#00ff00',
+      opacity: 0.5
+    }
+  });
+
+  const style = card.getDayStyleConfig(new Date(), [], true);
+  assert.equal(style.background, '#00ff00');
+  assert.equal(style.opacity, 0.5);
+});
+
+test('today convenience styles preserve explicit day_styles behavior', () => {
+  const card = makeCard({
+    entities: ['calendar.a'],
+    today_background_color: '#ff0000',
+    day_styles: [{ condition: 'day_of_week', day_of_week: ['friday'], background: '#123456' }]
+  });
+
+  const friday = new Date('2026-05-01T00:00:00Z');
+  assert.equal(card.getDayStyleConfig(friday, [], false).background, '#123456');
+});
+
+test('today convenience styles use default priority lower than explicit higher priority day_styles', () => {
+  const card = makeCard({
+    entities: ['calendar.a'],
+    today_style: { background_color: '#111111', opacity: 0.25, border_color: '#222222' },
+    day_styles: [
+      { condition: 'today', priority: 1, background: '#333333' },
+      { condition: 'today', priority: 0, opacity: 0.8 }
+    ]
+  });
+
+  const style = card.getDayStyleConfig(new Date(), [], true);
+  assert.equal(style.background, '#333333');
+  assert.equal(style.opacity, 0.8);
+  assert.equal(style.border_color, '#222222');
+});
+
+test('today convenience styles ignore invalid style values safely', () => {
+  const card = makeCard({
+    entities: ['calendar.a'],
+    today_style: {
+      background_color: '',
+      opacity: 'not-a-number',
+      background_opacity: 'invalid',
+      border_width: '-2'
+    }
+  });
+
+  assert.deepEqual(card._config.day_styles, []);
+  assert.equal(card.getDayStyleConfig(new Date(), [], true), null);
+});
+
 
 
 test('day_styles apply priority per field with tie-break by rule order', () => {


### PR DESCRIPTION
### Motivation

- Provide simple top-level config for styling today's date without requiring a full `day_styles` rule. 
- Treat the new options as syntactic sugar that maps to an internal `day_styles` rule with `condition: today` so the existing style pipeline can be reused. 
- Preserve existing `day_styles` behavior, priority semantics, and rendering paths so explicit rules continue to work unchanged.

### Description

- Build an internal day-style rule list via `buildDayStyleRules` (used during normalization) so `today_background_color` / `today_style` are converted into a generated `condition: today` rule and appended to the normalized `day_styles` list. 
- Implement `buildTodayDayStyleRule` that merges `today_background_color` and `today_style` (with `today_style` taking precedence for overlapping fields) and assigns a sensible default `priority: 0`. 
- Add `normalizeDayStyleBlock` to centralize normalization of style fields (`background_color`/`background`, `background_opacity`, `opacity`, `border_color`, `border_width`) and update `normalizeDayStyles` to reuse it so the new today convenience options follow the same validation/normalization rules. 
- Update documentation with brief `README.md` entries and YAML examples demonstrating `today_background_color` and `today_style` usage.

### Testing

- Ran the full unit test suite with `npm test`, and all tests passed (155 tests, 0 failures). 
- Added new unit tests covering: default no-op behavior, `today_background_color` affecting only today, `today_style` supporting the same style fields as `day_styles`, `today_style` overriding `today_background_color`, preservation of explicit `day_styles` rules, priority interaction with explicit `day_styles`, and safe ignoring of invalid style values.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ca8e94b1883318004df7d35c4e3dd)