### PR TITLE
Fix event modal stacking above Home Assistant header

### DIFF
--- a/playwright/visual.spec.js
+++ b/playwright/visual.spec.js
@@ -293,9 +293,10 @@ test('behavior: event modal overlays native header at tablet viewport', async ({
 
   const card = page.locator('skylight-calendar-card');
   await expect(card).toBeVisible();
-  await expect(card.locator('.month-view')).toBeVisible();
+  const coffeeEvent = card.locator('.event').filter({ hasText: 'Coffee' });
+  await expect(coffeeEvent).toBeVisible();
 
-  await card.locator('.event').filter({ hasText: 'Coffee' }).click();
+  await coffeeEvent.click();
   const modal = card.locator('#event-modal');
   await expect(modal).toHaveClass(/show/);
   await expect(card).toHaveClass(/event-modal-open/);

--- a/playwright/visual.spec.js
+++ b/playwright/visual.spec.js
@@ -260,6 +260,65 @@ test.beforeEach(async ({ page }) => {
   }, FIXED_NOW);
 });
 
+
+test('behavior: event modal overlays native header at tablet viewport', async ({ page }) => {
+  await page.setViewportSize({ width: 768, height: 1024 });
+  const fixtureUrl = `file://${path.join(process.cwd(), 'playwright', 'ha-fixture.html')}`;
+  await page.goto(fixtureUrl);
+  await page.addStyleTag({
+    content: `
+      #native-ha-header {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 64px;
+        z-index: 100;
+        background: rgb(37, 99, 235);
+      }
+      body { padding-top: 80px; }
+    `
+  });
+  await page.evaluate(() => {
+    const header = document.createElement('div');
+    header.id = 'native-ha-header';
+    header.textContent = 'Home Assistant';
+    document.body.prepend(header);
+  });
+  await page.evaluate((params) => window.renderCalendarCard(params), {
+    config: { entities: ['calendar.family', 'calendar.work'], title: 'Tablet Modal Calendar', default_view: 'month' },
+    events: baseEvents,
+    darkMode: false
+  });
+
+  const card = page.locator('skylight-calendar-card');
+  await expect(card).toBeVisible();
+  await expect(card.locator('.month-view')).toBeVisible();
+
+  await card.locator('.event').filter({ hasText: 'Coffee' }).click();
+  const modal = card.locator('#event-modal');
+  await expect(modal).toHaveClass(/show/);
+  await expect(card).toHaveClass(/event-modal-open/);
+  await expect(modal).toHaveCSS('position', 'fixed');
+  await expect(modal).toHaveCSS('z-index', '2147483647');
+
+  const modalBox = await modal.boundingBox();
+  expect(modalBox.x).toBe(0);
+  expect(modalBox.y).toBe(0);
+  expect(modalBox.width).toBe(768);
+  expect(modalBox.height).toBe(1024);
+
+  const topElementInfo = await page.evaluate(() => {
+    const el = document.elementFromPoint(384, 32);
+    return {
+      id: el?.id || '',
+      className: typeof el?.className === 'string' ? el.className : '',
+      closestModalId: el?.closest?.('#event-modal')?.id || ''
+    };
+  });
+  expect(topElementInfo.closestModalId || topElementInfo.id).toBe('event-modal');
+});
+
 test('visual: event modal renders rich markdown and HTML descriptions', async ({ page }) => {
   const fixtureUrl = `file://${path.join(process.cwd(), 'playwright', 'ha-fixture.html')}`;
   await page.goto(fixtureUrl);

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3067,6 +3067,7 @@ class SkylightCalendarCard extends HTMLElement {
     }
     this.detachSystemThemeListener();
     this.teardownWeatherForecastSubscription();
+    this.updateEventModalOpenState(null);
     if (this._modalVisibilityObserver) {
       this._modalVisibilityObserver.disconnect();
       this._modalVisibilityObserver = null;
@@ -3634,6 +3635,14 @@ class SkylightCalendarCard extends HTMLElement {
         width: 100%;
         height: 100%;
         min-height: 0;
+      }
+
+      :host(.event-modal-open),
+      daylight-calendar-card.event-modal-open,
+      skylight-calendar-card.event-modal-open {
+        position: relative;
+        z-index: 2147483000;
+        overflow: visible;
       }
 
       .calendar-container {
@@ -5285,17 +5294,25 @@ class SkylightCalendarCard extends HTMLElement {
         top: -3px;
       }
 
+      :host(.event-modal-open) .calendar-container,
+      :host(.event-modal-open) .calendar-body,
+      daylight-calendar-card.event-modal-open .calendar-container,
+      daylight-calendar-card.event-modal-open .calendar-body,
+      skylight-calendar-card.event-modal-open .calendar-container,
+      skylight-calendar-card.event-modal-open .calendar-body {
+        overflow: visible;
+      }
+
       .event-modal {
         display: none;
         position: fixed;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
+        inset: 0;
         background: rgba(0, 0, 0, 0.5);
-        z-index: 1000;
+        z-index: 2147483647;
         align-items: center;
         justify-content: center;
+        box-sizing: border-box;
+        padding: 16px;
       }
 
       .event-modal.show {
@@ -5309,6 +5326,7 @@ class SkylightCalendarCard extends HTMLElement {
         max-width: 500px;
         width: 90%;
         max-height: 80vh;
+        max-height: min(80vh, calc(100dvh - 32px));
         overflow-y: auto;
         box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
       }
@@ -6391,10 +6409,10 @@ class SkylightCalendarCard extends HTMLElement {
         ${this._config.hide_header ? '' : (this._config.compact_header ? this.renderCompactHeader() : this.renderStandardHeader())}
         <div class="calendar-body">
           ${this.renderCalendarView()}
+        </div>
 
-          <div class="event-modal" id="event-modal">
-            <div class="modal-content" id="modal-content">
-            </div>
+        <div class="event-modal" id="event-modal">
+          <div class="modal-content" id="modal-content">
           </div>
         </div>
       </div>
@@ -8841,15 +8859,23 @@ class SkylightCalendarCard extends HTMLElement {
     });
   }
 
+  updateEventModalOpenState(modal = this.getRootElementById('event-modal')) {
+    const isOpen = !!modal && modal.classList.contains('show');
+    this.classList?.toggle('event-modal-open', isOpen);
+  }
+
   observeModalVisibility(modal) {
     if (this._modalVisibilityObserver) {
       this._modalVisibilityObserver.disconnect();
       this._modalVisibilityObserver = null;
     }
 
+    this.updateEventModalOpenState(modal);
+
     if (!modal) return;
 
     this._modalVisibilityObserver = new MutationObserver(() => {
+      this.updateEventModalOpenState(modal);
       if (!this.isEventManagementDialogOpen()) {
         this.flushPendingHeaderTimeRender();
       }

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -644,6 +644,53 @@ test('calendar badge can show linked person location and picture', () => {
   assert.match(html, /src="\/api\/image\/serve\/ian\/original"/);
 });
 
+
+test('event modal overlay CSS uses viewport-fixed coverage and high stacking', () => {
+  const card = makeCard();
+  const styles = card.getStyles();
+
+  assert.match(styles, /\.event-modal\s*\{[\s\S]*position:\s*fixed;/);
+  assert.match(styles, /\.event-modal\s*\{[\s\S]*inset:\s*0;/);
+  assert.match(styles, /\.event-modal\s*\{[\s\S]*z-index:\s*2147483647;/);
+  assert.match(styles, /:host\(\.event-modal-open\)[\s\S]*z-index:\s*2147483000;/);
+  assert.match(styles, /event-modal-open[\s\S]*\.calendar-container[\s\S]*overflow:\s*visible;/);
+  assert.match(styles, /event-modal-open[\s\S]*\.calendar-body[\s\S]*overflow:\s*visible;/);
+});
+
+test('event modal open state toggles a host stacking class', () => {
+  const card = makeCard();
+  const classes = new Set();
+  card.classList = {
+    toggle(name, enabled) {
+      if (enabled) classes.add(name);
+      else classes.delete(name);
+    },
+    contains(name) {
+      return classes.has(name);
+    }
+  };
+
+  const modalClasses = new Set();
+  const modal = {
+    classList: {
+      contains(name) {
+        return modalClasses.has(name);
+      }
+    }
+  };
+
+  card.updateEventModalOpenState(modal);
+  assert.equal(card.classList.contains('event-modal-open'), false);
+
+  modalClasses.add('show');
+  card.updateEventModalOpenState(modal);
+  assert.equal(card.classList.contains('event-modal-open'), true);
+
+  modalClasses.delete('show');
+  card.updateEventModalOpenState(modal);
+  assert.equal(card.classList.contains('event-modal-open'), false);
+});
+
 test('calendar render includes header controls and modal container', () => {
   const card = new Card();
   card._hass = { states: {}, locale: { language: 'en' }, language: 'en', themes: { darkMode: false } };


### PR DESCRIPTION
### Motivation

- The event management modal could be visually trapped under the Home Assistant header on tablet/compact view because it relied on the card's stacking context and lower z-index. 
- The intent is to render the modal as a true viewport overlay so it always sits above the native HA header and remains usable when vertical space is reduced (on-screen keyboard). 

### Description

- Render the modal as a viewport-level overlay by updating `.event-modal` to `position: fixed`, `inset: 0`, and `z-index: 2147483647`, and add `box-sizing`/`padding` and a viewport-aware `max-height` using `calc(100dvh - 32px)`. (changes in `skylight-calendar-card.js`) 
- Add a host state class `event-modal-open` via `updateEventModalOpenState()` and toggle it from `observeModalVisibility()` so the host/card is raised only while the modal is open (`:host(.event-modal-open)` uses `z-index: 2147483000` and `overflow: visible`). (changes in `skylight-calendar-card.js`) 
- Move the modal markup out of the inner `.calendar-body` into a direct child of the card container so ancestors do not clip the fixed overlay, and keep the modal DOM top-level inside the component. (changes in `skylight-calendar-card.js`) 
- Add minimal unit tests asserting the modal CSS uses `position: fixed`, `inset: 0`, the high `z-index`, and that the host toggles `event-modal-open`, and add a Playwright behavior test that simulates a native HA header at tablet viewport to assert the modal covers it. (changes in `skylight-calendar-card.test.js` and `playwright/visual.spec.js`) 

### Testing

- Ran unit test suite with `npm test`, and all tests passed (157 tests, 0 failures). 
- Ran JS syntax/type checks with `node --check skylight-calendar-card.js && node --check skylight-calendar-card.test.js && node --check playwright/visual.spec.js` which completed successfully. 
- Added a Playwright behavior test and attempted to run it with `npx playwright test` but the browser binary was unavailable in the environment; `npx playwright install chromium` failed due to a CDN download `403` (Playwright browser download blocked), so the visual/behavior test could not be executed in CI here. 

Files changed: `skylight-calendar-card.js`, `skylight-calendar-card.test.js`, `playwright/visual.spec.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2328c38b6c8331920950140fa9f7b9)