### PR TITLE
Align documentation with calendar card behavior

### DIFF
--- a/docs/advanced/combine-calendars.mdx
+++ b/docs/advanced/combine-calendars.mdx
@@ -8,14 +8,14 @@ A common problem in multi-calendar setups is that the same event appears more th
 
 ## How Deduplication Works
 
-When `combine_calendars` is `true`, the card compares every event loaded from your calendar entities. Two events are considered duplicates if they share the same **title**, **start time**, and **end time**. When a match is found, the events are merged into one chip, and a small indicator is added to show that the event came from multiple sources.
+When `combine_calendars` is `true`, the card compares every event loaded from your calendar entities. Two events are considered duplicates if they share the same normalized **title**, **start time**, **end time**, and **location**. When a match is found, the events are merged into one chip, and a small indicator is added to show that the event came from multiple sources.
 
 The merged event inherits the color of the first matching source calendar unless overridden by an `event_styles` rule.
 
 ## Configuration
 
 <ParamField path="combine_calendars" default="false" type="boolean">
-  Set to `true` to enable event deduplication. When enabled, events with identical title, start time, and end time are merged into a single display event.
+  Set to `true` to enable event deduplication. When enabled, events with identical title, start time, end time, and location are merged into a single display event.
 </ParamField>
 
 <ParamField path="combine_style" default="bars" type="string">
@@ -70,7 +70,7 @@ combine_style: dots
 ```
 
 <Note>
-  Deduplication requires an **exact match** on title, start time, and end time. If the same real-world event is stored with slightly different times across calendars — for example, due to timezone conversion differences of even one minute — the events will **not** be merged and will appear as separate chips. If you notice duplicates that are not being merged, check whether the event times are truly identical in both calendar sources.
+  Deduplication requires an **exact match** on title, start time, end time, and location. If the same real-world event is stored with slightly different times across calendars — for example, due to timezone conversion differences of even one minute — the events will **not** be merged and will appear as separate chips. If you notice duplicates that are not being merged, check whether the title, event times, and location are truly identical in both calendar sources.
 </Note>
 
 <Tip>

--- a/docs/advanced/event-styles.mdx
+++ b/docs/advanced/event-styles.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Event Styles"
 description: "Use event_styles rules to apply colors, icons, opacity, and hide overrides to Home Assistant calendar events matched by title, calendar, location, or date."
 ---
 
-The `event_styles` configuration lets you define a list of rules that change how individual events look on your calendar. Each rule specifies which events to target through a `match` object and how to style them through a `style` object. When multiple rules match the same event, the rule with the highest `priority` value wins. This makes it easy to build layered styling — for example, dimming all past events while still highlighting specific recurring ones at a higher priority.
+The `event_styles` configuration lets you define a list of rules that change how individual events look on your calendar. Each rule specifies which events to target through a `match` object and how to style them through a `style` object. When multiple rules match the same event, conflicts are resolved per style property: the matching rule with the highest `priority` for that property wins. This makes it easy to build layered styling — for example, dimming all past events while still highlighting specific recurring ones at a higher priority.
 
 ## Rule Structure
 

--- a/docs/advanced/virtual-calendars.mdx
+++ b/docs/advanced/virtual-calendars.mdx
@@ -82,5 +82,5 @@ virtual_calendars:
 With this configuration, the card header shows two toggles — **Family** and **Work** — instead of five separate calendar entity entries. Toggling "Family" off hides events from all three family calendars simultaneously.
 
 <Tip>
-  Pair virtual calendars with `combine_calendars: true` if family members or colleagues share events across their individual calendars. Combined with virtual calendars, duplicate events will be merged and shown once under the shared group color.
+  Pair virtual calendars with `combine_calendars: true` if family members or colleagues share events across their individual calendars. Combined with virtual calendars, duplicate events will be merged and shown once using the primary matching calendar color. If the duplicate sources are inside the same virtual group, that is the virtual calendar color.
 </Tip>

--- a/docs/configuration/appearance.mdx
+++ b/docs/configuration/appearance.mdx
@@ -65,10 +65,18 @@ The Daylight Calendar Card gives you extensive control over its visual presentat
   The transparency of the header background, from `0` (fully opaque) to `100` (fully transparent). Values between these extremes produce a semi-transparent header. Useful when you set a background image and want the image to show through the header.
 </ParamField>
 
+<ParamField path="header_background_transparent" default="false" type="boolean">
+  Legacy shortcut for a fully transparent header. When `header_background_opacity` is not set, `true` is equivalent to `header_background_opacity: 100`.
+</ParamField>
+
 ## Card Background
 
 <ParamField path="background_opacity" default="0" type="number">
   The transparency of the card body background, from `0` (fully opaque) to `100` (fully transparent). Setting this to `100` lets the underlying dashboard wallpaper or HA theme background show through.
+</ParamField>
+
+<ParamField path="background_transparent" default="false" type="boolean">
+  Legacy shortcut for a fully transparent card body. When `background_opacity` is not set, `true` is equivalent to `background_opacity: 100`.
 </ParamField>
 
 <ParamField path="background_image_url" type="string">

--- a/docs/configuration/basic.mdx
+++ b/docs/configuration/basic.mdx
@@ -103,7 +103,6 @@ language: en
 locale: en-GB
 color_scheme: auto
 preference_storage_key: main_dashboard_calendar
-max_events: 50
 calendar_person_entities:
   calendar.family: person.parent
 ```

--- a/docs/configuration/display.mdx
+++ b/docs/configuration/display.mdx
@@ -63,13 +63,27 @@ The calendar list lets users toggle individual calendars on or off from inside t
 </ParamField>
 
 <ParamField path="default_hidden_calendars" type="list">
-  A list of calendar entity IDs that should be hidden when the card loads for the first time. The user can still reveal them using the calendar toggle list. Once the user changes their selection it is saved in browser storage.
+  A list of calendar entity IDs that should be hidden when the card loads for the first time. The user can still reveal them using the calendar toggle list. Once the user changes their selection it is saved in browser storage and overrides this initial default for that browser.
 
   ```yaml
   default_hidden_calendars:
     - calendar.work
     - calendar.holidays_in_united_states
   ```
+</ParamField>
+
+<ParamField path="default_calendar_visibility" type="map">
+  A map of calendar entity IDs to initial visibility states. Use `show`, `shown`, `visible`, `on`, or `true` to force a calendar visible; use `hide`, `hidden`, `off`, or `false` to hide it initially. This is an alternative to `default_hidden_calendars` when you prefer one map of explicit states.
+
+  ```yaml
+  default_calendar_visibility:
+    calendar.family: show
+    calendar.work: hide
+  ```
+</ParamField>
+
+<ParamField path="calendar_visibility" type="map">
+  Legacy alias for `default_calendar_visibility`. Use `default_calendar_visibility` for new configurations.
 </ParamField>
 
 <ParamField path="calendar_names" type="map">
@@ -159,6 +173,10 @@ The calendar list lets users toggle individual calendars on or off from inside t
   - `none` — past events appear exactly like future events
   - `hide` — past events are removed from view entirely
   - `muted` — past events are shown with reduced opacity to de-emphasise them
+</ParamField>
+
+<ParamField path="hide_the_past" default="false" type="boolean">
+  Legacy alias for `past_event_mode: hide`. Use `past_event_mode` for new configurations because it also supports the `muted` option.
 </ParamField>
 
 <ParamField path="disable_swipe_controls" default="false" type="boolean">

--- a/docs/configuration/event-management.mdx
+++ b/docs/configuration/event-management.mdx
@@ -23,7 +23,7 @@ What you can do from inside the card depends on the underlying Home Assistant ca
 </Note>
 
 <Note>
-  **CalDAV is version dependent.** The card can always add new events to a CalDAV calendar, but editing and deleting existing events is dependent on the CalDAV version. Edit and delete functionality will be read by this card and it will show Edit/Delete buttons accordingly.
+  **CalDAV is version dependent.** The card can always add new events to a CalDAV calendar, but editing and deleting existing events is dependent on the CalDAV version. The card reads those capabilities and shows Edit/Delete buttons accordingly.
 </Note>
 
 ## Creating Events

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -18,7 +18,7 @@ The Daylight Calendar Card is a custom Lovelace card for Home Assistant that bri
 
     **Important limitations with Google Calendar:**
 
-    - **Editing events** is not natively supported through the Home Assistant Google Calendar integration. Google Calendar edits are simulated via create-then-delete, which changes the event's UID. To truly an event, use the Google Calendar app or website directly.
+    - **Editing events** is not natively supported through the Home Assistant Google Calendar integration. Google Calendar edits are simulated via create-then-delete, which changes the event's UID. To truly edit an event, use the Google Calendar app or website directly.
     - **Deleting events** does work through Home Assistant and the card.
     - **Creating new events** works if the calendar is writable in HA.
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -145,14 +145,14 @@ The Daylight Calendar Card is designed to work out of the box with any Home Assi
   <Accordion title="Events are duplicated">
     If you see the same event appearing twice (or more), you likely have multiple calendar entities that both contain that event — for example, a personal Google Calendar and a shared family calendar that both include the same entry.
 
-    Enable calendar combining to automatically deduplicate events that share the same UID:
+    Enable calendar combining to automatically deduplicate events that share the same normalized title, start time, end time, and location:
 
     ```yaml
     combine_calendars: true
     ```
 
     <Note>
-      Deduplication relies on event UIDs. If duplicates persist after enabling `combine_calendars`, the events may have different UIDs across calendars, in which case the card treats them as distinct events.
+      Deduplication does not rely on event UIDs. If duplicates persist after enabling `combine_calendars`, compare the event title, start time, end time, and location across calendars. Any difference in those fields makes the card treat the entries as distinct events.
     </Note>
   </Accordion>
 


### PR DESCRIPTION
### Motivation
- Documentation contained a few inaccuracies and missing configuration entries that did not reflect how the card actually behaves (deduplication, legacy aliases, transparency shortcuts, and style priority semantics). 
- The goal is to make the docs a faithful, user-facing reflection of the runtime behavior implemented in `skylight-calendar-card.js` so users can configure the card reliably.

### Description
- Updated combine/deduplication docs to match implementation: `combine_calendars` now documents matching on normalized `title`, `start time`, `end time`, and `location` (not UIDs); files changed: `docs/advanced/combine-calendars.mdx` and `docs/troubleshooting.mdx`.
- Clarified `event_styles` conflict resolution semantics to state priority is resolved per style property and clarified virtual calendar combine-color semantics; file changed: `docs/advanced/event-styles.mdx` and `docs/advanced/virtual-calendars.mdx`.
- Added explicit docs for initial calendar visibility maps and the legacy alias (`default_calendar_visibility` / `calendar_visibility`), documented that persisted browser preferences override `default_hidden_calendars`, and added `hide_the_past` legacy alias; file changed: `docs/configuration/display.mdx`.
- Documented legacy transparency shorthand flags that map to full opacity behavior (`header_background_transparent`, `background_transparent`); file changed: `docs/configuration/appearance.mdx`.
- Removed an inaccurate `max_events` example entry from the basic sample and fixed small wording errors in FAQ and event-management pages; files changed: `docs/configuration/basic.mdx`, `docs/faq.mdx`, `docs/configuration/event-management.mdx`.
- Total docs files modified: `docs/advanced/combine-calendars.mdx`, `docs/advanced/event-styles.mdx`, `docs/advanced/virtual-calendars.mdx`, `docs/configuration/appearance.mdx`, `docs/configuration/basic.mdx`, `docs/configuration/display.mdx`, `docs/configuration/event-management.mdx`, `docs/faq.mdx`, and `docs/troubleshooting.mdx`.

### Testing
- Ran the automated unit/test suite with `npm test`, which completed successfully with all tests passing (`177` tests passed).
- Performed a documentation schema inventory check via a small `python3` script that verifies every normalized schema key is represented in the docs; the check passed (excluded the intentionally-normalized-but-unused `max_events`).
- Attempted `npx mintlify@latest broken-links` to validate docs links but the run failed due to `npm` registry `403 Forbidden` in this environment, so broken-link validation could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a190257d8833197e2ea433bdc6845)