### PR TITLE
Add configurable event modal size

### DIFF
--- a/docs/configuration/event-management.mdx
+++ b/docs/configuration/event-management.mdx
@@ -87,6 +87,14 @@ The **Delete** button only appears for events on calendars that support deletion
   Hide the **Add Event** button from the header. Users can still edit and delete existing events unless you also disable event management or mark calendars as read-only.
 </ParamField>
 
+<ParamField path="event_modal_size" default="medium" type="string">
+  Set the event management modal width. Supported values are `narrow`, `medium`, `wide`, and `full`. Invalid or missing values use `medium`.
+
+  ```yaml
+  event_modal_size: wide
+  ```
+</ParamField>
+
 ## Example
 
 ```yaml
@@ -100,6 +108,7 @@ enable_event_management: true
 readonly_calendars:
   - calendar.holidays_in_united_states
 hide_add_event_button: false
+event_modal_size: wide
 ```
 
 <Tip>

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -5818,6 +5818,14 @@ class SkylightCalendarCard extends HTMLElement {
         max-height: calc(100dvh - 32px);
       }
 
+      .modal-content.modal-size-narrow > .confirm-dialog,
+      .modal-content.modal-size-wide > .confirm-dialog,
+      .modal-content.modal-size-full > .confirm-dialog {
+        box-sizing: border-box;
+        max-width: none;
+        width: 100%;
+      }
+
       @media (max-width: 480px) {
         .modal-content,
         .modal-content.modal-size-narrow,

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1523,6 +1523,7 @@ class SkylightCalendarCard extends HTMLElement {
       { key: 'event_neutral_background', defaultValue: ({ rawConfig }) => this.normalizeSingleColor(rawConfig.event_neutral_background) || '#F8F3E9', normalize: ({ rawConfig }) => this.normalizeSingleColor(rawConfig.event_neutral_background) || '#F8F3E9' },
       { key: 'event_tint_opacity', defaultValue: ({ rawConfig }) => this.normalizeBackgroundOpacity(rawConfig.event_tint_opacity, 80), normalize: ({ rawConfig }) => this.normalizeBackgroundOpacity(rawConfig.event_tint_opacity, 80) },
       { key: 'enable_event_management', defaultValue: ({ rawConfig }) => rawConfig.enable_event_management !== false },
+      { key: 'event_modal_size', defaultValue: ({ rawConfig }) => this.normalizeEventModalSize(rawConfig.event_modal_size), normalize: ({ rawConfig }) => this.normalizeEventModalSize(rawConfig.event_modal_size) },
       { key: 'readonly_calendars', defaultValue: ({ rawConfig }) => rawConfig.readonly_calendars || [] },
       { key: 'hide_badge_calendars', defaultValue: ({ rawConfig }) => rawConfig.hide_badge_calendars || [] },
       { key: 'default_hidden_calendars', defaultValue: ({ derived }) => derived.normalizedDefaultHiddenCalendars, normalize: ({ derived }) => derived.normalizedDefaultHiddenCalendars },
@@ -5793,6 +5794,44 @@ class SkylightCalendarCard extends HTMLElement {
         box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
       }
 
+      .modal-content.modal-size-narrow {
+        box-sizing: border-box;
+        max-width: 380px;
+        width: min(90%, 380px);
+      }
+
+      .modal-content.modal-size-medium {
+        max-width: 500px;
+        width: 90%;
+      }
+
+      .modal-content.modal-size-wide {
+        box-sizing: border-box;
+        max-width: 760px;
+        width: min(94%, 760px);
+      }
+
+      .modal-content.modal-size-full {
+        box-sizing: border-box;
+        max-width: none;
+        width: calc(100vw - 32px);
+        max-height: calc(100dvh - 32px);
+      }
+
+      @media (max-width: 480px) {
+        .modal-content,
+        .modal-content.modal-size-narrow,
+        .modal-content.modal-size-medium,
+        .modal-content.modal-size-wide,
+        .modal-content.modal-size-full {
+          width: calc(100vw - 24px);
+          max-width: calc(100vw - 24px);
+          max-height: calc(100dvh - 24px);
+          padding: 16px;
+          box-sizing: border-box;
+        }
+      }
+
       .modal-header {
         display: flex;
         justify-content: space-between;
@@ -6874,7 +6913,7 @@ class SkylightCalendarCard extends HTMLElement {
         </div>
 
         <div class="event-modal" id="event-modal">
-          <div class="modal-content" id="modal-content">
+          <div class="modal-content ${this.getEventModalSizeClass()}" id="modal-content">
           </div>
         </div>
       </div>
@@ -9717,6 +9756,7 @@ class SkylightCalendarCard extends HTMLElement {
 
     const modal = this.getRootElementById('event-modal');
     const content = this.getRootElementById('modal-content');
+    this.applyEventModalSizeClass(content);
 
     const writableCalendars = this.getWritableCalendars();
     if (writableCalendars.length === 0) {
@@ -10133,6 +10173,7 @@ class SkylightCalendarCard extends HTMLElement {
   showEditEventModal(event, startDate, endDate, isAllDay, editScope = 'this') {
     const modal = this.getRootElementById('event-modal');
     const content = this.getRootElementById('modal-content');
+    this.applyEventModalSizeClass(content);
 
     const writableCalendars = this.getWritableCalendars();
     if (writableCalendars.length === 0) {
@@ -10831,6 +10872,7 @@ class SkylightCalendarCard extends HTMLElement {
   showForwardEventModal(event, startDate, endDate, isAllDay) {
     const modal = this.getRootElementById('event-modal');
     const content = this.getRootElementById('modal-content');
+    this.applyEventModalSizeClass(content);
     const writableCalendars = this.getWritableCalendars();
     const existingCalendarIds = this.getForwardExistingCalendarIds(event);
 
@@ -10905,6 +10947,7 @@ class SkylightCalendarCard extends HTMLElement {
   showEditConfirmation(event, startDate, endDate, isAllDay, selectedEvents = null) {
     const modal = this.getRootElementById('event-modal');
     const content = this.getRootElementById('modal-content');
+    this.applyEventModalSizeClass(content);
 
     const isRecurring = event.rrule || event.recurrence_id;
     if (!isRecurring) {
@@ -10974,6 +11017,7 @@ class SkylightCalendarCard extends HTMLElement {
   showCombinedEditSelectionModal(event, startDate, endDate, isAllDay) {
     const modal = this.getRootElementById('event-modal');
     const content = this.getRootElementById('modal-content');
+    this.applyEventModalSizeClass(content);
 
     const sourceEvents = (event.sourceEvents || []).filter(sourceEvent => !this._hiddenCalendars.has(sourceEvent.entityId));
 
@@ -11027,6 +11071,7 @@ class SkylightCalendarCard extends HTMLElement {
   showCombinedDeleteSelectionModal(event) {
     const modal = this.getRootElementById('event-modal');
     const content = this.getRootElementById('modal-content');
+    this.applyEventModalSizeClass(content);
 
     const sourceEvents = (event.sourceEvents || []).filter(sourceEvent => !this._hiddenCalendars.has(sourceEvent.entityId));
 
@@ -11082,6 +11127,7 @@ class SkylightCalendarCard extends HTMLElement {
   showDeleteConfirmation(event, selectedEvents = null) {
     const modal = this.getRootElementById('event-modal');
     const content = this.getRootElementById('modal-content');
+    this.applyEventModalSizeClass(content);
     const deleteTargets = Array.isArray(selectedEvents) && selectedEvents.length > 0
       ? selectedEvents
       : (Array.isArray(this._combinedDeleteTargets) && this._combinedDeleteTargets.length > 0
@@ -11250,6 +11296,7 @@ class SkylightCalendarCard extends HTMLElement {
   showEventModal(event, onCloseBack = null) {
     const modal = this.getRootElementById('event-modal');
     const content = this.getRootElementById('modal-content');
+    this.applyEventModalSizeClass(content);
 
     let startDate, endDate, isAllDay;
 
@@ -11425,6 +11472,7 @@ class SkylightCalendarCard extends HTMLElement {
   showDayCompactModal(date, events) {
     const modal = this.getRootElementById('event-modal');
     const content = this.getRootElementById('modal-content');
+    this.applyEventModalSizeClass(content);
 
     const sortedEvents = this.sortEventsForDate(events, date);
 
@@ -11480,6 +11528,7 @@ class SkylightCalendarCard extends HTMLElement {
   showDayModal(date, events) {
     const modal = this.getRootElementById('event-modal');
     const content = this.getRootElementById('modal-content');
+    this.applyEventModalSizeClass(content);
 
     const sortedEvents = this.sortEventsForDate(events, date);
 
@@ -12193,6 +12242,22 @@ class SkylightCalendarCard extends HTMLElement {
     return Math.min(100, Math.max(0, numericOpacity));
   }
 
+  normalizeEventModalSize(value) {
+    const normalized = String(value || '').trim().toLowerCase();
+    return ['narrow', 'medium', 'wide', 'full'].includes(normalized) ? normalized : 'medium';
+  }
+
+  getEventModalSizeClass() {
+    return `modal-size-${this.normalizeEventModalSize(this._config?.event_modal_size)}`;
+  }
+
+  applyEventModalSizeClass(content = this.getRootElementById('modal-content')) {
+    if (!content?.classList) return;
+
+    content.classList.remove('modal-size-narrow', 'modal-size-medium', 'modal-size-wide', 'modal-size-full');
+    content.classList.add(this.getEventModalSizeClass());
+  }
+
   static getStubConfig() {
     return {
       title: 'Family Calendar',
@@ -12241,7 +12306,8 @@ class SkylightCalendarCard extends HTMLElement {
       calendar_person_entities: {},
       default_hidden_calendars: [],
       color_scheme: 'auto',
-      enable_event_management: true
+      enable_event_management: true,
+      event_modal_size: 'medium'
     };
   }
 
@@ -12340,7 +12406,8 @@ class SkylightCalendarCardEditor extends HTMLElement {
       default_view: normalizedDefaultView || (SkylightCalendarCard.getStubConfig().default_view || 'month'),
       past_event_mode: normalizedPastEventMode,
       color_scheme: SkylightCalendarCard.prototype.normalizeDefaultDarkMode(config.color_scheme),
-      header_dashboard_path: SkylightCalendarCard.prototype.normalizeDashboardPath(config.header_dashboard_path)
+      header_dashboard_path: SkylightCalendarCard.prototype.normalizeDashboardPath(config.header_dashboard_path),
+      event_modal_size: SkylightCalendarCard.prototype.normalizeEventModalSize(config.event_modal_size)
     };
     this.syncCombineBackgroundEditorState(this._config.combine_background);
 
@@ -13404,6 +13471,17 @@ class SkylightCalendarCardEditor extends HTMLElement {
     const managementSection = this.renderSection('Event management', `
       <div class="boolean-list">
         <label><input type="checkbox" data-field="enable_event_management" ${this._config.enable_event_management !== false ? 'checked' : ''}> Enable event management</label>
+      </div>
+      <div class="field-row">
+        <div class="field field-inline">
+          <label for="event_modal_size">Event modal size</label>
+          <select id="event_modal_size" data-field="event_modal_size">
+            <option value="narrow" ${this._config.event_modal_size === 'narrow' ? 'selected' : ''}>Narrow</option>
+            <option value="medium" ${this._config.event_modal_size === 'medium' || !this._config.event_modal_size ? 'selected' : ''}>Medium</option>
+            <option value="wide" ${this._config.event_modal_size === 'wide' ? 'selected' : ''}>Wide</option>
+            <option value="full" ${this._config.event_modal_size === 'full' ? 'selected' : ''}>Full</option>
+          </select>
+        </div>
       </div>
       ${this.renderSubSection('Read-only calendars', `<div class="list-checkbox-grid">${this.renderCalendarListCheckboxes('readonly_calendars', { label: 'read-only calendars' })}</div>`)}
       ${this.renderSubSection('Hide header badges for calendars', `<div class="list-checkbox-grid">${this.renderCalendarListCheckboxes('hide_badge_calendars', { label: 'hidden header badges calendars' })}</div>`)}

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -147,6 +147,7 @@ const CONFIG_COVERAGE_INVENTORY = {
   event_neutral_background: 'event color modes normalize widths and tint opacity endpoints',
   event_tint_opacity: 'event color modes normalize widths and tint opacity endpoints',
   enable_event_management: 'checkAllCalendarCapabilities marks google, caldav, and local capabilities correctly',
+  event_modal_size: 'event_modal_size defaults and normalizes to supported modal size classes',
   readonly_calendars: 'readonly calendars suppress event management actions',
   hide_badge_calendars: 'calendar badges respect hidden badge calendars',
   default_hidden_calendars: 'default_hidden_calendars initializes hidden calendar badges',
@@ -249,7 +250,7 @@ test('getStubConfig and normalized defaults include key configuration defaults',
     'combine_background', 'hide_calendars', 'hide_header', 'hide_year', 'hide_controls',
     'hide_navigation_buttons', 'hide_add_event_button', 'hide_view_selector',
     'hide_dark_mode_toggle', 'show_dashboard_nav_button', 'header_dashboard_path',
-    'header_weather_sensor', 'calendar_person_entities', 'default_hidden_calendars', 'color_scheme', 'enable_event_management'
+    'header_weather_sensor', 'calendar_person_entities', 'default_hidden_calendars', 'color_scheme', 'enable_event_management', 'event_modal_size'
   ];
   for (const key of requiredStubKeys) assert.ok(key in stub, `${key} should exist in getStubConfig()`);
 
@@ -258,7 +259,40 @@ test('getStubConfig and normalized defaults include key configuration defaults',
     assert.ok(field.key in normalized, `${field.key} should exist after normalizeConfig()`);
   }
   assert.equal(normalized.firstDayOfWeek, 0);
+  assert.equal(normalized.event_modal_size, 'medium');
   assert.equal(Object.prototype.hasOwnProperty.call(normalized, 'use_24hr_schedule'), false);
+});
+
+test('event_modal_size defaults and normalizes to supported modal size classes', () => {
+  assert.equal(Card.getStubConfig().event_modal_size, 'medium');
+
+  const invalid = makeCard({ entities: ['calendar.family'], event_modal_size: 'giant' });
+  assert.equal(invalid._config.event_modal_size, 'medium');
+  assert.equal(invalid.getEventModalSizeClass(), 'modal-size-medium');
+
+  for (const size of ['narrow', 'medium', 'wide', 'full']) {
+    const card = new Card();
+    card._hass = { states: {}, locale: { language: 'en' }, language: 'en', themes: { darkMode: false } };
+    card.setConfig({ entities: ['calendar.family'], event_modal_size: size });
+    originalCardRender.call(card);
+    assert.match(card._root.innerHTML, new RegExp(`class="modal-content modal-size-${size}" id="modal-content"`));
+  }
+});
+
+test('event modal size classes can be applied without changing modal content behavior', () => {
+  const card = makeCard({ entities: ['calendar.family'], event_modal_size: 'wide' });
+  const classes = new Set(['modal-content']);
+  const content = {
+    classList: {
+      add: (...names) => names.forEach((name) => classes.add(name)),
+      remove: (...names) => names.forEach((name) => classes.delete(name))
+    }
+  };
+
+  card.applyEventModalSizeClass(content);
+  assert.equal(classes.has('modal-content'), true);
+  assert.equal(classes.has('modal-size-wide'), true);
+  assert.equal(classes.has('modal-size-medium'), false);
 });
 
 test('setConfig applies visual layout and styling options', () => {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -295,6 +295,13 @@ test('event modal size classes can be applied without changing modal content beh
   assert.equal(classes.has('modal-size-medium'), false);
 });
 
+test('event modal confirm dialogs expand in non-medium modal sizes', () => {
+  const styles = makeCard().getStyles();
+
+  assert.match(styles, /\.modal-content\.modal-size-narrow\s*>\s*\.confirm-dialog,\s*\.modal-content\.modal-size-wide\s*>\s*\.confirm-dialog,\s*\.modal-content\.modal-size-full\s*>\s*\.confirm-dialog\s*\{[\s\S]*max-width:\s*none;[\s\S]*width:\s*100%;/);
+  assert.doesNotMatch(styles, /\.modal-content\.modal-size-medium\s*>\s*\.confirm-dialog/);
+});
+
 test('setConfig applies visual layout and styling options', () => {
   const card = makeCard({
     entities: ['calendar.family'],


### PR DESCRIPTION
### Motivation
- Allow YAML configuration of the event management modal width so users can choose `narrow`, `medium`, `wide`, or `full` while preserving the current default behavior. 
- Ensure invalid or missing values safely normalize to `medium` and the setting is applied consistently across all event modal flows and the editor.

### Description
- Add `event_modal_size: 'medium'` to `SkylightCalendarCard.getStubConfig()` and include a schema entry so it is normalized at runtime. 
- Implement `normalizeEventModalSize(value)`, `getEventModalSizeClass()`, and `applyEventModalSizeClass(content)` to normalize values and attach the appropriate class (`modal-size-narrow|medium|wide|full`) to the modal content. 
- Apply the size class to the shared modal element and call `applyEventModalSizeClass` in all modal flows (create, edit, view, delete confirmation, recurring edit/delete confirmations, and combined selection flows). 
- Add responsive CSS rules for `.modal-size-narrow`, `.modal-size-medium`, `.modal-size-wide`, and `.modal-size-full` that keep `medium` behavior unchanged and avoid horizontal overflow on small screens. 
- Expose the option in the visual editor under “Event management” as a select control and update documentation with an example YAML snippet (`event_modal_size: wide`).

### Testing
- Added unit tests in `skylight-calendar-card.test.js` to assert the `getStubConfig()` default is `medium`, invalid values normalize to `medium`, each valid value produces the expected modal-size class in rendered markup, and `applyEventModalSizeClass` modifies classes without altering modal behavior. 
- Ran the full test suite via `npm test`; all tests passed (`179` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a3aa07ce08331aa1dce56ace234de)