### PR TITLE
Add option to display full localized weekday names

### DIFF
--- a/docs/configuration/display.mdx
+++ b/docs/configuration/display.mdx
@@ -159,6 +159,10 @@ The calendar list lets users toggle individual calendars on or off from inside t
   Display times in a compact format — for example, `10 AM` instead of `10:00 AM`. Applies to Month, Week Compact, Schedule, and Agenda views.
 </ParamField>
 
+<ParamField path="display_full_weekday_names" default="false" type="boolean">
+  Display full weekday names, such as `Monday` and `Tuesday`, instead of abbreviated names like `Mon` and `Tue`. The card formats names using the configured `locale` or `language`, or the locale inherited from Home Assistant when neither is set.
+</ParamField>
+
 <ParamField path="show_event_location" default="false" type="boolean">
   Show the event's location text below the event title. Applies to **Week Compact**, **Schedule**, and **Agenda** views. Also applies to **Month** only when `show_all_details_month` is enabled.
 </ParamField>
@@ -208,6 +212,7 @@ calendar_badge_icons:
 event_font_size: 12
 event_time_font_size: 10
 shorten_event_times: true
+display_full_weekday_names: true
 show_event_location: true
 use_short_location: true
 past_event_mode: muted

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1468,6 +1468,7 @@ class SkylightCalendarCard extends HTMLElement {
       { key: 'past_event_mode', defaultValue: ({ derived }) => derived.normalizedPastEventMode, normalize: ({ derived }) => derived.normalizedPastEventMode },
       { key: 'hide_empty_days', defaultValue: ({ rawConfig }) => rawConfig.hide_empty_days || false },
       { key: 'agenda_compact_events', defaultValue: ({ rawConfig }) => rawConfig.agenda_compact_events ?? false, normalize: ({ rawConfig }) => rawConfig.agenda_compact_events ?? false },
+      { key: 'display_full_weekday_names', defaultValue: ({ rawConfig }) => rawConfig.display_full_weekday_names ?? false },
       { key: 'shorten_event_times', defaultValue: ({ rawConfig }) => rawConfig.shorten_event_times ?? false },
       { key: 'disable_swipe_controls', defaultValue: ({ rawConfig }) => rawConfig.disable_swipe_controls ?? false },
       { key: 'week_start_hour', defaultValue: ({ derived }) => derived.normalizedWeekStartHour },
@@ -3856,15 +3857,35 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getLocale() {
-    const resolved = this._activeLanguage || this.getLanguage();
-    return this._config.locale || TRANSLATIONS[resolved]?.locale || this._hass?.locale?.language || TRANSLATIONS[DEFAULT_LANGUAGE]?.locale || 'en-US';
+    if (this._config.locale) return this._config.locale;
+
+    const configuredLanguage = this._config.language ? resolveLanguage(this._config.language) : null;
+    if (configuredLanguage) return TRANSLATIONS[configuredLanguage]?.locale || this._config.language;
+
+    const hassLocale = this._hass?.locale?.language;
+    if (hassLocale) return hassLocale;
+
+    const hassLanguage = this._hass?.language;
+    if (hassLanguage) {
+      const resolvedHassLanguage = resolveLanguage(hassLanguage);
+      return TRANSLATIONS[resolvedHassLanguage]?.locale || hassLanguage;
+    }
+
+    return globalThis.navigator?.languages?.[0]
+      || globalThis.navigator?.language
+      || TRANSLATIONS[DEFAULT_LANGUAGE]?.locale
+      || 'en-US';
   }
 
   t(key, params = {}) {
     return translate(this.getLanguage(), key, params);
   }
 
-  getWeekdayNames(format = 'short') {
+  getWeekdayNameFormat() {
+    return this._config?.display_full_weekday_names ? 'long' : 'short';
+  }
+
+  getWeekdayNames(format = this.getWeekdayNameFormat()) {
     const formatter = new Intl.DateTimeFormat(this.getLocale(), { weekday: format });
     const baseDate = new Date(2021, 5, 6);
     const names = [];
@@ -7200,7 +7221,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   renderDayHeaders() {
-    const days = this.getWeekdayNames('short');
+    const days = this.getWeekdayNames();
     const firstDay = this._config.firstDayOfWeek;
     const orderedDays = [...days.slice(firstDay), ...days.slice(0, firstDay)];
     const shouldShowWeekNumbers = this.shouldShowMonthWeekNumbers();
@@ -7220,7 +7241,7 @@ class SkylightCalendarCard extends HTMLElement {
     const weekDays = this.getWeekDays();
     const today = new Date();
     today.setHours(0, 0, 0, 0);
-    const dayNames = this.getWeekdayNames('short');
+    const dayNames = this.getWeekdayNames();
     const containerStyle = this.getCompactContainerStyle();
 
     return `
@@ -7272,7 +7293,7 @@ class SkylightCalendarCard extends HTMLElement {
     const baseHourHeight = 120;
     const preferredHourHeight = baseHourHeight * (this._config.height_scale || 1.0);
 
-    const dayNames = this.getWeekdayNames('short');
+    const dayNames = this.getWeekdayNames();
 
     const allDayLayout = this.buildAllDayLayoutForSchedule(weekDays);
     const maxAllDayEvents = allDayLayout.maxLanes;
@@ -7354,7 +7375,7 @@ class SkylightCalendarCard extends HTMLElement {
     const containerStyle = this.getCompactContainerStyle(compactMaxHeight);
     const today = new Date();
     today.setHours(0, 0, 0, 0);
-    const dayNames = this.getWeekdayNames('short');
+    const dayNames = this.getWeekdayNames();
     const monthFormatter = new Intl.DateTimeFormat(this.getLocale(), { month: 'long', year: 'numeric' });
     const agendaRows = [];
     const shouldHideEmptyDays = this._viewMode === 'agenda' && !!this._config.hide_empty_days;
@@ -11493,7 +11514,7 @@ class SkylightCalendarCard extends HTMLElement {
         <div class="week-compact-container single-day-modal">
           <div class="week-day-column">
             <div class="week-day-header">
-              <div class="week-day-name">${this.getWeekdayNames('short')[date.getDay()]}</div>
+              <div class="week-day-name">${this.getWeekdayNames()[date.getDay()]}</div>
               <div class="week-day-date">${date.getDate()}</div>
             </div>
             ${sortedEvents.length > 0 ? sortedEvents.map(event => {
@@ -12284,6 +12305,7 @@ class SkylightCalendarCard extends HTMLElement {
       hide_empty_days: false,
       agenda_compact_events: false,
       shorten_event_times: false,
+      display_full_weekday_names: false,
       compact_width: false,
       show_current_time_bar: false,
       show_event_location: false,
@@ -13434,6 +13456,7 @@ class SkylightCalendarCardEditor extends HTMLElement {
         <label><input type="checkbox" data-field="show_current_time_bar" ${this._config.show_current_time_bar ? 'checked' : ''}> Show current time bar</label>
         <label><input type="checkbox" data-field="use_24hr_schedule" ${this._config.use_24hr_schedule ? 'checked' : ''}> Use 24-hour schedule time</label>
         <label><input type="checkbox" data-field="shorten_event_times" ${this._config.shorten_event_times ? 'checked' : ''}> Shorten event times</label>
+        <label><input type="checkbox" data-field="display_full_weekday_names" ${this._config.display_full_weekday_names ? 'checked' : ''}> Display full weekday names</label>
         <label><input type="checkbox" data-field="show_event_location" ${this._config.show_event_location ? 'checked' : ''}> Show event location</label>
         <label><input type="checkbox" data-field="use_short_location" ${this._config.use_short_location ? 'checked' : ''}> Shorten event location in views</label>
         <label><input type="checkbox" data-field="combine_calendars" ${this._config.combine_calendars ? 'checked' : ''}> Combine duplicate events across calendars</label>

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -92,6 +92,7 @@ const CONFIG_COVERAGE_INVENTORY = {
   past_event_mode: 'past_event_mode muted leaves ended events visible and applies muted style',
   hide_empty_days: 'agenda hide_empty_days removes empty day rows',
   agenda_compact_events: 'agenda compact events use compact class and sizing',
+  display_full_weekday_names: 'display_full_weekday_names renders localized long weekday labels',
   shorten_event_times: 'shorten_event_times removes minutes from whole-hour 12-hour event times',
   disable_swipe_controls: 'disable_swipe_controls disables swipe controls without affecting agenda',
   week_start_hour: 'lock_schedule_hours keeps configured schedule hours from expanding to events',
@@ -243,7 +244,7 @@ test('getStubConfig and normalized defaults include key configuration defaults',
   const requiredStubKeys = [
     'default_view', 'first_day_of_week', 'week_days', 'week_start_hour', 'week_end_hour',
     'lock_schedule_hours', 'disable_swipe_controls', 'show_all_events_month', 'show_all_details_month',
-    'hide_empty_days', 'agenda_compact_events', 'shorten_event_times', 'compact_width',
+    'hide_empty_days', 'agenda_compact_events', 'shorten_event_times', 'display_full_weekday_names', 'compact_width',
     'show_current_time_bar', 'show_event_location', 'use_short_location',
     'event_calendar_friendly_name', 'event_title_prefix', 'past_event_mode', 'event_color_mode',
     'event_neutral_background', 'event_tint_opacity', 'event_color_bar_width', 'combine_style',
@@ -330,6 +331,7 @@ test('setConfig applies visual layout and styling options', () => {
     event_title_prefix: 'icon',
     show_current_time_bar: true,
     shorten_event_times: true,
+    display_full_weekday_names: true,
     header_color: '#123456',
     header_text_color: '#ffffff',
     header_background_opacity: 55,
@@ -383,6 +385,7 @@ test('setConfig applies visual layout and styling options', () => {
   assert.equal(card._config.event_title_prefix, 'badge_icon');
   assert.equal(card._config.show_current_time_bar, true);
   assert.equal(card._config.shorten_event_times, true);
+  assert.equal(card._config.display_full_weekday_names, true);
   assert.equal(card._config.header_color, '#123456');
   assert.equal(card._config.header_text_color, '#ffffff');
   assert.equal(card._config.header_background_opacity, 55);
@@ -639,6 +642,27 @@ test('first_day_of_week normalizes to firstDayOfWeek and controls headers and we
   const headers = card.renderDayHeaders();
   assert.ok(headers.indexOf('Mon') < headers.indexOf('Tue'));
   assert.ok(headers.indexOf('Sun') > headers.indexOf('Sat'));
+});
+
+test('display_full_weekday_names renders localized long weekday labels', () => {
+  const card = makeCard({
+    entities: ['calendar.family'],
+    display_full_weekday_names: true,
+    locale: 'fr-FR'
+  });
+
+  assert.equal(card.getWeekdayNameFormat(), 'long');
+  assert.deepEqual(card.getWeekdayNames().slice(0, 3), ['dimanche', 'lundi', 'mardi']);
+  assert.match(card.renderDayHeaders(), /<div class="day-header">lundi<\/div>/);
+  assert.doesNotMatch(card.renderDayHeaders(), /<div class="day-header">lun\.<\/div>/);
+});
+
+test('weekday names inherit the Home Assistant locale when card locale is not configured', () => {
+  const card = makeCard({ entities: ['calendar.family'], display_full_weekday_names: true });
+  card._hass = { states: {}, locale: { language: 'en-GB' }, language: 'en', themes: { darkMode: false } };
+
+  assert.equal(card.getLocale(), 'en-GB');
+  assert.equal(card.getWeekdayNames()[0], 'Sunday');
 });
 
 test('week_days filters configured week rendering days', () => {


### PR DESCRIPTION
### Motivation
- Provide a user-configurable option to show full weekday names (e.g., `Monday`, `Tuesday`) instead of abbreviated names (`Mon`, `Tue`) so the card can display more readable labels when desired. 
- Ensure weekday labels respect configured `locale`/`language` or inherit Home Assistant/browser locale for correct localized names.

### Description
- Added a new normalized configuration key `display_full_weekday_names` with default `false` and included it in the stub defaults, editor UI, and example YAML. 
- Introduced `getWeekdayNameFormat()` and changed `getWeekdayNames()` to accept a selectable format (`'short'` or `'long'`) and applied it across Month headers, Week Compact, Week Standard, Schedule, Agenda, and the single-day modal renderers. 
- Improved `getLocale()` resolution to prefer `config.locale`, then `config.language`, then Home Assistant `locale.language`, then Home Assistant `language`, then browser `navigator` fallbacks to ensure weekday formatting uses the correct locale. 
- Updated docs (`docs/configuration/display.mdx`) and unit tests (`skylight-calendar-card.test.js`) to cover the new option and locale inheritance behavior.

### Testing
- Ran `npm test`; all unit tests passed (`182` tests, `0` failures). 
- Attempted the Playwright visual snapshot run and browser install with `npx playwright test` / `npx playwright install chromium`, but the visual test run was blocked because the Playwright browser binary could not be downloaded (CDN returned HTTP 403). 
- Changes are committed and include modifications to `skylight-calendar-card.js`, `skylight-calendar-card.test.js`, and `docs/configuration/display.mdx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b6fd5f6208331a838adeeaaf8de68)