### PR TITLE
Add dynamic day_badge display values from matched event metadata

### DIFF
--- a/docs/advanced/day-badges.mdx
+++ b/docs/advanced/day-badges.mdx
@@ -198,6 +198,7 @@ Dynamic badge values are intentionally narrow in scope:
 - Invalid JSON descriptions are ignored.
 - Missing fields are ignored safely.
 - Values that resolve to objects or arrays are ignored for display fields.
+- Dynamic `background_color` and `color` values must resolve to supported CSS color formats, such as hex, `rgb()`/`rgba()`, `hsl()`/`hsla()`, or a recognized named color. Invalid color values are ignored.
 - Dynamic resolution currently applies only to `day_badges` display fields, not matching, priority, hidden calendar rules, or actions.
 
 ### Mark all-day event days with an indicator

--- a/docs/advanced/day-badges.mdx
+++ b/docs/advanced/day-badges.mdx
@@ -160,6 +160,46 @@ day_badges:
     background_color: '#EDE7F6'
 ```
 
+
+### Use values from matched event metadata
+
+Badge display fields can reference simple values from the event that matched the badge conditions. This is useful when a helper calendar stores day classification metadata in the event description.
+
+Only full-value path templates are supported. The whole string must be a template like `{{ event.description_json.badge_text }}`. Partial strings such as `Type: {{ event.description_json.badge_text }}` are not interpolated and remain literal text.
+
+```yaml
+day_badges:
+  - conditions:
+      calendar: calendar.helper_day_types
+      all_day: true
+    icon: "{{ event.description_json.icon }}"
+    text: "{{ event.description_json.badge_text }}"
+    background_color: "{{ event.description_json.badge_color }}"
+```
+
+The matched helper event description can contain a JSON object like this:
+
+```json
+{
+  "icon": "mdi:school",
+  "badge_text": "School",
+  "badge_color": "#EDE7F6"
+}
+```
+
+This renders one badge with the `mdi:school` icon, the `School` label, and the `#EDE7F6` background color.
+
+Supported dynamic display fields are `icon`, `text`, `background_color`, and `color`. Available paths include `event.description_json.<field>`, `event.title`, `event.summary`, `event.calendar`, `event.entity_id`, `title`, `calendar`, and `date`.
+
+Dynamic badge values are intentionally narrow in scope:
+
+- This is not a general-purpose template engine.
+- JavaScript, expressions, function calls, conditionals, filters, arithmetic, bracket access, and mixed string interpolation are not supported.
+- Invalid JSON descriptions are ignored.
+- Missing fields are ignored safely.
+- Values that resolve to objects or arrays are ignored for display fields.
+- Dynamic resolution currently applies only to `day_badges` display fields, not matching, priority, hidden calendar rules, or actions.
+
 ### Mark all-day event days with an indicator
 
 This badge shows a calendar icon on every day that has at least one all-day event.

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -2338,9 +2338,9 @@ class SkylightCalendarCard extends HTMLElement {
     if (normalizedText) normalized.text = normalizedText;
     if (normalizedIcon) normalized.icon = normalizedIcon;
 
-    const backgroundColor = this.normalizeSingleColor(rule.background_color);
+    const backgroundColor = this.normalizeDayBadgeDisplayColor(rule.background_color);
     if (backgroundColor) normalized.background_color = backgroundColor;
-    const color = this.normalizeSingleColor(rule.color);
+    const color = this.normalizeDayBadgeDisplayColor(rule.color);
     if (color) normalized.color = color;
 
     const size = this.normalizeStyleSizeValue(rule.size);
@@ -2349,6 +2349,87 @@ class SkylightCalendarCard extends HTMLElement {
     const fontSize = this.normalizeStyleSizeValue(rule.font_size);
     if (fontSize) normalized.font_size = fontSize;
     return normalized;
+  }
+
+  isFullValueTemplate(value) {
+    return typeof value === 'string' && /^\s*\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}\s*$/.test(value);
+  }
+
+  normalizeDayBadgeDisplayColor(value) {
+    if (this.isFullValueTemplate(value)) return String(value).trim();
+    return this.normalizeSingleColor(value);
+  }
+
+  parseEventDescriptionJson(event) {
+    const raw = String(event?.description || '').trim();
+    if (!raw.startsWith('{') || !raw.endsWith('}')) return undefined;
+
+    try {
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
+      return parsed;
+    } catch {
+      return undefined;
+    }
+  }
+
+  buildDayBadgeResolutionContext(date, matchedEvent) {
+    const event = matchedEvent && typeof matchedEvent === 'object' ? matchedEvent : {};
+    const calendar = event.entityId || event.entity_id || event.calendar;
+    const title = event.summary || event.title;
+    return {
+      date: date instanceof Date && !Number.isNaN(date.getTime()) ? this.formatLocalDate(date) : date,
+      calendar,
+      title,
+      event: {
+        ...event,
+        calendar,
+        entity_id: event.entity_id || event.entityId,
+        title,
+        summary: event.summary || event.title,
+        description_json: this.parseEventDescriptionJson(event)
+      }
+    };
+  }
+
+  resolveSafePath(path, context) {
+    if (typeof path !== 'string' || !path) return undefined;
+    const blockedSegments = new Set(['__proto__', 'prototype', 'constructor']);
+    const segments = path.split('.');
+    if (!segments.length) return undefined;
+
+    let current = context;
+    for (const segment of segments) {
+      if (!/^[A-Za-z0-9_-]+$/.test(segment) || blockedSegments.has(segment)) return undefined;
+      if (current === null || current === undefined || (typeof current !== 'object' && typeof current !== 'function')) return undefined;
+      if (!Object.prototype.hasOwnProperty.call(current, segment)) return undefined;
+      current = current[segment];
+    }
+
+    if (current === null || current === undefined) return undefined;
+    if (['string', 'number', 'boolean'].includes(typeof current)) return String(current);
+    return undefined;
+  }
+
+  resolveDayBadgeDisplayValue(value, context) {
+    if (typeof value !== 'string') return value;
+    const match = value.match(/^\s*\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}\s*$/);
+    if (!match) return value;
+    return this.resolveSafePath(match[1], context);
+  }
+
+  resolveDayBadgeForRender(rule, date, matchedEvent) {
+    const context = this.buildDayBadgeResolutionContext(date, matchedEvent);
+    const resolved = { ...rule };
+    ['icon', 'text', 'background_color', 'color'].forEach((field) => {
+      const value = this.resolveDayBadgeDisplayValue(rule[field], context);
+      if (value === undefined || value === null || String(value).trim() === '') {
+        delete resolved[field];
+      } else {
+        resolved[field] = String(value).trim();
+      }
+    });
+    return resolved;
   }
 
   normalizeDayBadgeConditions(rawConditions) {
@@ -8498,7 +8579,15 @@ class SkylightCalendarCard extends HTMLElement {
     const rules = Array.isArray(this._config?.day_badges) ? this._config.day_badges : [];
     if (!rules.length || !Array.isArray(dayEvents)) return [];
 
-    return rules.filter((rule) => this.matchesAdvancedRule(rule, { date, dayEvents }).matches);
+    return rules
+      .map((rule) => {
+        const matchResult = this.matchesAdvancedRule(rule, { date, dayEvents });
+        if (!matchResult.matches) return null;
+        const resolvedRule = this.resolveDayBadgeForRender(rule, date, matchResult.matchedEvent);
+        if (!resolvedRule.icon && !resolvedRule.text) return null;
+        return resolvedRule;
+      })
+      .filter(Boolean);
   }
 
   renderDayBadges(date, dayEvents) {

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -2360,6 +2360,19 @@ class SkylightCalendarCard extends HTMLElement {
     return this.normalizeSingleColor(value);
   }
 
+  normalizeResolvedDayBadgeDisplayColor(value) {
+    const normalized = this.normalizeSingleColor(value);
+    if (typeof normalized !== 'string') return undefined;
+    const trimmed = normalized.trim();
+    if (!trimmed) return undefined;
+
+    if (/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(trimmed)) return trimmed;
+    if (/^rgba?\(\s*[+-]?(?:\d+|\d*\.\d+)%?\s*(?:,|\s)\s*[+-]?(?:\d+|\d*\.\d+)%?\s*(?:,|\s)\s*[+-]?(?:\d+|\d*\.\d+)%?(?:\s*(?:,|\/)\s*(?:[01](?:\.\d+)?|\.\d+|\d+%))?\s*\)$/i.test(trimmed)) return trimmed;
+    if (/^hsla?\(\s*[+-]?(?:\d+|\d*\.\d+)(?:deg|grad|rad|turn)?\s*(?:,|\s)\s*[+-]?(?:\d+|\d*\.\d+)%\s*(?:,|\s)\s*[+-]?(?:\d+|\d*\.\d+)%(?:\s*(?:,|\/)\s*(?:[01](?:\.\d+)?|\.\d+|\d+%))?\s*\)$/i.test(trimmed)) return trimmed;
+
+    return undefined;
+  }
+
   parseEventDescriptionJson(event) {
     const raw = String(event?.description || '').trim();
     if (!raw.startsWith('{') || !raw.endsWith('}')) return undefined;
@@ -2425,9 +2438,20 @@ class SkylightCalendarCard extends HTMLElement {
       const value = this.resolveDayBadgeDisplayValue(rule[field], context);
       if (value === undefined || value === null || String(value).trim() === '') {
         delete resolved[field];
-      } else {
-        resolved[field] = String(value).trim();
+        return;
       }
+
+      if (field === 'background_color' || field === 'color') {
+        const normalizedColor = this.normalizeResolvedDayBadgeDisplayColor(value);
+        if (normalizedColor) {
+          resolved[field] = normalizedColor;
+        } else {
+          delete resolved[field];
+        }
+        return;
+      }
+
+      resolved[field] = String(value).trim();
     });
     return resolved;
   }

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -2055,6 +2055,80 @@ test('day_badges supports legacy-style condition aliases', () => {
   assert.match(html, /day-badge-text">L</);
 });
 
+
+test('day_badges parses JSON object descriptions safely', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  assert.deepEqual(card.parseEventDescriptionJson({ description: ' { "icon": "mdi:school" } ' }), { icon: 'mdi:school' });
+  assert.equal(card.parseEventDescriptionJson({ description: '{ nope' }), undefined);
+  assert.equal(card.parseEventDescriptionJson({ description: 'regular notes' }), undefined);
+  assert.equal(card.parseEventDescriptionJson({ description: '["mdi:school"]' }), undefined);
+  assert.equal(card.parseEventDescriptionJson({ description: '' }), undefined);
+});
+
+test('day_badges resolves display templates from matched event description JSON', () => {
+  const card = makeCard({ entities: ['calendar.helper_day_types'], day_badges: [{
+    conditions: { calendar: 'calendar.helper_day_types', all_day: true },
+    icon: '{{ event.description_json.icon }}',
+    text: '{{ event.description_json.badge_text }}',
+    background_color: '{{ event.description_json.badge_color }}'
+  }] });
+  const events = [{ entityId: 'calendar.helper_day_types', summary: 'Schoolday', description: '{"icon":"mdi:school","badge_text":"School","badge_color":"#EDE7F6"}', start: { date: '2026-05-01' }, end: { date: '2026-05-02' } }];
+  const html = card.renderDayBadges(new Date('2026-05-01T00:00:00Z'), events);
+  assert.match(html, /class="day-badge has-icon has-text"/);
+  assert.match(html, /ha-icon icon="mdi:school"/);
+  assert.match(html, /day-badge-text">School</);
+  assert.match(html, /--dcc-day-badge-background: #EDE7F6;/);
+});
+
+test('day_badges accepts compact template whitespace and non-template literals remain literal', () => {
+  const card = makeCard({ entities: ['calendar.a'], day_badges: [
+    { conditions: { title: 'schoolday' }, text: '{{event.description_json.badge_text}}' },
+    { conditions: { title: 'schoolday' }, text: 'School: {{ event.description_json.badge_text }}' }
+  ] });
+  const events = [{ entityId: 'calendar.a', summary: 'Schoolday', description: '{"badge_text":"School"}', start: { date: '2026-05-01' }, end: { date: '2026-05-02' } }];
+  const html = card.renderDayBadges(new Date('2026-05-01T00:00:00Z'), events);
+  assert.match(html, /day-badge-text">School</);
+  assert.match(html, /day-badge-text">School: \{\{ event.description_json.badge_text \}\}</);
+});
+
+test('day_badges omits unresolved unsafe and non-scalar dynamic display fields', () => {
+  const card = makeCard({ entities: ['calendar.a'], day_badges: [
+    { conditions: { title: 'schoolday' }, icon: '{{ event.description_json.missing }}', text: '{{ event.description_json.items }}' },
+    { conditions: { title: 'schoolday' }, icon: '{{ event.description_json.nested }}', text: '{{ event.__proto__.polluted }}' },
+    { conditions: { title: 'schoolday' }, text: '{{ event.description_json.ok }}' }
+  ] });
+  const events = [{ entityId: 'calendar.a', summary: 'Schoolday', description: '{"items":["A"],"nested":{"icon":"mdi:x"},"ok":true}', start: { date: '2026-05-01' }, end: { date: '2026-05-02' } }];
+  const html = card.renderDayBadges(new Date('2026-05-01T00:00:00Z'), events);
+  assert.equal((html.match(/<span class="day-badge(?:\s|")/g) || []).length, 1);
+  assert.match(html, /day-badge-text">true</);
+  assert.doesNotMatch(html, /polluted|mdi:x/);
+});
+
+test('day_badges renders dynamic icon-only text-only and no empty unresolved badges', () => {
+  const card = makeCard({ entities: ['calendar.a'], day_badges: [
+    { conditions: { title: 'schoolday' }, icon: '{{ event.description_json.icon }}' },
+    { conditions: { title: 'schoolday' }, text: '{{ event.description_json.badge_text }}' },
+    { conditions: { title: 'schoolday' }, icon: '{{ event.description_json.missing_icon }}', text: '{{ event.description_json.missing_text }}' }
+  ] });
+  const events = [{ entityId: 'calendar.a', summary: 'Schoolday', description: '{"icon":"mdi:school","badge_text":"School"}', start: { date: '2026-05-01' }, end: { date: '2026-05-02' } }];
+  const html = card.renderDayBadges(new Date('2026-05-01T00:00:00Z'), events);
+  assert.equal((html.match(/<span class="day-badge(?:\s|")/g) || []).length, 2);
+  assert.match(html, /class="day-badge has-icon"/);
+  assert.match(html, /class="day-badge has-text"/);
+});
+
+test('day_badges hidden helper calendar events provide dynamic badge values', () => {
+  const card = makeCard({ entities: ['calendar.visible', 'calendar.helper'], event_styles: [{ match: { calendar: 'calendar.helper' }, style: 'hide' }], day_badges: [{ conditions: { calendar: 'calendar.helper' }, icon: '{{ event.description_json.icon }}', text: '{{ event.description_json.badge_text }}' }] });
+  const day = new Date('2026-05-01T00:00:00Z');
+  card._events = [{ entityId: 'calendar.helper', summary: 'Helper', description: '{"icon":"mdi:school","badge_text":"School"}', start: { date: '2026-05-01' }, end: { date: '2026-05-02' } }];
+  const matchingEvents = card.getEventsForDay(day, { includeHiddenStyledEvents: true });
+  const visibleEvents = matchingEvents.filter((event) => !card.isEventHiddenByStyle(event));
+  const html = card.renderDayBadges(day, matchingEvents);
+  assert.equal(visibleEvents.length, 0);
+  assert.match(html, /ha-icon icon="mdi:school"/);
+  assert.match(html, /day-badge-text">School</);
+});
+
 test('day_badges supports configurable size and font_size', () => {
   const card = makeCard({ entities: ['calendar.a'], day_badges: [{ conditions: { title: 'ballet' }, text: 'PL', size: 32, font_size: '14px' }] });
   const events = [{ entityId: 'calendar.a', summary: 'Ballet Practice', start: { dateTime: '2026-05-01T10:00:00Z' }, end: { dateTime: '2026-05-01T11:00:00Z' } }];

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -2080,6 +2080,31 @@ test('day_badges resolves display templates from matched event description JSON'
   assert.match(html, /--dcc-day-badge-background: #EDE7F6;/);
 });
 
+
+test('day_badges validates dynamic color templates before rendering styles', () => {
+  const card = makeCard({ entities: ['calendar.a'], day_badges: [
+    {
+      conditions: { title: 'schoolday' },
+      text: '{{ event.description_json.badge_text }}',
+      background_color: '{{ event.description_json.badge_color }}',
+      color: '{{ event.description_json.text_color }}'
+    },
+    {
+      conditions: { title: 'schoolday' },
+      text: 'Safe',
+      background_color: '{{ event.description_json.safe_color }}',
+      color: '{{ event.description_json.safe_text_color }}'
+    }
+  ] });
+  const events = [{ entityId: 'calendar.a', summary: 'Schoolday', description: JSON.stringify({ badge_text: 'Bad', badge_color: 'red" onclick="alert(1)', text_color: '#fff; color:red', safe_color: 'rgb(10, 20, 30)', safe_text_color: 'blue' }), start: { date: '2026-05-01' }, end: { date: '2026-05-02' } }];
+  const html = card.renderDayBadges(new Date('2026-05-01T00:00:00Z'), events);
+  assert.match(html, /day-badge-text">Bad</);
+  assert.match(html, /day-badge-text">Safe</);
+  assert.match(html, /--dcc-day-badge-background: rgb\(10, 20, 30\);/);
+  assert.match(html, /--dcc-day-badge-color: #0000FF;/);
+  assert.doesNotMatch(html, /onclick|alert|#fff; color:red/);
+});
+
 test('day_badges accepts compact template whitespace and non-template literals remain literal', () => {
   const card = makeCard({ entities: ['calendar.a'], day_badges: [
     { conditions: { title: 'schoolday' }, text: '{{event.description_json.badge_text}}' },


### PR DESCRIPTION
### Motivation

- Allow `day_badges` display fields to be resolved from the event that matched the badge, enabling helper calendars to drive badge `icon`, `text`, and colors via JSON stored in an event `description`.
- Keep the feature narrowly scoped and safe by supporting only full-value path templates and excluding expressions, bracket access, or JS evaluation.
- Preserve existing static behavior so literal `icon`/`text`/color configs continue to work unchanged.

### Description

- Added `parseEventDescriptionJson(event)` to safely parse plain-object JSON from `event.description` and return `event.description_json` when valid.
- Added a small resolution pipeline: `buildDayBadgeResolutionContext(date, matchedEvent)`, `resolveSafePath(path, context)`, `resolveDayBadgeDisplayValue(value, context)`, and `resolveDayBadgeForRender(rule, date, matchedEvent)` to resolve full-value templates like `{{ event.description_json.icon }}` for display fields.
- Restricted dynamic resolution to full-value templates only (regex `/^\s*\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}\s*$/`) and rejected unsafe/prototype segments and non-scalar values per spec.
- Applied resolution for badge display fields `icon`, `text`, `background_color`, and `color`, and updated `getDayBadges` to resolve matched rules and omit badges that resolve to neither `icon` nor `text`.
- Kept normalization/validation for other fields and preserved existing static behavior by introducing `normalizeDayBadgeDisplayColor` to allow color templates while still normalizing literals.
- Added unit tests in `skylight-calendar-card.test.js` covering JSON parsing, template resolution, whitespace tolerance, unsafe/unresolved values, object/array rejection, icon/text combinations, and hidden helper-calendar support, and updated documentation in `docs/advanced/day-badges.mdx` with usage and limitations.

### Testing

- Ran the full test suite with `npm test`, which completed with all tests passing (`# pass 191 # fail 0`).
- Ran focused tests with `node --test --test-name-pattern='day_badges' skylight-calendar-card.test.js`, and the `day_badges` test cases passed (new tests included).
- Verified that static badge behavior remains unchanged by existing unit tests which continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ce56b69e483318410657f8ecf07ca)