### PR TITLE
Fix wrapped header color fallback

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -4396,6 +4396,10 @@ class SkylightCalendarCard extends HTMLElement {
         padding-right: 12px;
       }
 
+      .header.is-wrapped,
+      .header-compact.is-wrapped {
+        background: var(--header-wrapped-background, transparent);
+      }
 
       .header.is-wrapped .header-left,
       .header.is-wrapped .header-controls {
@@ -7018,7 +7022,10 @@ class SkylightCalendarCard extends HTMLElement {
     const headerControlActiveBackground = this.colorWithAlpha(resolvedHeaderTextColor, 0.32);
     const headerControlBorder = this.colorWithAlpha(resolvedHeaderTextColor, 0.4);
     const headerControlBorderHover = this.colorWithAlpha(resolvedHeaderTextColor, 0.6);
-    const headerStyle = `--header-background-base: ${resolvedHeaderBackgroundBase}; --header-background-alpha: ${headerAlpha}; --header-text-color: ${resolvedHeaderTextColor}; --header-control-bg: ${headerControlBackground}; --header-control-bg-hover: ${headerControlHoverBackground}; --header-control-bg-active: ${headerControlActiveBackground}; --header-control-border: ${headerControlBorder}; --header-control-border-hover: ${headerControlBorderHover};`;
+    const wrappedHeaderBackground = normalizedHeaderBackgroundOpacity <= 0
+      ? resolvedHeaderBackgroundBase
+      : 'transparent';
+    const headerStyle = `--header-background-base: ${resolvedHeaderBackgroundBase}; --header-background-alpha: ${headerAlpha}; --header-wrapped-background: ${wrappedHeaderBackground}; --header-text-color: ${resolvedHeaderTextColor}; --header-control-bg: ${headerControlBackground}; --header-control-bg-hover: ${headerControlHoverBackground}; --header-control-bg-active: ${headerControlActiveBackground}; --header-control-border: ${headerControlBorder}; --header-control-border-hover: ${headerControlBorderHover};`;
     const normalizedBackgroundImageUrl = this.normalizeBackgroundImageUrl(this._config.background_image_url);
     const safeBackgroundImageUrl = normalizedBackgroundImageUrl
       ? String(normalizedBackgroundImageUrl).replace(/[\'\\]/g, '\\$&')

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -2375,6 +2375,36 @@ test('empty day_badges config does not emit badge variables', () => {
   assert.doesNotMatch(html, /--day-badge-/);
 });
 
+
+test('issue 384 wrapped header keeps configured opaque header background fallback', () => {
+  const card = new Card();
+  card._hass = { states: {}, locale: { language: 'en' }, language: 'en', themes: { darkMode: false } };
+  card.setConfig({ entities: ['calendar.family'], header_color: '#123456', compact_header: true });
+
+  originalCardRender.call(card);
+
+  assert.match(card.getStyles(), /\.header\.is-wrapped,[\s\S]*\.header-compact\.is-wrapped\s*\{[\s\S]*background:\s*var\(--header-wrapped-background, transparent\);/);
+  assert.match(card._root.innerHTML, /--header-background-base:\s*#123456;/);
+  assert.match(card._root.innerHTML, /--header-background-alpha:\s*1;/);
+  assert.match(card._root.innerHTML, /--header-wrapped-background:\s*#123456;/);
+});
+
+test('issue 384 transparent header mode does not get an opaque wrapped fallback', () => {
+  const card = new Card();
+  card._hass = { states: {}, locale: { language: 'en' }, language: 'en', themes: { darkMode: false } };
+  card.setConfig({
+    entities: ['calendar.family'],
+    header_color: '#123456',
+    header_background_transparent: true,
+    compact_header: true
+  });
+
+  originalCardRender.call(card);
+
+  assert.match(card._root.innerHTML, /--header-background-base:\s*#123456;/);
+  assert.match(card._root.innerHTML, /--header-wrapped-background:\s*transparent;/);
+});
+
 test('standard header wrapped state does not force header groups to full width', () => {
   const card = makeCard({ entities: ['calendar.a'], compact_header: false });
   const styles = card.getStyles();


### PR DESCRIPTION
### Motivation

- Prevent configured `header_color` from disappearing when the header becomes wrapped (gains `is-wrapped`) on older WebView implementations by making the explicit header background authoritative in the wrapped state. 
- Keep the fix narrowly scoped to CSS/rendering precedence and avoid broad browser compatibility changes. 
- Preserve the card's intentional transparent header modes so user-configured transparency is not overwritten. 

### Description

- Add a targeted CSS rule so `.header.is-wrapped` and `.header-compact.is-wrapped` use `background: var(--header-wrapped-background, transparent)` instead of relying solely on the pseudo-element. 
- Expose a new CSS variable `--header-wrapped-background` in the inline header style and set it to the resolved configured header color only when the header background is fully opaque; otherwise set it to `transparent`. 
- This change keeps existing pseudo-element-based header background behavior for modern browsers while ensuring the explicit header color remains authoritative after wrap detection. 
- Add two focused unit tests in `skylight-calendar-card.test.js` that assert an opaque configured `header_color` is applied to the wrapped fallback and that `header_background_transparent` preserves a transparent wrapped fallback. 

### Testing

- Ran the repository unit test suite with `npm test` (node --test), which executed the full test file and completed successfully with all tests passing. 
- The new targeted tests were included and passed, and no existing tests or modern-browser behaviors regressed. 
- No visual Playwright suite was modified or executed as part of this narrow compatibility fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30d2a86a388331a7d0cde347718c19)