### PR TITLE
Scope calendar card typography styles

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -4216,17 +4216,14 @@ class SkylightCalendarCard extends HTMLElement {
 
   getStyles() {
     return `
-      :host,
       daylight-calendar-card,
       skylight-calendar-card {
         display: block;
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
         width: 100%;
         height: 100%;
         min-height: 0;
       }
 
-      :host(.event-modal-open),
       daylight-calendar-card.event-modal-open,
       skylight-calendar-card.event-modal-open {
         position: relative;
@@ -4246,6 +4243,7 @@ class SkylightCalendarCard extends HTMLElement {
         display: flex;
         flex-direction: column;
         color-scheme: light;
+        font-family: var(--ha-font-family-body, var(--paper-font-body1_-_font-family, inherit));
         --schedule-hour-line-color: #d1d5db;
       }
 
@@ -4273,6 +4271,12 @@ class SkylightCalendarCard extends HTMLElement {
       .calendar-container textarea,
       .calendar-container button {
         color-scheme: light;
+      }
+
+      .calendar-container input,
+      .calendar-container select,
+      .calendar-container textarea,
+      .calendar-container button {
         font-family: inherit;
       }
 
@@ -5902,8 +5906,6 @@ class SkylightCalendarCard extends HTMLElement {
         top: -3px;
       }
 
-      :host(.event-modal-open) .calendar-container,
-      :host(.event-modal-open) .calendar-body,
       daylight-calendar-card.event-modal-open .calendar-container,
       daylight-calendar-card.event-modal-open .calendar-body,
       skylight-calendar-card.event-modal-open .calendar-container,

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -1017,7 +1017,7 @@ test('event modal overlay CSS uses viewport-fixed coverage and high stacking', (
   assert.match(styles, /\.event-modal\s*\{[\s\S]*position:\s*fixed;/);
   assert.match(styles, /\.event-modal\s*\{[\s\S]*inset:\s*0;/);
   assert.match(styles, /\.event-modal\s*\{[\s\S]*z-index:\s*2147483647;/);
-  assert.match(styles, /:host\(\.event-modal-open\)[\s\S]*z-index:\s*2147483000;/);
+  assert.match(styles, /daylight-calendar-card\.event-modal-open,[\s\S]*skylight-calendar-card\.event-modal-open[\s\S]*z-index:\s*2147483000;/);
   assert.match(styles, /event-modal-open[\s\S]*\.calendar-container[\s\S]*overflow:\s*visible;/);
   assert.match(styles, /event-modal-open[\s\S]*\.calendar-body[\s\S]*overflow:\s*visible;/);
 });
@@ -2172,13 +2172,35 @@ function extractCssRule(styles, selector) {
   return styles.slice(start, end + 1);
 }
 
+
+test('getStyles keeps light-DOM card typography scoped to internal content', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const styles = card.getStyles();
+
+  assert.doesNotMatch(styles, /-apple-system,\s*BlinkMacSystemFont,\s*'Segoe UI',\s*Roboto,\s*Oxygen,\s*Ubuntu,\s*Cantarell,\s*sans-serif/);
+
+  const cardElementRule = extractCssRule(styles, 'daylight-calendar-card,');
+  assert.doesNotMatch(cardElementRule, /font-family\s*:/);
+
+  const containerRule = extractCssRule(styles, '.calendar-container {');
+  assert.match(containerRule, /font-family:\s*var\(--ha-font-family-body,\s*var\(--paper-font-body1_-_font-family,\s*inherit\)\)/);
+
+  const formControlsFontRule = styles.match(/\.calendar-container input,[\s\S]*?\.calendar-container button \{[\s\S]*?font-family:\s*inherit;[\s\S]*?\}/)?.[0] ?? '';
+  assert.notEqual(formControlsFontRule, '', 'form controls should explicitly inherit the scoped card font');
+  assert.doesNotMatch(formControlsFontRule, /-apple-system|BlinkMacSystemFont|'Segoe UI'|Roboto|Oxygen|Ubuntu|Cantarell|sans-serif/);
+});
+
 test('getStyles includes full-height flex layout contract for HA Sections grids', () => {
   const card = makeCard({ entities: ['calendar.a'] });
   const styles = card.getStyles();
 
-  const hostRule = extractCssRule(styles, ':host,');
-  assert.match(hostRule, /height:\s*100%/);
-  assert.match(hostRule, /min-height:\s*0/);
+  const cardElementRule = extractCssRule(styles, 'daylight-calendar-card,');
+  assert.match(cardElementRule, /display:\s*block/);
+  assert.match(cardElementRule, /width:\s*100%/);
+  assert.match(cardElementRule, /height:\s*100%/);
+  assert.match(cardElementRule, /min-height:\s*0/);
+  assert.doesNotMatch(cardElementRule, /font-family\s*:/);
+  assert.doesNotMatch(cardElementRule, /:host/);
 
   const containerRule = extractCssRule(styles, '.calendar-container {');
   assert.match(containerRule, /height:\s*100%/);


### PR DESCRIPTION
### Motivation
- Fix issue #385 by preventing the card from injecting a system font stack into the light DOM so host/global CSS remains conservative. 
- Ensure the top-level card selector remains layout-only while preserving expected layout behavior for Home Assistant section/grid contracts. 
- Keep modal stacking and z-index behavior working while scoping typography to the card internals.

### Description
- Updated `getStyles()` in `skylight-calendar-card.js` to remove `:host` from the base light-DOM selector and keep `daylight-calendar-card, skylight-calendar-card` as a layout-only selector preserving `display: block`, `width: 100%`, `height: 100%`, and `min-height: 0`.
- Removed the hardcoded system font stack from top-level rules and moved Home Assistant theme font resolution into `.calendar-container` using `font-family: var(--ha-font-family-body, var(--paper-font-body1_-_font-family, inherit));` so internal content follows HA theme fonts.
- Kept internal form controls/buttons inheriting the scoped font by applying `font-family: inherit` specifically to `.calendar-container input, select, textarea, button` and removed any broad `font-family` on host/sibling selectors.
- Preserved modal/z-index behavior by removing ineffective `:host(.event-modal-open)` rules and keeping explicit `daylight-calendar-card.event-modal-open` and `skylight-calendar-card.event-modal-open` selectors.
- Updated `skylight-calendar-card.test.js` to replace `:host` modal assertions and to add a new test (`getStyles keeps light-DOM card typography scoped to internal content`) that verifies no hardcoded top-level system font stack, that the card-level selector is layout-only, and that form controls inherit the scoped card font.

### Testing
- Ran the unit test suite with `npm test` (invokes `node --test skylight-calendar-card.test.js`) and all tests passed (`193` tests passing, `0` failures).
- Confirmed the new and updated CSS assertions in `skylight-calendar-card.test.js` succeed and that modal stacking/z-index assertions remain valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30d4fab8c8833193b267e6eedc18d6)