### PR TITLE
Defer host/parent ResizeObserver renders while event modal is open

### DIFF
--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -180,6 +180,26 @@ The Daylight Calendar Card is designed to work out of the box with any Home Assi
     </Tip>
   </Accordion>
 
+  <Accordion title="Card only shows the header after updating">
+    If the card header appears but the calendar body is missing, check whether your dashboard card has an explicit `grid_options.rows` value that is too small.
+
+    This can happen in v4.5.0 and newer because the card body now fills the available height of the Home Assistant dashboard card. If the dashboard card is only one row tall, the calendar body may collapse and only the header remains visible.
+
+    **Fix:**
+
+    ```yaml
+    grid_options:
+      columns: 120
+      rows: 8
+    ```
+
+    If you currently have `rows:` set to anything less than 4, it is probably too small.
+
+    <Tip>
+      The safest approach remains removing `rows:` entirely and letting the card size naturally.
+    </Tip>
+  </Accordion>
+
   <Accordion title="Submitting a bug report">
     If none of the above resolves your issue, please open a GitHub issue so the maintainer can investigate.
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -189,7 +189,6 @@ The Daylight Calendar Card is designed to work out of the box with any Home Assi
 
     ```yaml
     grid_options:
-      columns: 120
       rows: 8
     ```
 

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1037,6 +1037,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._headerResizeObserver = null;
     this._hostResizeObserver = null;
     this._hostResizeRaf = null;
+    this._pendingHostParentResizeRender = false;
     this._observedResizeParent = null;
     this._lastObservedHostSize = null;
     this._monthCompactMeasurementDirty = true;
@@ -3630,6 +3631,7 @@ class SkylightCalendarCard extends HTMLElement {
     }
     this._observedResizeParent = null;
     this._lastObservedHostSize = null;
+    this._pendingHostParentResizeRender = false;
     if (this._hostResizeRaf !== null) {
       window.cancelAnimationFrame(this._hostResizeRaf);
       this._hostResizeRaf = null;
@@ -3865,8 +3867,20 @@ class SkylightCalendarCard extends HTMLElement {
       if (this._config.compact_height && this._viewMode === 'month' && !this.shouldShowAllEventsInMonth()) {
         this._monthCompactMeasurementDirty = true;
       }
+
+      if (this.isEventManagementDialogOpen()) {
+        this._pendingHostParentResizeRender = true;
+        return;
+      }
+
       this.render();
     });
+  }
+
+  flushPendingHostParentResizeRender() {
+    if (!this._pendingHostParentResizeRender) return;
+    this._pendingHostParentResizeRender = false;
+    this.render();
   }
 
   observeHeaderResize() {
@@ -9553,6 +9567,7 @@ class SkylightCalendarCard extends HTMLElement {
       this.updateEventModalOpenState(modal);
       if (!this.isEventManagementDialogOpen()) {
         this.flushPendingHeaderTimeRender();
+        this.flushPendingHostParentResizeRender();
       }
     });
 

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -7,7 +7,7 @@
 // 3. Copy the strings from 'en' and translate each value
 // ============================================================================
 
-const DAYLIGHT_CALENDAR_CARD_VERSION = 'v4.5.0';
+const DAYLIGHT_CALENDAR_CARD_VERSION = 'v4.6.0';
 
 function getDaylightCalendarCardVersion() {
   return DAYLIGHT_CALENDAR_CARD_VERSION.includes('__')

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -2346,6 +2346,81 @@ test('disconnectedCallback disconnects host ResizeObserver', () => {
   }
 });
 
+
+
+test('scheduleHostAndParentResizeHandling defers render while event management modal is open', () => {
+  const card = makeCard({ entities: ['calendar.a'], compact_height: true });
+  card._viewMode = 'month';
+  card._lastObservedHostSize = { hostWidth: 300, hostHeight: 400, parentWidth: 320, parentHeight: 480 };
+  card._monthCompactMeasurementDirty = false;
+  let renderCount = 0;
+  const originalRender = card.render;
+  const originalRaf = window.requestAnimationFrame;
+  try {
+    card.render = () => { renderCount += 1; };
+    card.isEventManagementDialogOpen = () => true;
+    card.measureHostAndParentSize = () => ({ hostWidth: 301, hostHeight: 405, parentWidth: 320, parentHeight: 500 });
+    window.requestAnimationFrame = (cb) => {
+      cb();
+      return 1;
+    };
+
+    card.scheduleHostAndParentResizeHandling();
+
+    assert.equal(renderCount, 0);
+    assert.deepEqual(card._lastObservedHostSize, { hostWidth: 301, hostHeight: 405, parentWidth: 320, parentHeight: 500 });
+    assert.equal(card._monthCompactMeasurementDirty, true);
+    assert.equal(card._pendingHostParentResizeRender, true);
+  } finally {
+    card.render = originalRender;
+    window.requestAnimationFrame = originalRaf;
+  }
+});
+
+test('pending host/parent resize render flushes once after event management modal closes', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  let renderCount = 0;
+  const originalRender = card.render;
+  try {
+    card.render = () => { renderCount += 1; };
+    card._pendingHostParentResizeRender = true;
+
+    card.flushPendingHostParentResizeRender();
+    card.flushPendingHostParentResizeRender();
+
+    assert.equal(renderCount, 1);
+    assert.equal(card._pendingHostParentResizeRender, false);
+  } finally {
+    card.render = originalRender;
+  }
+});
+
+test('scheduleHostAndParentResizeHandling renders immediately when event management modal is closed', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  card._lastObservedHostSize = { hostWidth: 300, hostHeight: 400, parentWidth: 320, parentHeight: 480 };
+  let renderCount = 0;
+  const originalRender = card.render;
+  const originalRaf = window.requestAnimationFrame;
+  try {
+    card.render = () => { renderCount += 1; };
+    card.isEventManagementDialogOpen = () => false;
+    card.measureHostAndParentSize = () => ({ hostWidth: 310, hostHeight: 400, parentWidth: 320, parentHeight: 480 });
+    window.requestAnimationFrame = (cb) => {
+      cb();
+      return 1;
+    };
+
+    card.scheduleHostAndParentResizeHandling();
+
+    assert.equal(renderCount, 1);
+    assert.deepEqual(card._lastObservedHostSize, { hostWidth: 310, hostHeight: 400, parentWidth: 320, parentHeight: 480 });
+    assert.equal(card._pendingHostParentResizeRender, false);
+  } finally {
+    card.render = originalRender;
+    window.requestAnimationFrame = originalRaf;
+  }
+});
+
 test('day_badge CSS variables do not leak into non-badge selectors', () => {
   const card = makeCard({ entities: ['calendar.a'] });
   const styles = card.getStyles();


### PR DESCRIPTION
### Motivation
- Prevent host/parent `ResizeObserver`-driven `render()` from stealing focus when the event management modal is open (Android soft keyboard case) while retaining grid/Sections sizing behavior. 
- Keep measuring and compact-month bookkeeping during modal-open viewport changes but delay DOM-affecting renders until the modal closes. 

### Description
- Add a one-shot pending flag `_pendingHostParentResizeRender` initialized on the component and cleared in `disconnectedCallback` to track deferred host/parent renders. 
- Update `scheduleHostAndParentResizeHandling()` to continue measuring and update `_lastObservedHostSize` and `_monthCompactMeasurementDirty`, but set the pending flag and skip calling `render()` when `isEventManagementDialogOpen()` is true. 
- Add `flushPendingHostParentResizeRender()` that consumes the pending flag and calls `render()` once, and wire it into the modal visibility observer so the deferred render is flushed when the modal closes. 
- Ensure repeated resize observations while the modal is open do not cause repeated renders and that RAF/cancel state is preserved/cleaned up on disconnect. 
- Add unit tests that exercise deferral, state updates while modal is open, one-shot flush behavior, and unchanged immediate-render behavior when the modal is closed. 

### Testing
- Added tests: `scheduleHostAndParentResizeHandling defers render while event management modal is open`, `pending host/parent resize render flushes once after event management modal closes`, and `scheduleHostAndParentResizeHandling renders immediately when event management modal is closed`. 
- Ran the full test suite with `npm test`; all tests passed (198 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33f93ac5108331b472824c62641e3a)