### PR TITLE
Defer host/parent resize-triggered render while event modal is open

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1037,6 +1037,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._headerResizeObserver = null;
     this._hostResizeObserver = null;
     this._hostResizeRaf = null;
+    this._pendingHostResizeRender = false;
     this._observedResizeParent = null;
     this._lastObservedHostSize = null;
     this._monthCompactMeasurementDirty = true;
@@ -3630,6 +3631,7 @@ class SkylightCalendarCard extends HTMLElement {
     }
     this._observedResizeParent = null;
     this._lastObservedHostSize = null;
+    this._pendingHostResizeRender = false;
     if (this._hostResizeRaf !== null) {
       window.cancelAnimationFrame(this._hostResizeRaf);
       this._hostResizeRaf = null;
@@ -3865,8 +3867,20 @@ class SkylightCalendarCard extends HTMLElement {
       if (this._config.compact_height && this._viewMode === 'month' && !this.shouldShowAllEventsInMonth()) {
         this._monthCompactMeasurementDirty = true;
       }
+
+      if (this.isEventManagementDialogOpen()) {
+        this._pendingHostResizeRender = true;
+        return;
+      }
+
       this.render();
     });
+  }
+
+  flushPendingHostResizeRender() {
+    if (!this._pendingHostResizeRender) return;
+    this._pendingHostResizeRender = false;
+    this.render();
   }
 
   observeHeaderResize() {
@@ -9537,6 +9551,9 @@ class SkylightCalendarCard extends HTMLElement {
   updateEventModalOpenState(modal = this.getRootElementById('event-modal')) {
     const isOpen = !!modal && modal.classList.contains('show');
     this.classList?.toggle('event-modal-open', isOpen);
+    if (!isOpen) {
+      this.flushPendingHostResizeRender();
+    }
   }
 
   observeModalVisibility(modal) {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -2317,6 +2317,87 @@ test('getCompactContainerStyle preserves viewport fallback without constrained p
   }
 });
 
+
+test('scheduleHostAndParentResizeHandling defers host resize render while event modal is open', () => {
+  const card = makeCard({ entities: ['calendar.a'], compact_height: true });
+  let renderCount = 0;
+  let hostSize = { width: 300, height: 400 };
+  let parentSize = { width: 320, height: 480 };
+  const modalClasses = new Set(['show']);
+  const modal = { classList: { contains: (name) => modalClasses.has(name) } };
+  const originalRequestAnimationFrame = window.requestAnimationFrame;
+
+  try {
+    window.requestAnimationFrame = (callback) => {
+      callback();
+      return 1;
+    };
+    card.render = () => { renderCount += 1; };
+    card._viewMode = 'month';
+    card._monthCompactMeasurementDirty = false;
+    card._root = { querySelector: (selector) => selector === '#event-modal' ? modal : null };
+    card.getBoundingClientRect = () => ({ width: hostSize.width, height: hostSize.height });
+    card.parentElement = { getBoundingClientRect: () => ({ width: parentSize.width, height: parentSize.height }) };
+    card._lastObservedHostSize = card.measureHostAndParentSize();
+
+    hostSize = { width: 340, height: 410 };
+    parentSize = { width: 360, height: 500 };
+    card.scheduleHostAndParentResizeHandling();
+
+    assert.equal(renderCount, 0);
+    assert.deepEqual(card._lastObservedHostSize, {
+      hostWidth: 340,
+      hostHeight: 410,
+      parentWidth: 360,
+      parentHeight: 500
+    });
+    assert.equal(card._monthCompactMeasurementDirty, true);
+    assert.equal(card._pendingHostResizeRender, true);
+
+    hostSize = { width: 380, height: 430 };
+    card.scheduleHostAndParentResizeHandling();
+    assert.equal(renderCount, 0);
+    assert.equal(card._pendingHostResizeRender, true);
+
+    modalClasses.delete('show');
+    card.updateEventModalOpenState(modal);
+    assert.equal(renderCount, 1);
+    assert.equal(card._pendingHostResizeRender, false);
+
+    card.updateEventModalOpenState(modal);
+    assert.equal(renderCount, 1);
+  } finally {
+    window.requestAnimationFrame = originalRequestAnimationFrame;
+  }
+});
+
+test('scheduleHostAndParentResizeHandling renders immediately when event modal is closed', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  let renderCount = 0;
+  let hostSize = { width: 300, height: 400 };
+  const originalRequestAnimationFrame = window.requestAnimationFrame;
+
+  try {
+    window.requestAnimationFrame = (callback) => {
+      callback();
+      return 1;
+    };
+    card.render = () => { renderCount += 1; };
+    card.isEventManagementDialogOpen = () => false;
+    card.getBoundingClientRect = () => ({ width: hostSize.width, height: hostSize.height });
+    card.parentElement = { getBoundingClientRect: () => ({ width: 320, height: 480 }) };
+    card._lastObservedHostSize = card.measureHostAndParentSize();
+
+    hostSize = { width: 340, height: 400 };
+    card.scheduleHostAndParentResizeHandling();
+
+    assert.equal(renderCount, 1);
+    assert.equal(card._pendingHostResizeRender, false);
+  } finally {
+    window.requestAnimationFrame = originalRequestAnimationFrame;
+  }
+});
+
 test('disconnectedCallback disconnects host ResizeObserver', () => {
   const card = makeCard({ entities: ['calendar.a'] });
   let disconnectCount = 0;


### PR DESCRIPTION
### Motivation
- Prevent Android soft-keyboard-driven viewport changes from calling `render()` while the event management modal is open, which caused the modal to lose focus when the card is used inside grid/layout wrappers.
- Keep the host/parent `ResizeObserver` path active for grid-aware sizing while avoiding modal-destabilizing renders.

### Description
- Added a `_pendingHostResizeRender` flag to track a deferred render triggered by `scheduleHostAndParentResizeHandling()` when `isEventManagementDialogOpen()` is true and a host/parent size change is observed.
- Preserve size measurement and month-compact dirty updates inside `scheduleHostAndParentResizeHandling()` and set `_pendingHostResizeRender = true` instead of calling `render()` while the modal is open.
- Added `flushPendingHostResizeRender()` and invoke it from `updateEventModalOpenState()` when the modal closes so a single deferred render is performed once; ensure pending state is cleared in `disconnectedCallback()`.
- Added unit tests to cover modal-open deferral, size/state updates while modal is open, one-time deferred flush after close, and unchanged immediate rendering when modal is closed.

### Testing
- Ran the full test suite with `node --test skylight-calendar-card.test.js`, which passed locally (all tests passed).
- Added tests: `scheduleHostAndParentResizeHandling defers host resize render while event modal is open` and `scheduleHostAndParentResizeHandling renders immediately when event modal is closed`, both included in the run and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33fcf9cb208331aee9ac044cbd21ad)