### PR TITLE
docs: clarify compact_height usage

### DIFF
--- a/docs/configuration/appearance.mdx
+++ b/docs/configuration/appearance.mdx
@@ -98,7 +98,17 @@ The Daylight Calendar Card gives you extensive control over its visual presentat
 ## Layout
 
 <ParamField path="compact_height" default="false" type="boolean">
-  Make the card fit precisely into its parent container's height rather than expanding to fill its content. Useful in fixed-height grid layouts or when the card is placed inside a vertical stack with constrained space.
+  Make the card fit precisely into its parent container's height instead of expanding to fit its content.
+
+  This is especially useful in Home Assistant **Panel** dashboards and fixed-height grid layouts. In a Panel dashboard, the parent container is usually the full available dashboard viewport, so `compact_height: true` makes Daylight Calendar Card automatically size itself to fill the screen height.
+
+  Use this when:
+  - the card should fill a wall-tablet or kiosk screen
+  - the card is inside a fixed-height grid area
+  - Agenda view should scroll internally instead of making the whole dashboard taller
+  - Month/Schedule view should compress vertically to fit the available space
+
+  Avoid this in normal masonry/sidebar layouts where the card’s parent may not have a defined height. In those layouts, use the default content height or adjust `height_scale` for Schedule view.
 </ParamField>
 
 <ParamField path="compact_width" default="false" type="boolean">


### PR DESCRIPTION
### Motivation
- Clarify the behavior and recommended usage of the `compact_height` option so users understand when the card will size to its parent container rather than its content.
- Provide concrete guidance for Panel dashboards, fixed-height grid layouts, kiosk/wall-tablet use cases, internal scrolling in Agenda view, and when to avoid `compact_height` in masonry/sidebar layouts.

### Description
- Update the `compact_height` `ParamField` in `docs/configuration/appearance.mdx` to replace a short note with a fuller explanation of parent-height fitting and Panel/dashboard behavior.
- Add a short list of recommended use cases and an explicit warning to avoid `compact_height` in layouts where the parent may not have a defined height.
- This is a documentation-only change and does not modify any runtime code or behavior.

### Testing
- Ran `git diff --check` to validate the change and ensure no whitespace or diff errors, which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34c44115dc83319da68a214d824680)