### PR TITLE
docs: clarify font display options

### DIFF
--- a/docs/configuration/appearance.mdx
+++ b/docs/configuration/appearance.mdx
@@ -9,7 +9,7 @@ The Daylight Calendar Card gives you extensive control over its visual presentat
 <Tip>
   Looking for font size, event text, time text, or location text settings?
 
-  Font-related display options are documented in [Display Options](/configuration/display-options), including:
+  Font-related display options are documented in [Display Options](/configuration/display), including:
 
   - `event_font_size`
   - `event_time_font_size`

--- a/docs/configuration/appearance.mdx
+++ b/docs/configuration/appearance.mdx
@@ -6,6 +6,17 @@ description: "Customize calendar colors, event color mode, header style, backgro
 
 The Daylight Calendar Card gives you extensive control over its visual presentation. You can assign distinct colors to each calendar, choose how those colors are applied to event chips, style the header independently from the card body, and even set a background image — all through YAML configuration.
 
+<Tip>
+  Looking for font size, event text, time text, or location text settings?
+
+  Font-related display options are documented in [Display Options](/configuration/display-options), including:
+
+  - `event_font_size`
+  - `event_time_font_size`
+  - `event_location_font_size`
+  - `event_font_colors`
+</Tip>
+
 ## Calendar Colors
 
 <ParamField path="colors" default="[]" type="map">

--- a/docs/configuration/display.mdx
+++ b/docs/configuration/display.mdx
@@ -130,6 +130,13 @@ The calendar list lets users toggle individual calendars on or off from inside t
   The font size (in pixels) of the event location text.
 </ParamField>
 
+```yaml
+type: custom:daylight-calendar-card
+event_font_size: 14px
+event_time_font_size: 12px
+event_location_font_size: 11px
+```
+
 <ParamField path="event_calendar_friendly_name" default="false" type="boolean">
   Show the calendar's friendly name beneath the event title in event detail modals.
 </ParamField>


### PR DESCRIPTION
### Motivation
- Make it easier for readers to find and use font-related event display settings by surfacing a pointer from the Appearance docs and adding a concrete YAML example to the Display Options page.

### Description
- Added a short `<Tip>` near the top of `docs/configuration/appearance.mdx` that points readers to the `Display Options` page and lists `event_font_size`, `event_time_font_size`, `event_location_font_size`, and `event_font_colors`, and inserted a small YAML example after the event font size fields in `docs/configuration/display.mdx` showing `event_font_size`, `event_time_font_size`, and `event_location_font_size` usage.

### Testing
- Ran `git diff --check` and `npm test`, with the test suite passing (`npm test` ran 195 tests with 0 failures); running `npx mint broken-links` failed due to an `npm` registry `403 Forbidden` error preventing the link check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34cafae89883319a3f311e227f03f7)