### PR TITLE
Add optional calendar timezone override (time_zone)

### DIFF
--- a/docs/configuration/display.mdx
+++ b/docs/configuration/display.mdx
@@ -159,6 +159,17 @@ The calendar list lets users toggle individual calendars on or off from inside t
   Display times in a compact format — for example, `10 AM` instead of `10:00 AM`. Applies to Month, Week Compact, Schedule, and Agenda views.
 </ParamField>
 
+
+<ParamField path="time_zone" type="string">
+  Override the browser or WebView timezone used by the card. Use an IANA timezone name, such as `America/New_York`.
+
+  Leave this unset to keep the existing behavior, which uses the device's local timezone. If the value is blank or invalid, the card ignores it and falls back to the device timezone.
+
+  ```yaml
+  time_zone: America/New_York
+  ```
+</ParamField>
+
 <ParamField path="display_full_weekday_names" default="false" type="boolean">
   Display full weekday names, such as `Monday` and `Tuesday`, instead of abbreviated names like `Mon` and `Tue`. The card formats names using the configured `locale` or `language`, or the locale inherited from Home Assistant when neither is set.
 </ParamField>
@@ -212,6 +223,7 @@ calendar_badge_icons:
 event_font_size: 12
 event_time_font_size: 10
 shorten_event_times: true
+time_zone: America/New_York
 display_full_weekday_names: true
 show_event_location: true
 use_short_location: true

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1471,6 +1471,7 @@ class SkylightCalendarCard extends HTMLElement {
       { key: 'agenda_compact_events', defaultValue: ({ rawConfig }) => rawConfig.agenda_compact_events ?? false, normalize: ({ rawConfig }) => rawConfig.agenda_compact_events ?? false },
       { key: 'display_full_weekday_names', defaultValue: ({ rawConfig }) => rawConfig.display_full_weekday_names ?? false },
       { key: 'shorten_event_times', defaultValue: ({ rawConfig }) => rawConfig.shorten_event_times ?? false },
+      { key: 'time_zone', defaultValue: ({ derived }) => derived.normalizedTimeZone, normalize: ({ derived }) => derived.normalizedTimeZone },
       { key: 'disable_swipe_controls', defaultValue: ({ rawConfig }) => rawConfig.disable_swipe_controls ?? false },
       { key: 'week_start_hour', defaultValue: ({ derived }) => derived.normalizedWeekStartHour },
       { key: 'week_end_hour', defaultValue: ({ derived }) => derived.normalizedWeekEndHour },
@@ -1584,6 +1585,7 @@ class SkylightCalendarCard extends HTMLElement {
       normalizedWeekStartHour,
       normalizedWeekEndHour,
       normalizedEventTitlePrefix: this.normalizeEventTitlePrefixMode(rawConfig.event_title_prefix),
+      normalizedTimeZone: this.normalizeTimeZone(rawConfig.time_zone),
       normalizedPastEventMode: rawConfig.past_event_mode !== undefined && rawConfig.past_event_mode !== null && rawConfig.past_event_mode !== ''
         ? this.normalizePastEventMode(rawConfig.past_event_mode)
         : (rawConfig.hide_the_past ? 'hide' : 'none'),
@@ -3598,6 +3600,82 @@ class SkylightCalendarCard extends HTMLElement {
     const month = String(date.getMonth() + 1).padStart(2, '0');
     const day = String(date.getDate()).padStart(2, '0');
     return `${year}-${month}-${day}`;
+  }
+
+
+  normalizeTimeZone(timeZone) {
+    if (timeZone === undefined || timeZone === null) return null;
+    const normalized = String(timeZone).trim();
+    if (!normalized) return null;
+
+    try {
+      return new Intl.DateTimeFormat('en-US', { timeZone: normalized }).resolvedOptions().timeZone || normalized;
+    } catch (error) {
+      console.warn(`Daylight Calendar Card: ignoring invalid time_zone config value "${normalized}".`);
+      return null;
+    }
+  }
+
+  getConfiguredTimeZone() {
+    return this._config?.time_zone || null;
+  }
+
+  withTimeZone(formatOptions = {}) {
+    const timeZone = this.getConfiguredTimeZone();
+    return timeZone ? { ...formatOptions, timeZone } : formatOptions;
+  }
+
+  getDateTimeParts(date, options = {}) {
+    const formatter = new Intl.DateTimeFormat('en-US', this.withTimeZone({
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', second: '2-digit',
+      hourCycle: 'h23', ...options
+    }));
+    return formatter.formatToParts(date).reduce((acc, part) => {
+      if (part.type !== 'literal') acc[part.type] = part.value;
+      return acc;
+    }, {});
+  }
+
+  getDateParts(date) {
+    if (!this.getConfiguredTimeZone()) {
+      return { year: date.getFullYear(), month: date.getMonth() + 1, day: date.getDate(), weekday: date.getDay() };
+    }
+    const parts = this.getDateTimeParts(date, { weekday: 'short' });
+    const utcDate = new Date(Date.UTC(Number(parts.year), Number(parts.month) - 1, Number(parts.day)));
+    return { year: Number(parts.year), month: Number(parts.month), day: Number(parts.day), weekday: utcDate.getUTCDay() };
+  }
+
+  getDisplayDateParts(date) {
+    return { year: date.getFullYear(), month: date.getMonth() + 1, day: date.getDate(), weekday: date.getDay() };
+  }
+
+  zonedTimeToDate(year, month, day, hour = 0, minute = 0, second = 0, millisecond = 0) {
+    const timeZone = this.getConfiguredTimeZone();
+    if (!timeZone) return new Date(year, month - 1, day, hour, minute, second, millisecond);
+
+    let timestamp = Date.UTC(year, month - 1, day, hour, minute, second, millisecond);
+    for (let i = 0; i < 3; i++) {
+      const parts = this.getDateTimeParts(new Date(timestamp));
+      const asUTC = Date.UTC(Number(parts.year), Number(parts.month) - 1, Number(parts.day), Number(parts.hour), Number(parts.minute), Number(parts.second), millisecond);
+      const wantedUTC = Date.UTC(year, month - 1, day, hour, minute, second, millisecond);
+      const delta = asUTC - wantedUTC;
+      if (delta === 0) break;
+      timestamp -= delta;
+    }
+    return new Date(timestamp);
+  }
+
+  getDayBounds(date) {
+    const { year, month, day } = this.getDisplayDateParts(date);
+    const dayStart = this.zonedTimeToDate(year, month, day, 0, 0, 0, 0);
+    const next = new Date(year, month - 1, day + 1);
+    const nextDayStart = this.zonedTimeToDate(next.getFullYear(), next.getMonth() + 1, next.getDate(), 0, 0, 0, 0);
+    return { dayStart, nextDayStart };
+  }
+
+  getDatePartValue(date, part) {
+    return this.getDisplayDateParts(date)[part];
   }
 
   getDefaultColor(index) {
@@ -7311,7 +7389,7 @@ class SkylightCalendarCard extends HTMLElement {
       formatOptions.year = 'numeric';
     }
 
-    const formatter = new Intl.DateTimeFormat(this.getLocale(), formatOptions);
+    const formatter = new Intl.DateTimeFormat(this.getLocale(), this.withTimeZone(formatOptions));
 
     if (!includeYear) {
       if (startDate.getTime() === endDate.getTime()) {
@@ -7523,7 +7601,7 @@ class SkylightCalendarCard extends HTMLElement {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
     const dayNames = this.getWeekdayNames();
-    const monthFormatter = new Intl.DateTimeFormat(this.getLocale(), { month: 'long', year: 'numeric' });
+    const monthFormatter = new Intl.DateTimeFormat(this.getLocale(), this.withTimeZone({ month: 'long', year: 'numeric' }));
     const agendaRows = [];
     const shouldHideEmptyDays = this._viewMode === 'agenda' && !!this._config.hide_empty_days;
     const agendaDayEntries = agendaDays
@@ -7940,14 +8018,16 @@ class SkylightCalendarCard extends HTMLElement {
   getLocalDayHourFloat(dateTime, referenceDate) {
     // Use wall-clock hour values relative to the rendered day so DST transitions
     // do not visually shift events by ±1 hour in the schedule grid.
-    const dayKey = Date.UTC(referenceDate.getFullYear(), referenceDate.getMonth(), referenceDate.getDate());
-    const timeKey = Date.UTC(dateTime.getFullYear(), dateTime.getMonth(), dateTime.getDate());
+    const referenceParts = this.getDisplayDateParts(referenceDate);
+    const timeParts = this.getDateTimeParts(dateTime);
+    const dayKey = Date.UTC(referenceParts.year, referenceParts.month - 1, referenceParts.day);
+    const timeKey = Date.UTC(Number(timeParts.year), Number(timeParts.month) - 1, Number(timeParts.day));
     const dayDiff = (timeKey - dayKey) / 86400000;
 
     return (dayDiff * 24) +
-      dateTime.getHours() +
-      (dateTime.getMinutes() / 60) +
-      (dateTime.getSeconds() / 3600) +
+      Number(timeParts.hour) +
+      (Number(timeParts.minute) / 60) +
+      (Number(timeParts.second) / 3600) +
       (dateTime.getMilliseconds() / 3600000);
   }
 
@@ -8271,7 +8351,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   formatScheduleHour(hour) {
-    const date = new Date(2020, 0, 1, hour, 0, 0, 0);
+    const date = this.zonedTimeToDate(2020, 1, 1, hour, 0, 0, 0);
     return this.formatScheduleTime(date);
   }
 
@@ -8290,20 +8370,21 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   formatScheduleTime(date) {
-    return new Intl.DateTimeFormat(this.getLocale(), this.getTimeFormatOptions()).format(date);
+    return new Intl.DateTimeFormat(this.getLocale(), this.withTimeZone(this.getTimeFormatOptions())).format(date);
   }
 
   uses24HourEventTime() {
-    const formatter = new Intl.DateTimeFormat(this.getLocale(), this.getTimeFormatOptions());
+    const formatter = new Intl.DateTimeFormat(this.getLocale(), this.withTimeZone(this.getTimeFormatOptions()));
     return formatter.resolvedOptions().hour12 === false;
   }
 
   isWholeHour(date) {
-    return date.getMinutes() === 0 && date.getSeconds() === 0 && date.getMilliseconds() === 0;
+    const parts = this.getDateTimeParts(date);
+    return Number(parts.minute) === 0 && Number(parts.second) === 0 && date.getMilliseconds() === 0;
   }
 
   formatLocalizedHour(date) {
-    const formatter = new Intl.DateTimeFormat(this.getLocale(), this.getTimeFormatOptions());
+    const formatter = new Intl.DateTimeFormat(this.getLocale(), this.withTimeZone(this.getTimeFormatOptions()));
     const hourPart = formatter.formatToParts(date).find((part) => part.type === 'hour');
     if (hourPart) {
       return hourPart.value;
@@ -8317,7 +8398,7 @@ class SkylightCalendarCard extends HTMLElement {
       return this.formatBaseEventTime(date, options);
     }
 
-    const formatter = new Intl.DateTimeFormat(this.getLocale(), this.getTimeFormatOptions());
+    const formatter = new Intl.DateTimeFormat(this.getLocale(), this.withTimeZone(this.getTimeFormatOptions()));
     const parts = formatter.formatToParts(date);
     const minuteIndex = parts.findIndex((part) => part.type === 'minute');
     const shortenedParts = parts.filter((part, index) => {
@@ -9198,7 +9279,8 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getLocalDateKey(date) {
-    return Date.UTC(date.getFullYear(), date.getMonth(), date.getDate());
+    const { year, month, day } = this.getDateParts(date);
+    return Date.UTC(year, month - 1, day);
   }
 
   eventSpansMultipleLocalDates(eventStart, eventEnd) {
@@ -9235,9 +9317,7 @@ class SkylightCalendarCard extends HTMLElement {
     const { eventStart, eventEnd, isAllDay } = scheduleVisualInfo || this.getEventDateTimeInfo(event);
     const rendersAsAllDay = scheduleVisualInfo?.rendersAsAllDay || isAllDay;
 
-    const dayStart = new Date(date.getFullYear(), date.getMonth(), date.getDate());
-    const nextDayStart = new Date(dayStart);
-    nextDayStart.setDate(nextDayStart.getDate() + 1);
+    const { dayStart, nextDayStart } = this.getDayBounds(date);
 
     if (eventEnd <= dayStart || eventStart >= nextDayStart) {
       return null;
@@ -11776,7 +11856,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   formatTime(date) {
-    return new Intl.DateTimeFormat(this.getLocale(), this.getTimeFormatOptions()).format(date);
+    return new Intl.DateTimeFormat(this.getLocale(), this.withTimeZone(this.getTimeFormatOptions())).format(date);
   }
 
   parseTimeValue(value) {
@@ -12067,7 +12147,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   formatDate(date) {
-    return new Intl.DateTimeFormat(this.getLocale(), { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' }).format(date);
+    return new Intl.DateTimeFormat(this.getLocale(), this.withTimeZone({ weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })).format(date);
   }
 
   formatDuration(startDate, endDate) {
@@ -12467,6 +12547,7 @@ class SkylightCalendarCard extends HTMLElement {
       hide_empty_days: false,
       agenda_compact_events: false,
       shorten_event_times: false,
+      time_zone: '',
       display_full_weekday_names: false,
       compact_width: false,
       show_current_time_bar: false,

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -94,6 +94,7 @@ const CONFIG_COVERAGE_INVENTORY = {
   agenda_compact_events: 'agenda compact events use compact class and sizing',
   display_full_weekday_names: 'display_full_weekday_names renders localized long weekday labels',
   shorten_event_times: 'shorten_event_times removes minutes from whole-hour 12-hour event times',
+  time_zone: 'time_zone normalizes optional IANA zones and drives formatting and grouping',
   disable_swipe_controls: 'disable_swipe_controls disables swipe controls without affecting agenda',
   week_start_hour: 'lock_schedule_hours keeps configured schedule hours from expanding to events',
   week_end_hour: 'lock_schedule_hours keeps configured schedule hours from expanding to events',
@@ -244,7 +245,7 @@ test('getStubConfig and normalized defaults include key configuration defaults',
   const requiredStubKeys = [
     'default_view', 'first_day_of_week', 'week_days', 'week_start_hour', 'week_end_hour',
     'lock_schedule_hours', 'disable_swipe_controls', 'show_all_events_month', 'show_all_details_month',
-    'hide_empty_days', 'agenda_compact_events', 'shorten_event_times', 'display_full_weekday_names', 'compact_width',
+    'hide_empty_days', 'agenda_compact_events', 'shorten_event_times', 'time_zone', 'display_full_weekday_names', 'compact_width',
     'show_current_time_bar', 'show_event_location', 'use_short_location',
     'event_calendar_friendly_name', 'event_title_prefix', 'past_event_mode', 'event_color_mode',
     'event_neutral_background', 'event_tint_opacity', 'event_color_bar_width', 'combine_style',
@@ -331,6 +332,7 @@ test('setConfig applies visual layout and styling options', () => {
     event_title_prefix: 'icon',
     show_current_time_bar: true,
     shorten_event_times: true,
+    time_zone: 'America/New_York',
     display_full_weekday_names: true,
     header_color: '#123456',
     header_text_color: '#ffffff',
@@ -385,6 +387,7 @@ test('setConfig applies visual layout and styling options', () => {
   assert.equal(card._config.event_title_prefix, 'badge_icon');
   assert.equal(card._config.show_current_time_bar, true);
   assert.equal(card._config.shorten_event_times, true);
+  assert.equal(card._config.time_zone, 'America/New_York');
   assert.equal(card._config.display_full_weekday_names, true);
   assert.equal(card._config.header_color, '#123456');
   assert.equal(card._config.header_text_color, '#ffffff');
@@ -513,6 +516,70 @@ test('shorten_event_times leaves all-day event labels unaffected', () => {
 
   assert.match(html, /week-compact-event-time">All Day</);
   assert.doesNotMatch(html, /10 AM|10h/);
+});
+
+
+test('time_zone is optional and preserves default local formatting when unset', () => {
+  const card = makeCard({ entities: ['calendar.family'], locale: 'en-US' });
+  const date = new Date('2026-01-01T12:00:00Z');
+
+  assert.equal(card._config.time_zone, null);
+  assert.equal(card.formatTime(date), new Intl.DateTimeFormat('en-US', card.getTimeFormatOptions()).format(date));
+});
+
+test('time_zone retains valid IANA zones and uses them in formatting', () => {
+  const card = makeCard({ entities: ['calendar.family'], locale: 'en-US', time_zone: 'America/New_York' });
+
+  assert.equal(card._config.time_zone, 'America/New_York');
+  assert.equal(card.formatTime(new Date('2026-01-01T12:00:00Z')), '7:00 AM');
+  assert.match(card.formatDate(new Date('2026-01-01T12:00:00Z')), /Thursday, January 1, 2026/);
+});
+
+test('time_zone ignores blank and invalid values safely', () => {
+  const originalWarn = console.warn;
+  const warnings = [];
+  console.warn = (message) => warnings.push(String(message));
+  try {
+    const blank = makeCard({ entities: ['calendar.family'], time_zone: '   ' });
+    const invalid = makeCard({ entities: ['calendar.family'], time_zone: 'Not/AZone' });
+
+    assert.equal(blank._config.time_zone, null);
+    assert.equal(invalid._config.time_zone, null);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /invalid time_zone/);
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
+test('time_zone can render an ISO event time differently than the default zone', () => {
+  const defaultCard = makeCard({ entities: ['calendar.family'], locale: 'en-US' });
+  const zonedCard = makeCard({ entities: ['calendar.family'], locale: 'en-US', time_zone: 'America/New_York' });
+  const date = new Date('2026-01-01T12:00:00Z');
+
+  assert.equal(defaultCard.formatEventTime(date), '12:00 PM');
+  assert.equal(zonedCard.formatEventTime(date), '7:00 AM');
+  assert.notEqual(defaultCard.formatEventTime(date), zonedCard.formatEventTime(date));
+});
+
+test('time_zone controls event day grouping and week placement calculations', () => {
+  const card = makeCard({ entities: ['calendar.family'], locale: 'en-US', time_zone: 'America/New_York' });
+  card._events = [{
+    entityId: 'calendar.family',
+    color: '#3366ff',
+    summary: 'Late UTC event',
+    start: { dateTime: '2026-01-02T02:00:00Z' },
+    end: { dateTime: '2026-01-02T03:00:00Z' }
+  }];
+
+  const jan1 = new Date(2026, 0, 1);
+  const jan2 = new Date(2026, 0, 2);
+  assert.equal(card.getEventsForDay(jan1).length, 1);
+  assert.equal(card.getEventsForDay(jan2).length, 0);
+
+  const segment = card.getEventDaySegment(card._events[0], jan1);
+  assert.equal(card.formatEventTimeRange(segment.segmentStart, segment.segmentEnd), '9:00 PM - 10:00 PM');
+  assert.equal(card.getLocalDayHourFloat(segment.segmentStart, jan1), 21);
 });
 
 test('default_hidden_calendars initializes hidden calendar badges', () => {


### PR DESCRIPTION
### Motivation
- Provide a card-level timezone override for browsers/WebViews that report the wrong local timezone so event formatting and placement match the intended IANA zone. 
- Preserve existing behavior when the option is unset and fail-safe ignore blank/invalid values instead of throwing. 
- Centralize timezone logic to avoid scattering `toLocale*`/`getHours()` hacks and ensure calculations (grouping, week placement, schedule positioning) use the configured zone consistently.

### Description
- Add an optional `time_zone` config key to the normalization schema and stub config and validate/normalize it with `normalizeTimeZone()` using `Intl.DateTimeFormat`; invalid or blank values are ignored with a `console.warn`. 
- Introduce centralized helpers: `getConfiguredTimeZone()`, `withTimeZone()`, `getDateTimeParts()`, `getDateParts()`, `zonedTimeToDate()`, and `getDayBounds()` and use them for zone-aware date parts and conversions. 
- Apply the configured timezone to all visible formatting and calculation points by switching many `Intl.DateTimeFormat(...)` usages to `this.withTimeZone(...)` and replacing direct `getHours()/getDate()`-based logic with the new helpers (notably `getLocalDayHourFloat`, `getDateKey`/`getLocalDateKey`, `getEventDaySegment`/day bounds and schedule calculations). 
- Add tests exercising unset/valid/invalid `time_zone`, formatting differences for an ISO event when a zone is specified, and timezone-driven event grouping/placement; and document the option in `docs/configuration/display.mdx` including the example `time_zone: America/New_York`.

### Testing
- Ran syntax check with `node --check skylight-calendar-card.js` which succeeded. 
- Ran unit tests with `npm test` and all tests passed (TAP output indicates `# pass 202` and `# fail 0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34d1fb40648331941e2a87f5227b01)