### PR TITLE
Fix timezone handling for synthetic display dates and all-day events

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3574,6 +3574,13 @@ class SkylightCalendarCard extends HTMLElement {
     return new Date(year, month - 1, day);
   }
 
+  parseCalendarDate(dateStr) {
+    if (!dateStr || typeof dateStr !== 'string') return new Date(dateStr);
+    const [year, month, day] = dateStr.split('-').map(Number);
+    if (![year, month, day].every(Number.isFinite)) return new Date(dateStr);
+    return this.zonedTimeToDate(year, month, day, 0, 0, 0, 0);
+  }
+
   parsePossiblyLocalDateTime(value) {
     if (!value || typeof value !== 'string') return new Date(value);
 
@@ -7389,7 +7396,7 @@ class SkylightCalendarCard extends HTMLElement {
       formatOptions.year = 'numeric';
     }
 
-    const formatter = new Intl.DateTimeFormat(this.getLocale(), this.withTimeZone(formatOptions));
+    const formatter = new Intl.DateTimeFormat(this.getLocale(), formatOptions);
 
     if (!includeYear) {
       if (startDate.getTime() === endDate.getTime()) {
@@ -9264,8 +9271,8 @@ class SkylightCalendarCard extends HTMLElement {
 
     if (event.start.date) {
       return {
-        eventStart: this.parseLocalDate(event.start.date),
-        eventEnd: this.parseLocalDate(event.end.date),
+        eventStart: this.parseCalendarDate(event.start.date),
+        eventEnd: this.parseCalendarDate(event.end.date),
         isAllDay: true
       };
     }
@@ -11576,9 +11583,9 @@ class SkylightCalendarCard extends HTMLElement {
       endDate = new Date(event.end.dateTime);
       isAllDay = false;
     } else if (event.start.date) {
-      // For all-day events, add T00:00:00 to prevent timezone shifts
-      startDate = this.parseLocalDate(event.start.date);
-      endDate = this.parseLocalDate(event.end.date);
+      // Date-only all-day events use configured-zone calendar bounds for display.
+      startDate = this.parseCalendarDate(event.start.date);
+      endDate = this.parseCalendarDate(event.end.date);
 
       // End date is exclusive for all-day events, so subtract 1 day for display
       endDate.setDate(endDate.getDate() - 1);
@@ -11749,7 +11756,7 @@ class SkylightCalendarCard extends HTMLElement {
 
     content.innerHTML = `
       <div class="modal-header">
-        <h3 class="modal-title">${this.formatDate(date)}</h3>
+        <h3 class="modal-title">${this.formatDisplayDate(date)}</h3>
         <button class="modal-close" id="close-modal">×</button>
       </div>
       <div class="modal-body">
@@ -11805,7 +11812,7 @@ class SkylightCalendarCard extends HTMLElement {
 
     content.innerHTML = `
       <div class="modal-header">
-        <h3 class="modal-title">${this.formatDate(date)}</h3>
+        <h3 class="modal-title">${this.formatDisplayDate(date)}</h3>
         <button class="modal-close" id="close-modal">×</button>
       </div>
       <div class="modal-body">
@@ -12148,6 +12155,10 @@ class SkylightCalendarCard extends HTMLElement {
 
   formatDate(date) {
     return new Intl.DateTimeFormat(this.getLocale(), this.withTimeZone({ weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })).format(date);
+  }
+
+  formatDisplayDate(date) {
+    return new Intl.DateTimeFormat(this.getLocale(), { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' }).format(date);
   }
 
   formatDuration(startDate, endDate) {

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3581,6 +3581,14 @@ class SkylightCalendarCard extends HTMLElement {
     return this.zonedTimeToDate(year, month, day, 0, 0, 0, 0);
   }
 
+  parseCalendarDateWithOffset(dateStr, dayOffset = 0) {
+    if (!dateStr || typeof dateStr !== 'string') return new Date(dateStr);
+    const [year, month, day] = dateStr.split('-').map(Number);
+    if (![year, month, day].every(Number.isFinite)) return new Date(dateStr);
+    const adjusted = new Date(Date.UTC(year, month - 1, day + dayOffset));
+    return this.zonedTimeToDate(adjusted.getUTCFullYear(), adjusted.getUTCMonth() + 1, adjusted.getUTCDate(), 0, 0, 0, 0);
+  }
+
   parsePossiblyLocalDateTime(value) {
     if (!value || typeof value !== 'string') return new Date(value);
 
@@ -11585,10 +11593,9 @@ class SkylightCalendarCard extends HTMLElement {
     } else if (event.start.date) {
       // Date-only all-day events use configured-zone calendar bounds for display.
       startDate = this.parseCalendarDate(event.start.date);
-      endDate = this.parseCalendarDate(event.end.date);
-
-      // End date is exclusive for all-day events, so subtract 1 day for display
-      endDate.setDate(endDate.getDate() - 1);
+      // End date is exclusive for all-day events, so subtract a configured-zone
+      // calendar day before converting to a Date for display.
+      endDate = this.parseCalendarDateWithOffset(event.end.date, -1);
       isAllDay = true;
     } else {
       startDate = new Date(event.start);

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -617,6 +617,29 @@ test('time_zone compares date-only all-day events using configured-zone day boun
   assert.equal(segment.segmentEnd.toISOString(), '2026-01-02T05:00:00.000Z');
 });
 
+test('time_zone subtracts all-day modal end dates as configured-zone calendar days across DST', () => {
+  const card = makeCard({ entities: ['calendar.family'], locale: 'en-US', time_zone: 'America/New_York' });
+  const content = { innerHTML: '', classList: { add: () => {}, remove: () => {} } };
+  const modal = { classList: { add: () => {}, remove: () => {} } };
+
+  card.getRootElementById = (id) => {
+    if (id === 'event-modal') return modal;
+    if (id === 'modal-content') return content;
+    return null;
+  };
+
+  card.showEventModal({
+    entityId: 'calendar.family',
+    color: '#3366ff',
+    summary: 'DST all-day',
+    start: { date: '2025-03-09' },
+    end: { date: '2025-03-10' }
+  });
+
+  assert.match(content.innerHTML, /Sunday, March 9, 2025 \(All Day\)/);
+  assert.doesNotMatch(content.innerHTML, /Saturday, March 8, 2025 \(All Day\)/);
+});
+
 test('default_hidden_calendars initializes hidden calendar badges', () => {
   const card = makeCard({
     entities: ['calendar.family', 'calendar.work'],

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -582,6 +582,41 @@ test('time_zone controls event day grouping and week placement calculations', ()
   assert.equal(card.getLocalDayHourFloat(segment.segmentStart, jan1), 21);
 });
 
+test('time_zone does not shift synthetic display date labels west of browser zone', () => {
+  const card = makeCard({
+    entities: ['calendar.family'],
+    locale: 'en-US',
+    time_zone: 'America/New_York',
+    rolling_days_week_compact: 0
+  });
+  card._viewMode = 'week-compact';
+  card._currentDate = new Date('2026-01-01T00:00:00Z');
+
+  assert.equal(card.getPeriodLabel(), 'Jan 1, 2026');
+  assert.match(card.formatDisplayDate(card.getWeekDays()[0]), /Thursday, January 1, 2026/);
+});
+
+test('time_zone compares date-only all-day events using configured-zone day bounds', () => {
+  const card = makeCard({ entities: ['calendar.family'], locale: 'en-US', time_zone: 'America/New_York' });
+  card._events = [{
+    entityId: 'calendar.family',
+    color: '#3366ff',
+    summary: 'New Year all-day',
+    start: { date: '2026-01-01' },
+    end: { date: '2026-01-02' }
+  }];
+
+  const dec31 = new Date('2025-12-31T00:00:00Z');
+  const jan1 = new Date('2026-01-01T00:00:00Z');
+  assert.equal(card.getEventsForDay(dec31).length, 0);
+  assert.equal(card.getEventsForDay(jan1).length, 1);
+
+  const segment = card.getEventDaySegment(card._events[0], jan1);
+  assert.equal(segment.isAllDaySegment, true);
+  assert.equal(segment.segmentStart.toISOString(), '2026-01-01T05:00:00.000Z');
+  assert.equal(segment.segmentEnd.toISOString(), '2026-01-02T05:00:00.000Z');
+});
+
 test('default_hidden_calendars initializes hidden calendar badges', () => {
   const card = makeCard({
     entities: ['calendar.family', 'calendar.work'],


### PR DESCRIPTION
### Motivation
- Synthetic day objects and period labels were being formatted as instants using the configured `time_zone`, causing labels to shift one day when the configured zone is west of the browser/WebView zone. 
- Date-only (all-day) events were parsed at browser-local midnight but compared against configured-zone day bounds, producing spurious overlaps onto the previous displayed day.

### Description
- Add `parseCalendarDate(dateStr)` which constructs a date at midnight in the configured zone using `zonedTimeToDate` and use it for date-only calendar values instead of `parseLocalDate`.
- Use `parseCalendarDate` in `getEventDateTimeInfo` and in event modal parsing so date-only all-day start/end bounds use configured-zone calendar day bounds.
- Stop applying the configured timezone when formatting synthetic display dates and period ranges by formatting display parts in the WebView zone: replace `Intl.DateTimeFormat(..., this.withTimeZone(...))` with a formatter that omits the timezone for period/day-modal titles and add `formatDisplayDate(date)` for day-modal headers.
- Add regression tests in `skylight-calendar-card.test.js` to assert that synthetic period labels are not shifted (`time_zone does not shift synthetic display date labels west of browser zone`) and that date-only all-day events use configured-zone day bounds (`time_zone compares date-only all-day events using configured-zone day bounds`).

### Testing
- Ran the unit test suite with `node --test skylight-calendar-card.test.js`, which completed successfully (all tests passed).
- Added tests: `time_zone does not shift synthetic display date labels west of browser zone` and `time_zone compares date-only all-day events using configured-zone day bounds`, both included in the test run and passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a354db5991083319ecc68d2341a6815)