### PR TITLE
Phase 5 modularization: extract pure utility helpers

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1158,6 +1158,44 @@ function getIsoWeekNumber(date) {
   return Math.ceil((((utcDate - yearStart) / 86400000) + 1) / 7);
 }
 
+function normalizeDashboardPath(pathValue) {
+  if (typeof pathValue !== 'string') return null;
+  const trimmedPath = pathValue.trim();
+  if (!trimmedPath) return null;
+  return trimmedPath.startsWith('/') ? trimmedPath : `/${trimmedPath}`;
+}
+
+function normalizeEnumValue(value, { aliases = {}, allowed = [], fallback }) {
+  const normalizedValue = String(value ?? '').trim().toLowerCase();
+  const mappedValue = aliases[normalizedValue] ?? normalizedValue;
+  return allowed.includes(mappedValue) ? mappedValue : fallback;
+}
+
+function normalizeEntityStringMap(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  return Object.entries(value).reduce((acc, [key, mappedValue]) => {
+    const normalizedKey = typeof key === 'string' ? key.trim() : '';
+    const normalizedValue = typeof mappedValue === 'string' ? mappedValue.trim() : '';
+    if (normalizedKey && normalizedValue) {
+      acc[normalizedKey] = normalizedValue;
+    }
+    return acc;
+  }, {});
+}
+
+function normalizeBooleanStyleValue(value) {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    const normalizedValue = value.trim().toLowerCase();
+    if (normalizedValue === 'true') return true;
+    if (normalizedValue === 'false') return false;
+  }
+  return null;
+}
+
 function normalizeEventTextValue(value) {
   return String(value || '')
     .normalize('NFKC')
@@ -1351,10 +1389,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   normalizeDashboardPath(pathValue) {
-    if (typeof pathValue !== 'string') return null;
-    const trimmedPath = pathValue.trim();
-    if (!trimmedPath) return null;
-    return trimmedPath.startsWith('/') ? trimmedPath : `/${trimmedPath}`;
+    return normalizeDashboardPath(pathValue);
   }
 
   getConfiguredDashboardPath() {
@@ -1365,10 +1400,8 @@ class SkylightCalendarCard extends HTMLElement {
     return !!(this._config?.show_dashboard_nav_button && this.getConfiguredDashboardPath());
   }
 
-  normalizeEnumValue(value, { aliases = {}, allowed = [], fallback }) {
-    const normalizedValue = String(value ?? '').trim().toLowerCase();
-    const mappedValue = aliases[normalizedValue] ?? normalizedValue;
-    return allowed.includes(mappedValue) ? mappedValue : fallback;
+  normalizeEnumValue(value, options) {
+    return normalizeEnumValue(value, options);
   }
 
   normalizeDefaultDarkMode(value) {
@@ -1404,28 +1437,11 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   normalizeEntityStringMap(value) {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) {
-      return {};
-    }
-
-    return Object.entries(value).reduce((acc, [key, mappedValue]) => {
-      const normalizedKey = typeof key === 'string' ? key.trim() : '';
-      const normalizedValue = typeof mappedValue === 'string' ? mappedValue.trim() : '';
-      if (normalizedKey && normalizedValue) {
-        acc[normalizedKey] = normalizedValue;
-      }
-      return acc;
-    }, {});
+    return normalizeEntityStringMap(value);
   }
 
   normalizeBooleanStyleValue(value) {
-    if (typeof value === 'boolean') return value;
-    if (typeof value === 'string') {
-      const normalizedValue = value.trim().toLowerCase();
-      if (normalizedValue === 'true') return true;
-      if (normalizedValue === 'false') return false;
-    }
-    return null;
+    return normalizeBooleanStyleValue(value);
   }
 
   applyThemeMode(mode = this._themeMode) {

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1091,6 +1091,91 @@ const TRANSLATIONS = {
   }
 };
 
+function getDateRangeChunks(startDate, endDate, chunkDays = 30) {
+  const chunks = [];
+  let cursor = new Date(startDate);
+  cursor.setHours(0, 0, 0, 0);
+
+  while (cursor <= endDate) {
+    const chunkStart = new Date(cursor);
+    const chunkEnd = new Date(cursor);
+    chunkEnd.setDate(chunkEnd.getDate() + chunkDays - 1);
+    if (chunkEnd > endDate) {
+      chunkEnd.setTime(endDate.getTime());
+    }
+    chunkEnd.setHours(23, 59, 59, 999);
+
+    chunks.push({ startDate: chunkStart, endDate: chunkEnd });
+
+    cursor = new Date(chunkEnd);
+    cursor.setDate(cursor.getDate() + 1);
+    cursor.setHours(0, 0, 0, 0);
+  }
+
+  return chunks;
+}
+
+function parseLocalDate(dateStr) {
+  if (!dateStr || typeof dateStr !== 'string') return new Date(dateStr);
+  const [year, month, day] = dateStr.split('-').map(Number);
+  if (![year, month, day].every(Number.isFinite)) return new Date(dateStr);
+  return new Date(year, month - 1, day);
+}
+
+function parsePossiblyLocalDateTime(value) {
+  if (!value || typeof value !== 'string') return new Date(value);
+
+  const hasTimezone = /(?:[zZ]|[+-]\d{2}:?\d{2})$/.test(value);
+  if (hasTimezone) return new Date(value);
+
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?$/);
+  if (!match) return new Date(value);
+
+  const [, year, month, day, hour, minute, second = '0'] = match;
+  return new Date(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute),
+    Number(second)
+  );
+}
+
+function formatLocalDate(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '';
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function getIsoWeekNumber(date) {
+  const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const dayNumber = utcDate.getUTCDay() || 7;
+  utcDate.setUTCDate(utcDate.getUTCDate() + 4 - dayNumber);
+  const yearStart = new Date(Date.UTC(utcDate.getUTCFullYear(), 0, 1));
+  return Math.ceil((((utcDate - yearStart) / 86400000) + 1) / 7);
+}
+
+function normalizeEventTextValue(value) {
+  return String(value || '')
+    .normalize('NFKC')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function escapeHtmlAttribute(text) {
+  const replacements = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+  };
+  return String(text ?? '').replace(/[&<>"']/g, (char) => replacements[char]);
+}
+
 const DAYLIGHT_CALENDAR_CARD_VERSION = 'v4.5.0';
 
 function getDaylightCalendarCardVersion() {
@@ -3705,27 +3790,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getDateRangeChunks(startDate, endDate, chunkDays = 30) {
-    const chunks = [];
-    let cursor = new Date(startDate);
-    cursor.setHours(0, 0, 0, 0);
-
-    while (cursor <= endDate) {
-      const chunkStart = new Date(cursor);
-      const chunkEnd = new Date(cursor);
-      chunkEnd.setDate(chunkEnd.getDate() + chunkDays - 1);
-      if (chunkEnd > endDate) {
-        chunkEnd.setTime(endDate.getTime());
-      }
-      chunkEnd.setHours(23, 59, 59, 999);
-
-      chunks.push({ startDate: chunkStart, endDate: chunkEnd });
-
-      cursor = new Date(chunkEnd);
-      cursor.setDate(cursor.getDate() + 1);
-      cursor.setHours(0, 0, 0, 0);
-    }
-
-    return chunks;
+    return getDateRangeChunks(startDate, endDate, chunkDays);
   }
 
   getEventStartDate(event) {
@@ -3735,10 +3800,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   parseLocalDate(dateStr) {
-    if (!dateStr || typeof dateStr !== 'string') return new Date(dateStr);
-    const [year, month, day] = dateStr.split('-').map(Number);
-    if (![year, month, day].every(Number.isFinite)) return new Date(dateStr);
-    return new Date(year, month - 1, day);
+    return parseLocalDate(dateStr);
   }
 
   parseCalendarDate(dateStr) {
@@ -3757,31 +3819,11 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   parsePossiblyLocalDateTime(value) {
-    if (!value || typeof value !== 'string') return new Date(value);
-
-    const hasTimezone = /(?:[zZ]|[+-]\d{2}:?\d{2})$/.test(value);
-    if (hasTimezone) return new Date(value);
-
-    const match = value.match(/^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?$/);
-    if (!match) return new Date(value);
-
-    const [, year, month, day, hour, minute, second = '0'] = match;
-    return new Date(
-      Number(year),
-      Number(month) - 1,
-      Number(day),
-      Number(hour),
-      Number(minute),
-      Number(second)
-    );
+    return parsePossiblyLocalDateTime(value);
   }
 
   formatLocalDate(date) {
-    if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '';
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-    return `${year}-${month}-${day}`;
+    return formatLocalDate(date);
   }
 
 
@@ -8952,11 +8994,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getIsoWeekNumber(date) {
-    const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
-    const dayNumber = utcDate.getUTCDay() || 7;
-    utcDate.setUTCDate(utcDate.getUTCDate() + 4 - dayNumber);
-    const yearStart = new Date(Date.UTC(utcDate.getUTCFullYear(), 0, 1));
-    return Math.ceil((((utcDate - yearStart) / 86400000) + 1) / 7);
+    return getIsoWeekNumber(date);
   }
 
   formatMonthWeekNumberLabel(date) {
@@ -9098,10 +9136,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   normalizeEventTextValue(value) {
-    return String(value || '')
-      .normalize('NFKC')
-      .replace(/\s+/g, ' ')
-      .trim();
+    return normalizeEventTextValue(value);
   }
 
   getNormalizedEventTimeValue(value) {
@@ -12761,14 +12796,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   escapeHtmlAttribute(text) {
-    const replacements = {
-      '&': '&amp;',
-      '<': '&lt;',
-      '>': '&gt;',
-      '"': '&quot;',
-      "'": '&#39;'
-    };
-    return String(text ?? '').replace(/[&<>"']/g, (char) => replacements[char]);
+    return escapeHtmlAttribute(text);
   }
 
   normalizeBackgroundImageUrl(url) {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -3819,3 +3819,40 @@ test('advanced style conflict behavior is per property with priority and earlier
   assert.equal(dayStyle.background, '#555555');
   assert.equal(dayStyle.opacity, 0.8);
 });
+
+test('date utility helpers preserve local date and ISO week behavior', async () => {
+  const {
+    formatLocalDate,
+    getDateRangeChunks,
+    getIsoWeekNumber,
+    parseLocalDate,
+    parsePossiblyLocalDateTime
+  } = await import('./src/utils/date-utils.js');
+
+  assert.equal(formatLocalDate(new Date(2026, 5, 3)), '2026-06-03');
+  assert.equal(formatLocalDate(new Date('invalid')), '');
+  assert.deepEqual(
+    [parseLocalDate('2026-06-03').getFullYear(), parseLocalDate('2026-06-03').getMonth(), parseLocalDate('2026-06-03').getDate()],
+    [2026, 5, 3]
+  );
+  assert.deepEqual(
+    [parsePossiblyLocalDateTime('2026-06-03T04:05:06').getFullYear(), parsePossiblyLocalDateTime('2026-06-03T04:05:06').getMonth(), parsePossiblyLocalDateTime('2026-06-03T04:05:06').getDate(), parsePossiblyLocalDateTime('2026-06-03T04:05:06').getHours()],
+    [2026, 5, 3, 4]
+  );
+  assert.equal(getIsoWeekNumber(new Date(2021, 0, 4)), 1);
+  assert.equal(getIsoWeekNumber(new Date(2020, 11, 31)), 53);
+
+  const chunks = getDateRangeChunks(new Date(2026, 0, 1, 12), new Date(2026, 0, 5, 9), 2);
+  assert.equal(chunks.length, 3);
+  assert.equal(formatLocalDate(chunks[0].startDate), '2026-01-01');
+  assert.equal(formatLocalDate(chunks[0].endDate), '2026-01-02');
+  assert.equal(formatLocalDate(chunks[2].startDate), '2026-01-05');
+});
+
+test('string utility helpers preserve normalization and attribute escaping', async () => {
+  const { escapeHtmlAttribute, normalizeEventTextValue } = await import('./src/utils/string-utils.js');
+
+  assert.equal(normalizeEventTextValue('  Team\n\tSync  '), 'Team Sync');
+  assert.equal(normalizeEventTextValue('ＡＢＣ'), 'ABC');
+  assert.equal(escapeHtmlAttribute('Team "sync" & <review> \'plan\''), 'Team &quot;sync&quot; &amp; &lt;review&gt; &#39;plan&#39;');
+});

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -3856,3 +3856,29 @@ test('string utility helpers preserve normalization and attribute escaping', asy
   assert.equal(normalizeEventTextValue('ＡＢＣ'), 'ABC');
   assert.equal(escapeHtmlAttribute('Team "sync" & <review> \'plan\''), 'Team &quot;sync&quot; &amp; &lt;review&gt; &#39;plan&#39;');
 });
+
+test('normalization utility helpers preserve dashboard, enum, map, and boolean behavior', async () => {
+  const {
+    normalizeBooleanStyleValue,
+    normalizeDashboardPath,
+    normalizeEntityStringMap,
+    normalizeEnumValue
+  } = await import('./src/utils/normalization-utils.js');
+
+  assert.equal(normalizeDashboardPath(' lovelace/home '), '/lovelace/home');
+  assert.equal(normalizeDashboardPath('/lovelace/home'), '/lovelace/home');
+  assert.equal(normalizeDashboardPath('   '), null);
+  assert.equal(normalizeDashboardPath(null), null);
+
+  assert.equal(normalizeEnumValue(' Week ', { aliases: { week: 'week-compact' }, allowed: ['month', 'week-compact'], fallback: 'month' }), 'week-compact');
+  assert.equal(normalizeEnumValue('bad', { allowed: ['month'], fallback: 'month' }), 'month');
+
+  assert.deepEqual(normalizeEntityStringMap({ ' calendar.work ': ' Work ', '': 'Empty', 'calendar.blank': '   ', 'calendar.number': 5 }), {
+    'calendar.work': 'Work'
+  });
+  assert.deepEqual(normalizeEntityStringMap(['calendar.work']), {});
+
+  assert.equal(normalizeBooleanStyleValue(true), true);
+  assert.equal(normalizeBooleanStyleValue(' false '), false);
+  assert.equal(normalizeBooleanStyleValue('maybe'), null);
+});

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -31,6 +31,14 @@ import {
   VISIBLE_CALENDAR_VISIBILITY_VALUES
 } from './defaults.js';
 import { TRANSLATIONS } from './translations.js';
+import {
+  formatLocalDate,
+  getDateRangeChunks,
+  getIsoWeekNumber,
+  parseLocalDate,
+  parsePossiblyLocalDateTime
+} from './utils/date-utils.js';
+import { escapeHtmlAttribute, normalizeEventTextValue } from './utils/string-utils.js';
 
 const DAYLIGHT_CALENDAR_CARD_VERSION = 'v4.5.0';
 
@@ -2646,27 +2654,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getDateRangeChunks(startDate, endDate, chunkDays = 30) {
-    const chunks = [];
-    let cursor = new Date(startDate);
-    cursor.setHours(0, 0, 0, 0);
-
-    while (cursor <= endDate) {
-      const chunkStart = new Date(cursor);
-      const chunkEnd = new Date(cursor);
-      chunkEnd.setDate(chunkEnd.getDate() + chunkDays - 1);
-      if (chunkEnd > endDate) {
-        chunkEnd.setTime(endDate.getTime());
-      }
-      chunkEnd.setHours(23, 59, 59, 999);
-
-      chunks.push({ startDate: chunkStart, endDate: chunkEnd });
-
-      cursor = new Date(chunkEnd);
-      cursor.setDate(cursor.getDate() + 1);
-      cursor.setHours(0, 0, 0, 0);
-    }
-
-    return chunks;
+    return getDateRangeChunks(startDate, endDate, chunkDays);
   }
 
   getEventStartDate(event) {
@@ -2676,10 +2664,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   parseLocalDate(dateStr) {
-    if (!dateStr || typeof dateStr !== 'string') return new Date(dateStr);
-    const [year, month, day] = dateStr.split('-').map(Number);
-    if (![year, month, day].every(Number.isFinite)) return new Date(dateStr);
-    return new Date(year, month - 1, day);
+    return parseLocalDate(dateStr);
   }
 
   parseCalendarDate(dateStr) {
@@ -2698,31 +2683,11 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   parsePossiblyLocalDateTime(value) {
-    if (!value || typeof value !== 'string') return new Date(value);
-
-    const hasTimezone = /(?:[zZ]|[+-]\d{2}:?\d{2})$/.test(value);
-    if (hasTimezone) return new Date(value);
-
-    const match = value.match(/^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?$/);
-    if (!match) return new Date(value);
-
-    const [, year, month, day, hour, minute, second = '0'] = match;
-    return new Date(
-      Number(year),
-      Number(month) - 1,
-      Number(day),
-      Number(hour),
-      Number(minute),
-      Number(second)
-    );
+    return parsePossiblyLocalDateTime(value);
   }
 
   formatLocalDate(date) {
-    if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '';
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-    return `${year}-${month}-${day}`;
+    return formatLocalDate(date);
   }
 
 
@@ -7893,11 +7858,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getIsoWeekNumber(date) {
-    const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
-    const dayNumber = utcDate.getUTCDay() || 7;
-    utcDate.setUTCDate(utcDate.getUTCDate() + 4 - dayNumber);
-    const yearStart = new Date(Date.UTC(utcDate.getUTCFullYear(), 0, 1));
-    return Math.ceil((((utcDate - yearStart) / 86400000) + 1) / 7);
+    return getIsoWeekNumber(date);
   }
 
   formatMonthWeekNumberLabel(date) {
@@ -8039,10 +8000,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   normalizeEventTextValue(value) {
-    return String(value || '')
-      .normalize('NFKC')
-      .replace(/\s+/g, ' ')
-      .trim();
+    return normalizeEventTextValue(value);
   }
 
   getNormalizedEventTimeValue(value) {
@@ -11702,14 +11660,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   escapeHtmlAttribute(text) {
-    const replacements = {
-      '&': '&amp;',
-      '<': '&lt;',
-      '>': '&gt;',
-      '"': '&quot;',
-      "'": '&#39;'
-    };
-    return String(text ?? '').replace(/[&<>"']/g, (char) => replacements[char]);
+    return escapeHtmlAttribute(text);
   }
 
   normalizeBackgroundImageUrl(url) {

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -38,6 +38,12 @@ import {
   parseLocalDate,
   parsePossiblyLocalDateTime
 } from './utils/date-utils.js';
+import {
+  normalizeBooleanStyleValue,
+  normalizeDashboardPath,
+  normalizeEntityStringMap,
+  normalizeEnumValue
+} from './utils/normalization-utils.js';
 import { escapeHtmlAttribute, normalizeEventTextValue } from './utils/string-utils.js';
 
 const DAYLIGHT_CALENDAR_CARD_VERSION = 'v4.5.0';
@@ -215,10 +221,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   normalizeDashboardPath(pathValue) {
-    if (typeof pathValue !== 'string') return null;
-    const trimmedPath = pathValue.trim();
-    if (!trimmedPath) return null;
-    return trimmedPath.startsWith('/') ? trimmedPath : `/${trimmedPath}`;
+    return normalizeDashboardPath(pathValue);
   }
 
   getConfiguredDashboardPath() {
@@ -229,10 +232,8 @@ class SkylightCalendarCard extends HTMLElement {
     return !!(this._config?.show_dashboard_nav_button && this.getConfiguredDashboardPath());
   }
 
-  normalizeEnumValue(value, { aliases = {}, allowed = [], fallback }) {
-    const normalizedValue = String(value ?? '').trim().toLowerCase();
-    const mappedValue = aliases[normalizedValue] ?? normalizedValue;
-    return allowed.includes(mappedValue) ? mappedValue : fallback;
+  normalizeEnumValue(value, options) {
+    return normalizeEnumValue(value, options);
   }
 
   normalizeDefaultDarkMode(value) {
@@ -268,28 +269,11 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   normalizeEntityStringMap(value) {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) {
-      return {};
-    }
-
-    return Object.entries(value).reduce((acc, [key, mappedValue]) => {
-      const normalizedKey = typeof key === 'string' ? key.trim() : '';
-      const normalizedValue = typeof mappedValue === 'string' ? mappedValue.trim() : '';
-      if (normalizedKey && normalizedValue) {
-        acc[normalizedKey] = normalizedValue;
-      }
-      return acc;
-    }, {});
+    return normalizeEntityStringMap(value);
   }
 
   normalizeBooleanStyleValue(value) {
-    if (typeof value === 'boolean') return value;
-    if (typeof value === 'string') {
-      const normalizedValue = value.trim().toLowerCase();
-      if (normalizedValue === 'true') return true;
-      if (normalizedValue === 'false') return false;
-    }
-    return null;
+    return normalizeBooleanStyleValue(value);
   }
 
   applyThemeMode(mode = this._themeMode) {

--- a/src/utils/date-utils.js
+++ b/src/utils/date-utils.js
@@ -1,0 +1,66 @@
+export function getDateRangeChunks(startDate, endDate, chunkDays = 30) {
+  const chunks = [];
+  let cursor = new Date(startDate);
+  cursor.setHours(0, 0, 0, 0);
+
+  while (cursor <= endDate) {
+    const chunkStart = new Date(cursor);
+    const chunkEnd = new Date(cursor);
+    chunkEnd.setDate(chunkEnd.getDate() + chunkDays - 1);
+    if (chunkEnd > endDate) {
+      chunkEnd.setTime(endDate.getTime());
+    }
+    chunkEnd.setHours(23, 59, 59, 999);
+
+    chunks.push({ startDate: chunkStart, endDate: chunkEnd });
+
+    cursor = new Date(chunkEnd);
+    cursor.setDate(cursor.getDate() + 1);
+    cursor.setHours(0, 0, 0, 0);
+  }
+
+  return chunks;
+}
+
+export function parseLocalDate(dateStr) {
+  if (!dateStr || typeof dateStr !== 'string') return new Date(dateStr);
+  const [year, month, day] = dateStr.split('-').map(Number);
+  if (![year, month, day].every(Number.isFinite)) return new Date(dateStr);
+  return new Date(year, month - 1, day);
+}
+
+export function parsePossiblyLocalDateTime(value) {
+  if (!value || typeof value !== 'string') return new Date(value);
+
+  const hasTimezone = /(?:[zZ]|[+-]\d{2}:?\d{2})$/.test(value);
+  if (hasTimezone) return new Date(value);
+
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?$/);
+  if (!match) return new Date(value);
+
+  const [, year, month, day, hour, minute, second = '0'] = match;
+  return new Date(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute),
+    Number(second)
+  );
+}
+
+export function formatLocalDate(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '';
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function getIsoWeekNumber(date) {
+  const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const dayNumber = utcDate.getUTCDay() || 7;
+  utcDate.setUTCDate(utcDate.getUTCDate() + 4 - dayNumber);
+  const yearStart = new Date(Date.UTC(utcDate.getUTCFullYear(), 0, 1));
+  return Math.ceil((((utcDate - yearStart) / 86400000) + 1) / 7);
+}

--- a/src/utils/normalization-utils.js
+++ b/src/utils/normalization-utils.js
@@ -1,0 +1,37 @@
+export function normalizeDashboardPath(pathValue) {
+  if (typeof pathValue !== 'string') return null;
+  const trimmedPath = pathValue.trim();
+  if (!trimmedPath) return null;
+  return trimmedPath.startsWith('/') ? trimmedPath : `/${trimmedPath}`;
+}
+
+export function normalizeEnumValue(value, { aliases = {}, allowed = [], fallback }) {
+  const normalizedValue = String(value ?? '').trim().toLowerCase();
+  const mappedValue = aliases[normalizedValue] ?? normalizedValue;
+  return allowed.includes(mappedValue) ? mappedValue : fallback;
+}
+
+export function normalizeEntityStringMap(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  return Object.entries(value).reduce((acc, [key, mappedValue]) => {
+    const normalizedKey = typeof key === 'string' ? key.trim() : '';
+    const normalizedValue = typeof mappedValue === 'string' ? mappedValue.trim() : '';
+    if (normalizedKey && normalizedValue) {
+      acc[normalizedKey] = normalizedValue;
+    }
+    return acc;
+  }, {});
+}
+
+export function normalizeBooleanStyleValue(value) {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    const normalizedValue = value.trim().toLowerCase();
+    if (normalizedValue === 'true') return true;
+    if (normalizedValue === 'false') return false;
+  }
+  return null;
+}

--- a/src/utils/string-utils.js
+++ b/src/utils/string-utils.js
@@ -1,0 +1,17 @@
+export function normalizeEventTextValue(value) {
+  return String(value || '')
+    .normalize('NFKC')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function escapeHtmlAttribute(text) {
+  const replacements = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+  };
+  return String(text ?? '').replace(/[&<>"']/g, (char) => replacements[char]);
+}


### PR DESCRIPTION
### Motivation
- Continue the modularization refactor by moving clearly pure utility helpers out of the large `src/skylight-calendar-card.js` file into dedicated modules to improve maintainability while preserving runtime behavior.
- This change is strictly mechanical and behavior-preserving: helpers were moved only when they are pure (no instance state, DOM, hass, or rendering dependencies).

### Description
- Extracted date helpers into `src/utils/date-utils.js`: `getDateRangeChunks`, `parseLocalDate`, `parsePossiblyLocalDateTime`, `formatLocalDate`, and `getIsoWeekNumber` and re-used them from `src/skylight-calendar-card.js` via imports while keeping the original card method names as thin wrappers.
- Extracted string helpers into `src/utils/string-utils.js`: `normalizeEventTextValue` and `escapeHtmlAttribute` and imported them into `src/skylight-calendar-card.js`, preserving existing call sites.
- Added targeted unit tests that import and verify the moved utilities in `skylight-calendar-card.test.js` and preserved the original behavior of the card by keeping non-pure helpers in place.
- Rollup was run to regenerate the root shipped artifact `skylight-calendar-card.js`, and the artifact name/entrypoint were preserved; no runtime API, DOM structure, CSS classes, translation strings, or public config option names were changed.
- Left in place any helpers that are not pure or have hidden dependencies (examples: timezone-aware formatting and zoned helpers, DOM-based `escapeHtml`, color helpers that probe computed CSS, event/time formatting that depends on card config/locale, matching/style normalization tied to card state, day_styles/event_styles/day_badges, weather, editor, modal, and Home Assistant service logic).

### Testing
- Ran dependency install and build: `npm ci --no-audit --fund=false` and `npm run build` with Rollup to regenerate `skylight-calendar-card.js`, and the artifact was produced successfully.
- Performed static checks with `node --check` on `src/skylight-calendar-card.js`, `src/utils/date-utils.js`, `src/utils/string-utils.js`, and `skylight-calendar-card.js` and found no syntax errors.
- Ran unit tests: `npm test` — all unit tests passed (210 tests, 0 failures).
- Ran visual/browser tests: `npm run test:visual` — all visual Playwright tests passed (39 tests, 0 failures).

All automated checks listed above completed successfully and the change is limited to moving pure helpers and wiring imports so runtime behavior is preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3af5c1e79c8331bf8af18b032da882)