### PR TITLE
Phase 6.5: Add modularization checkpoint (src/README.md)

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,16 @@
+# Source map
+
+`src/skylight-calendar-card.js` is the Rollup entry point and the main custom element source for Daylight Calendar Card. It owns card-instance orchestration, Home Assistant integration glue, lifecycle methods, rendering, DOM updates, CSS, modals, and editor behavior.
+
+The root `skylight-calendar-card.js` file is generated from `src/skylight-calendar-card.js` and committed as the HACS/manual-install artifact. Run `npm run build` to regenerate it, then verify it is current with `git diff --exit-code -- skylight-calendar-card.js`.
+
+Current source module groups:
+
+- `translations.js`: translation data.
+- `constants.js`: shared static constants.
+- `defaults.js`: default config values, option lists, aliases, and stub config creation.
+- `utils/`: pure utility helpers.
+- `events/`: event normalization and event-related non-rendering helpers.
+- `rules/`: rule normalization and condition matching helpers.
+
+Future modules may be added as the card evolves. Keep runtime rendering, CSS, DOM structure, lifecycle, modal, editor, and service orchestration in `src/skylight-calendar-card.js` unless a change is explicitly scoped to move that area.


### PR DESCRIPTION
### Motivation
- Create a small consolidation checkpoint after Phases 1–6 to verify and document the current modularized source layout and CI/release enforcement without moving runtime logic or starting the next extraction phase.

### Description
- Added a concise `src/README.md` source module map documenting that `src/skylight-calendar-card.js` is the Rollup entry point, the root `skylight-calendar-card.js` is the generated HACS/manual-install artifact, how to regenerate it with `npm run build`, and the current module groups (`translations.js`, `constants.js`, `defaults.js`, `utils/`, `events/`, `rules/`).
- Inspected CI and release workflows and confirmed the Tests workflow already enforces artifact freshness via the `check:build` script (`npm run build && git diff --exit-code -- skylight-calendar-card.js`) and that the release/version workflow updates `src/skylight-calendar-card.js`, runs `npm run build`, validates source/generated versions, and includes both files in the release-prep PR; no workflow changes were required.
- Did not change runtime code, rendering, CSS, DOM, translations, public config names, custom elements, or `DAYLIGHT_CALENDAR_CARD_VERSION` and did not add dependencies or move functions between modules.

### Testing
- Ran `npm ci --no-audit --fund=false` (succeeded), `npm run build` (succeeded), and `git diff --exit-code -- skylight-calendar-card.js` (no differences; artifact is fresh).
- Ran `node --check src/skylight-calendar-card.js` and `node --check skylight-calendar-card.js` (both succeeded) and `npm test` (213 tests passed).
- Did not run `npm run test:visual` because this change is a workflow/documentation checkpoint only and does not affect rendering, CSS, DOM, layout, modal behavior, or visual output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b142d9a708331b4c3f0b4a7e3397a)