### PR TITLE
Move day-badge helpers into src/badges/day-badges.js (Phase 7)

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1091,6 +1091,179 @@ const TRANSLATIONS = {
   }
 };
 
+function normalizeDayBadgeBlock(rule = {}, {
+  normalizeEventTextValue,
+  normalizeDayBadgeDisplayColor,
+  normalizeStyleSizeValue
+} = {}) {
+  const normalized = {};
+  const text = normalizeEventTextValue(rule.text);
+  const icon = normalizeEventTextValue(rule.icon);
+  const normalizedText = text || '';
+  const normalizedIcon = icon || '';
+  if (normalizedText) normalized.text = normalizedText;
+  if (normalizedIcon) normalized.icon = normalizedIcon;
+
+  const backgroundColor = normalizeDayBadgeDisplayColor(rule.background_color);
+  if (backgroundColor) normalized.background_color = backgroundColor;
+  const color = normalizeDayBadgeDisplayColor(rule.color);
+  if (color) normalized.color = color;
+
+  const size = normalizeStyleSizeValue(rule.size);
+  if (size) normalized.size = size;
+
+  const fontSize = normalizeStyleSizeValue(rule.font_size);
+  if (fontSize) normalized.font_size = fontSize;
+  return normalized;
+}
+
+function isFullValueTemplate(value) {
+  return typeof value === 'string' && /^\s*\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}\s*$/.test(value);
+}
+
+function normalizeDayBadgeDisplayColor(value, { normalizeSingleColor } = {}) {
+  if (isFullValueTemplate(value)) return String(value).trim();
+  return normalizeSingleColor(value);
+}
+
+function normalizeResolvedDayBadgeDisplayColor(value, { normalizeSingleColor } = {}) {
+  const normalized = normalizeSingleColor(value);
+  if (typeof normalized !== 'string') return undefined;
+  const trimmed = normalized.trim();
+  if (!trimmed) return undefined;
+
+  if (/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(trimmed)) return trimmed;
+  if (/^rgba?\(\s*[+-]?(?:\d+|\d*\.\d+)%?\s*(?:,|\s)\s*[+-]?(?:\d+|\d*\.\d+)%?\s*(?:,|\s)\s*[+-]?(?:\d+|\d*\.\d+)%?(?:\s*(?:,|\/)\s*(?:[01](?:\.\d+)?|\.\d+|\d+%))?\s*\)$/i.test(trimmed)) return trimmed;
+  if (/^hsla?\(\s*[+-]?(?:\d+|\d*\.\d+)(?:deg|grad|rad|turn)?\s*(?:,|\s)\s*[+-]?(?:\d+|\d*\.\d+)%\s*(?:,|\s)\s*[+-]?(?:\d+|\d*\.\d+)%(?:\s*(?:,|\/)\s*(?:[01](?:\.\d+)?|\.\d+|\d+%))?\s*\)$/i.test(trimmed)) return trimmed;
+
+  return undefined;
+}
+
+function parseEventDescriptionJson(event) {
+  const raw = String(event?.description || '').trim();
+  if (!raw.startsWith('{') || !raw.endsWith('}')) return undefined;
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}
+
+function buildDayBadgeResolutionContext(date, matchedEvent, { formatLocalDate } = {}) {
+  const event = matchedEvent && typeof matchedEvent === 'object' ? matchedEvent : {};
+  const calendar = event.entityId || event.entity_id || event.calendar;
+  const title = event.summary || event.title;
+  return {
+    date: date instanceof Date && !Number.isNaN(date.getTime()) ? formatLocalDate(date) : date,
+    calendar,
+    title,
+    event: {
+      ...event,
+      calendar,
+      entity_id: event.entity_id || event.entityId,
+      title,
+      summary: event.summary || event.title,
+      description_json: parseEventDescriptionJson(event)
+    }
+  };
+}
+
+function resolveSafePath(path, context) {
+  if (typeof path !== 'string' || !path) return undefined;
+  const blockedSegments = new Set(['__proto__', 'prototype', 'constructor']);
+  const segments = path.split('.');
+  if (!segments.length) return undefined;
+
+  let current = context;
+  for (const segment of segments) {
+    if (!/^[A-Za-z0-9_-]+$/.test(segment) || blockedSegments.has(segment)) return undefined;
+    if (current === null || current === undefined || (typeof current !== 'object' && typeof current !== 'function')) return undefined;
+    if (!Object.prototype.hasOwnProperty.call(current, segment)) return undefined;
+    current = current[segment];
+  }
+
+  if (current === null || current === undefined) return undefined;
+  if (['string', 'number', 'boolean'].includes(typeof current)) return String(current);
+  return undefined;
+}
+
+function resolveDayBadgeDisplayValue(value, context) {
+  if (typeof value !== 'string') return value;
+  const match = value.match(/^\s*\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}\s*$/);
+  if (!match) return value;
+  return resolveSafePath(match[1], context);
+}
+
+function resolveDayBadgeForRender(rule, date, matchedEvent, {
+  formatLocalDate,
+  normalizeResolvedDayBadgeDisplayColor
+} = {}) {
+  const context = buildDayBadgeResolutionContext(date, matchedEvent, { formatLocalDate });
+  const resolved = { ...rule };
+  ['icon', 'text', 'background_color', 'color'].forEach((field) => {
+    const value = resolveDayBadgeDisplayValue(rule[field], context);
+    if (value === undefined || value === null || String(value).trim() === '') {
+      delete resolved[field];
+      return;
+    }
+
+    if (field === 'background_color' || field === 'color') {
+      const normalizedColor = normalizeResolvedDayBadgeDisplayColor(value);
+      if (normalizedColor) {
+        resolved[field] = normalizedColor;
+      } else {
+        delete resolved[field];
+      }
+      return;
+    }
+
+    resolved[field] = String(value).trim();
+  });
+  return resolved;
+}
+
+function normalizeDayBadgeConditions(rawConditions, { normalizeEventMatchConditions } = {}) {
+  return normalizeEventMatchConditions(rawConditions);
+}
+
+function normalizeDayBadges(rawRules, {
+  normalizeAdvancedRuleMatch,
+  normalizeDayBadgeBlock
+} = {}) {
+  if (!Array.isArray(rawRules)) return [];
+
+  return rawRules
+    .map((rule, index) => {
+      if (!rule || typeof rule !== 'object') return null;
+      const rawMatch = rule.match && typeof rule.match === 'object'
+        ? rule.match
+        : (rule.conditions && typeof rule.conditions === 'object' ? { event: rule.conditions } : null);
+      const match = normalizeAdvancedRuleMatch(rawMatch, 'event');
+      if (!match) return null;
+
+      const output = normalizeDayBadgeBlock(rule);
+      if (!output.text && !output.icon) return null;
+
+      const numericPriority = Number(rule.priority);
+      const priority = Number.isFinite(numericPriority) ? numericPriority : 0;
+      const normalized = {
+        id: typeof rule.id === 'string' && rule.id.trim() ? rule.id.trim() : `day-badge-${index + 1}`,
+        type: 'day_badge',
+        priority,
+        index,
+        match,
+        output,
+        conditions: match.event
+      };
+      Object.assign(normalized, output);
+      return normalized;
+    })
+    .filter(Boolean);
+}
+
 function getDateRangeChunks(startDate, endDate, chunkDays = 30) {
   const chunks = [];
   let cursor = new Date(startDate);
@@ -2959,166 +3132,65 @@ class SkylightCalendarCard extends HTMLElement {
 
 
   normalizeDayBadgeBlock(rule = {}) {
-    const normalized = {};
-    const text = this.normalizeEventTextValue(rule.text);
-    const icon = this.normalizeEventTextValue(rule.icon);
-    const normalizedText = text || '';
-    const normalizedIcon = icon || '';
-    if (normalizedText) normalized.text = normalizedText;
-    if (normalizedIcon) normalized.icon = normalizedIcon;
-
-    const backgroundColor = this.normalizeDayBadgeDisplayColor(rule.background_color);
-    if (backgroundColor) normalized.background_color = backgroundColor;
-    const color = this.normalizeDayBadgeDisplayColor(rule.color);
-    if (color) normalized.color = color;
-
-    const size = this.normalizeStyleSizeValue(rule.size);
-    if (size) normalized.size = size;
-
-    const fontSize = this.normalizeStyleSizeValue(rule.font_size);
-    if (fontSize) normalized.font_size = fontSize;
-    return normalized;
+    return normalizeDayBadgeBlock(rule, {
+      normalizeEventTextValue: this.normalizeEventTextValue.bind(this),
+      normalizeDayBadgeDisplayColor: this.normalizeDayBadgeDisplayColor.bind(this),
+      normalizeStyleSizeValue: this.normalizeStyleSizeValue.bind(this)
+    });
   }
 
   isFullValueTemplate(value) {
-    return typeof value === 'string' && /^\s*\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}\s*$/.test(value);
+    return isFullValueTemplate(value);
   }
 
   normalizeDayBadgeDisplayColor(value) {
-    if (this.isFullValueTemplate(value)) return String(value).trim();
-    return this.normalizeSingleColor(value);
+    return normalizeDayBadgeDisplayColor(value, {
+      normalizeSingleColor: this.normalizeSingleColor.bind(this)
+    });
   }
 
   normalizeResolvedDayBadgeDisplayColor(value) {
-    const normalized = this.normalizeSingleColor(value);
-    if (typeof normalized !== 'string') return undefined;
-    const trimmed = normalized.trim();
-    if (!trimmed) return undefined;
-
-    if (/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(trimmed)) return trimmed;
-    if (/^rgba?\(\s*[+-]?(?:\d+|\d*\.\d+)%?\s*(?:,|\s)\s*[+-]?(?:\d+|\d*\.\d+)%?\s*(?:,|\s)\s*[+-]?(?:\d+|\d*\.\d+)%?(?:\s*(?:,|\/)\s*(?:[01](?:\.\d+)?|\.\d+|\d+%))?\s*\)$/i.test(trimmed)) return trimmed;
-    if (/^hsla?\(\s*[+-]?(?:\d+|\d*\.\d+)(?:deg|grad|rad|turn)?\s*(?:,|\s)\s*[+-]?(?:\d+|\d*\.\d+)%\s*(?:,|\s)\s*[+-]?(?:\d+|\d*\.\d+)%(?:\s*(?:,|\/)\s*(?:[01](?:\.\d+)?|\.\d+|\d+%))?\s*\)$/i.test(trimmed)) return trimmed;
-
-    return undefined;
+    return normalizeResolvedDayBadgeDisplayColor(value, {
+      normalizeSingleColor: this.normalizeSingleColor.bind(this)
+    });
   }
 
   parseEventDescriptionJson(event) {
-    const raw = String(event?.description || '').trim();
-    if (!raw.startsWith('{') || !raw.endsWith('}')) return undefined;
-
-    try {
-      const parsed = JSON.parse(raw);
-      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
-      return parsed;
-    } catch {
-      return undefined;
-    }
+    return parseEventDescriptionJson(event);
   }
 
   buildDayBadgeResolutionContext(date, matchedEvent) {
-    const event = matchedEvent && typeof matchedEvent === 'object' ? matchedEvent : {};
-    const calendar = event.entityId || event.entity_id || event.calendar;
-    const title = event.summary || event.title;
-    return {
-      date: date instanceof Date && !Number.isNaN(date.getTime()) ? this.formatLocalDate(date) : date,
-      calendar,
-      title,
-      event: {
-        ...event,
-        calendar,
-        entity_id: event.entity_id || event.entityId,
-        title,
-        summary: event.summary || event.title,
-        description_json: this.parseEventDescriptionJson(event)
-      }
-    };
+    return buildDayBadgeResolutionContext(date, matchedEvent, {
+      formatLocalDate: this.formatLocalDate.bind(this)
+    });
   }
 
   resolveSafePath(path, context) {
-    if (typeof path !== 'string' || !path) return undefined;
-    const blockedSegments = new Set(['__proto__', 'prototype', 'constructor']);
-    const segments = path.split('.');
-    if (!segments.length) return undefined;
-
-    let current = context;
-    for (const segment of segments) {
-      if (!/^[A-Za-z0-9_-]+$/.test(segment) || blockedSegments.has(segment)) return undefined;
-      if (current === null || current === undefined || (typeof current !== 'object' && typeof current !== 'function')) return undefined;
-      if (!Object.prototype.hasOwnProperty.call(current, segment)) return undefined;
-      current = current[segment];
-    }
-
-    if (current === null || current === undefined) return undefined;
-    if (['string', 'number', 'boolean'].includes(typeof current)) return String(current);
-    return undefined;
+    return resolveSafePath(path, context);
   }
 
   resolveDayBadgeDisplayValue(value, context) {
-    if (typeof value !== 'string') return value;
-    const match = value.match(/^\s*\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}\s*$/);
-    if (!match) return value;
-    return this.resolveSafePath(match[1], context);
+    return resolveDayBadgeDisplayValue(value, context);
   }
 
   resolveDayBadgeForRender(rule, date, matchedEvent) {
-    const context = this.buildDayBadgeResolutionContext(date, matchedEvent);
-    const resolved = { ...rule };
-    ['icon', 'text', 'background_color', 'color'].forEach((field) => {
-      const value = this.resolveDayBadgeDisplayValue(rule[field], context);
-      if (value === undefined || value === null || String(value).trim() === '') {
-        delete resolved[field];
-        return;
-      }
-
-      if (field === 'background_color' || field === 'color') {
-        const normalizedColor = this.normalizeResolvedDayBadgeDisplayColor(value);
-        if (normalizedColor) {
-          resolved[field] = normalizedColor;
-        } else {
-          delete resolved[field];
-        }
-        return;
-      }
-
-      resolved[field] = String(value).trim();
+    return resolveDayBadgeForRender(rule, date, matchedEvent, {
+      formatLocalDate: this.formatLocalDate.bind(this),
+      normalizeResolvedDayBadgeDisplayColor: this.normalizeResolvedDayBadgeDisplayColor.bind(this)
     });
-    return resolved;
   }
 
   normalizeDayBadgeConditions(rawConditions) {
-    return this.normalizeEventMatchConditions(rawConditions);
+    return normalizeDayBadgeConditions(rawConditions, {
+      normalizeEventMatchConditions: this.normalizeEventMatchConditions.bind(this)
+    });
   }
 
   normalizeDayBadges(rawRules) {
-    if (!Array.isArray(rawRules)) return [];
-
-    return rawRules
-      .map((rule, index) => {
-        if (!rule || typeof rule !== 'object') return null;
-        const rawMatch = rule.match && typeof rule.match === 'object'
-          ? rule.match
-          : (rule.conditions && typeof rule.conditions === 'object' ? { event: rule.conditions } : null);
-        const match = this.normalizeAdvancedRuleMatch(rawMatch, 'event');
-        if (!match) return null;
-
-        const output = this.normalizeDayBadgeBlock(rule);
-        if (!output.text && !output.icon) return null;
-
-        const numericPriority = Number(rule.priority);
-        const priority = Number.isFinite(numericPriority) ? numericPriority : 0;
-        const normalized = {
-          id: typeof rule.id === 'string' && rule.id.trim() ? rule.id.trim() : `day-badge-${index + 1}`,
-          type: 'day_badge',
-          priority,
-          index,
-          match,
-          output,
-          conditions: match.event
-        };
-        Object.assign(normalized, output);
-        return normalized;
-      })
-      .filter(Boolean);
+    return normalizeDayBadges(rawRules, {
+      normalizeAdvancedRuleMatch: this.normalizeAdvancedRuleMatch.bind(this),
+      normalizeDayBadgeBlock: this.normalizeDayBadgeBlock.bind(this)
+    });
   }
 
 

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -2318,6 +2318,90 @@ test('hidden events do not contribute to month overflow counts', () => {
 });
 
 
+
+test('day badge helper module delegates preserve normalization and resolution behavior', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const block = card.normalizeDayBadgeBlock({
+    text: '  School  ',
+    icon: ' mdi:school ',
+    background_color: '{{ event.description_json.badge_color }}',
+    color: 'red',
+    size: 24,
+    font_size: ' 0.85rem '
+  });
+
+  assert.deepEqual(block, {
+    text: 'School',
+    icon: 'mdi:school',
+    background_color: '{{ event.description_json.badge_color }}',
+    color: '#FF0000',
+    size: '24px',
+    font_size: '0.85rem'
+  });
+  assert.equal(card.isFullValueTemplate('{{event.description_json.foo}}'), true);
+  assert.equal(card.isFullValueTemplate('Label {{ event.description_json.foo }}'), false);
+});
+
+test('day badge safe path resolution blocks prototype segments and missing/non-scalar values', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const context = {
+    event: {
+      description_json: {
+        label: 'School',
+        count: 3,
+        active: true,
+        nested: { label: 'Nested' },
+        items: ['a']
+      }
+    }
+  };
+
+  assert.equal(card.resolveSafePath('event.description_json.label', context), 'School');
+  assert.equal(card.resolveSafePath('event.description_json.count', context), '3');
+  assert.equal(card.resolveSafePath('event.description_json.active', context), 'true');
+  assert.equal(card.resolveSafePath('event.description_json.missing', context), undefined);
+  assert.equal(card.resolveSafePath('event.description_json.nested', context), undefined);
+  assert.equal(card.resolveSafePath('event.description_json.items', context), undefined);
+  assert.equal(card.resolveSafePath('event.__proto__.polluted', context), undefined);
+  assert.equal(card.resolveSafePath('event.prototype.polluted', context), undefined);
+  assert.equal(card.resolveSafePath('event.constructor.polluted', context), undefined);
+});
+
+test('day badge display value and description JSON helpers preserve primitive template semantics', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const event = { description: '{"badge_text":"School","count":2,"enabled":false}' };
+  const context = card.buildDayBadgeResolutionContext(new Date('2026-05-01T00:00:00Z'), event);
+
+  assert.deepEqual(card.parseEventDescriptionJson(event), { badge_text: 'School', count: 2, enabled: false });
+  assert.equal(card.parseEventDescriptionJson({ description: '{bad json}' }), undefined);
+  assert.equal(card.parseEventDescriptionJson({ description: '["array"]' }), undefined);
+  assert.equal(card.resolveDayBadgeDisplayValue('{{ event.description_json.badge_text }}', context), 'School');
+  assert.equal(card.resolveDayBadgeDisplayValue('{{ event.description_json.count }}', context), '2');
+  assert.equal(card.resolveDayBadgeDisplayValue('{{ event.description_json.enabled }}', context), 'false');
+  assert.equal(card.resolveDayBadgeDisplayValue('{{ event.description_json.missing }}', context), undefined);
+  assert.equal(card.resolveDayBadgeDisplayValue('School: {{ event.description_json.badge_text }}', context), 'School: {{ event.description_json.badge_text }}');
+});
+
+test('day badge render resolution removes empty fields and validates resolved colors', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const event = { description: '{"text":"School","icon":"mdi:school","empty":"","bad_color":"not-a-color","good_color":"#123456"}' };
+  const resolved = card.resolveDayBadgeForRender({
+    text: '{{ event.description_json.text }}',
+    icon: '{{ event.description_json.empty }}',
+    background_color: '{{ event.description_json.good_color }}',
+    color: '{{ event.description_json.bad_color }}',
+    size: '20px',
+    font_size: '12px'
+  }, new Date('2026-05-01T00:00:00Z'), event);
+
+  assert.equal(resolved.text, 'School');
+  assert.equal(resolved.icon, undefined);
+  assert.equal(resolved.background_color, '#123456');
+  assert.equal(resolved.color, undefined);
+  assert.equal(resolved.size, '20px');
+  assert.equal(resolved.font_size, '12px');
+});
+
 test('day_badges renders text badge when event title matches', () => {
   const card = makeCard({ entities: ['calendar.a'], day_badges: [{ conditions: { title_contains: 'ballet' }, text: 'PL', background_color: '#ff4b2b', color: '#000000' }] });
   const events = [{ entityId: 'calendar.a', summary: 'Ballet Practice', start: { dateTime: '2026-05-01T10:00:00Z' }, end: { dateTime: '2026-05-01T11:00:00Z' } }];
@@ -3965,4 +4049,95 @@ test('rule modules preserve event, day, badge, and priority matching behavior', 
     date: new Date('2026-06-23T00:00:00'),
     dayEvents: [event]
   }, helpers).matches, true);
+});
+
+test('day badge module preserves normalization, safe resolution, and render preparation behavior', async () => {
+  const {
+    isFullValueTemplate,
+    normalizeDayBadgeBlock,
+    normalizeDayBadgeDisplayColor,
+    normalizeResolvedDayBadgeDisplayColor,
+    parseEventDescriptionJson,
+    buildDayBadgeResolutionContext,
+    resolveSafePath,
+    resolveDayBadgeDisplayValue,
+    resolveDayBadgeForRender,
+    normalizeDayBadges
+  } = await import('./src/badges/day-badges.js');
+
+  const normalizeSingleColor = (value) => ({ red: '#FF0000', blue: '#0000FF' }[String(value || '').trim().toLowerCase()] || String(value || '').trim() || null);
+  const normalizeEventTextValueForTest = (value) => String(value ?? '').trim().replace(/\s+/g, ' ');
+  const normalizeStyleSizeValueForTest = (value) => {
+    const trimmed = String(value ?? '').trim();
+    if (!trimmed) return null;
+    const numeric = Number(trimmed);
+    return Number.isFinite(numeric) && numeric > 0 ? `${numeric}px` : trimmed;
+  };
+
+  assert.deepEqual(normalizeDayBadgeBlock({
+    text: '  Bus  ',
+    icon: ' mdi:bus ',
+    background_color: '{{ event.description_json.badge_color }}',
+    color: 'red',
+    size: 18,
+    font_size: '11px'
+  }, {
+    normalizeEventTextValue: normalizeEventTextValueForTest,
+    normalizeDayBadgeDisplayColor: (value) => normalizeDayBadgeDisplayColor(value, { normalizeSingleColor }),
+    normalizeStyleSizeValue: normalizeStyleSizeValueForTest
+  }), {
+    text: 'Bus',
+    icon: 'mdi:bus',
+    background_color: '{{ event.description_json.badge_color }}',
+    color: '#FF0000',
+    size: '18px',
+    font_size: '11px'
+  });
+  assert.equal(isFullValueTemplate('{{event.description_json.badge_color}}'), true);
+  assert.equal(isFullValueTemplate('Bus {{ event.description_json.badge_color }}'), false);
+  assert.equal(normalizeResolvedDayBadgeDisplayColor('blue', { normalizeSingleColor }), '#0000FF');
+  assert.equal(normalizeResolvedDayBadgeDisplayColor('not-a-color', { normalizeSingleColor }), undefined);
+
+  const event = { entityId: 'calendar.helper', summary: 'Helper', description: '{"label":"Bus","count":4,"enabled":true,"color":"#112233","empty":"","nested":{"x":1}}' };
+  const context = buildDayBadgeResolutionContext(new Date('2026-05-01T00:00:00Z'), event, { formatLocalDate: () => '2026-05-01' });
+  assert.deepEqual(parseEventDescriptionJson(event), { label: 'Bus', count: 4, enabled: true, color: '#112233', empty: '', nested: { x: 1 } });
+  assert.equal(parseEventDescriptionJson({ description: '{bad json}' }), undefined);
+  assert.equal(resolveSafePath('event.description_json.label', context), 'Bus');
+  assert.equal(resolveSafePath('event.description_json.count', context), '4');
+  assert.equal(resolveSafePath('event.__proto__.polluted', context), undefined);
+  assert.equal(resolveSafePath('event.prototype.polluted', context), undefined);
+  assert.equal(resolveSafePath('event.constructor.polluted', context), undefined);
+  assert.equal(resolveSafePath('event.description_json.missing', context), undefined);
+  assert.equal(resolveSafePath('event.description_json.nested', context), undefined);
+  assert.equal(resolveDayBadgeDisplayValue('{{ event.description_json.enabled }}', context), 'true');
+  assert.equal(resolveDayBadgeDisplayValue('Literal {{ event.description_json.label }}', context), 'Literal {{ event.description_json.label }}');
+
+  assert.deepEqual(resolveDayBadgeForRender({
+    text: '{{ event.description_json.label }}',
+    icon: '{{ event.description_json.empty }}',
+    background_color: '{{ event.description_json.color }}',
+    color: '{{ event.description_json.nested }}',
+    size: '18px'
+  }, new Date('2026-05-01T00:00:00Z'), event, {
+    formatLocalDate: () => '2026-05-01',
+    normalizeResolvedDayBadgeDisplayColor: (value) => normalizeResolvedDayBadgeDisplayColor(value, { normalizeSingleColor })
+  }), {
+    text: 'Bus',
+    background_color: '#112233',
+    size: '18px'
+  });
+
+  const normalizedRules = normalizeDayBadges([
+    { conditions: { title_contains: 'helper' }, text: 'H' },
+    { match: { event: { title: 'Helper' } }, icon: 'mdi:calendar' }
+  ], {
+    normalizeAdvancedRuleMatch: (rawMatch) => ({ event: rawMatch.event || rawMatch }),
+    normalizeDayBadgeBlock: (rule) => normalizeDayBadgeBlock(rule, {
+      normalizeEventTextValue: normalizeEventTextValueForTest,
+      normalizeDayBadgeDisplayColor: (value) => normalizeDayBadgeDisplayColor(value, { normalizeSingleColor }),
+      normalizeStyleSizeValue: normalizeStyleSizeValueForTest
+    })
+  });
+  assert.equal(normalizedRules[0].conditions.title_contains, 'helper');
+  assert.equal(normalizedRules[1].match.event.title, 'Helper');
 });

--- a/src/badges/day-badges.js
+++ b/src/badges/day-badges.js
@@ -1,0 +1,172 @@
+export function normalizeDayBadgeBlock(rule = {}, {
+  normalizeEventTextValue,
+  normalizeDayBadgeDisplayColor,
+  normalizeStyleSizeValue
+} = {}) {
+  const normalized = {};
+  const text = normalizeEventTextValue(rule.text);
+  const icon = normalizeEventTextValue(rule.icon);
+  const normalizedText = text || '';
+  const normalizedIcon = icon || '';
+  if (normalizedText) normalized.text = normalizedText;
+  if (normalizedIcon) normalized.icon = normalizedIcon;
+
+  const backgroundColor = normalizeDayBadgeDisplayColor(rule.background_color);
+  if (backgroundColor) normalized.background_color = backgroundColor;
+  const color = normalizeDayBadgeDisplayColor(rule.color);
+  if (color) normalized.color = color;
+
+  const size = normalizeStyleSizeValue(rule.size);
+  if (size) normalized.size = size;
+
+  const fontSize = normalizeStyleSizeValue(rule.font_size);
+  if (fontSize) normalized.font_size = fontSize;
+  return normalized;
+}
+
+export function isFullValueTemplate(value) {
+  return typeof value === 'string' && /^\s*\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}\s*$/.test(value);
+}
+
+export function normalizeDayBadgeDisplayColor(value, { normalizeSingleColor } = {}) {
+  if (isFullValueTemplate(value)) return String(value).trim();
+  return normalizeSingleColor(value);
+}
+
+export function normalizeResolvedDayBadgeDisplayColor(value, { normalizeSingleColor } = {}) {
+  const normalized = normalizeSingleColor(value);
+  if (typeof normalized !== 'string') return undefined;
+  const trimmed = normalized.trim();
+  if (!trimmed) return undefined;
+
+  if (/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(trimmed)) return trimmed;
+  if (/^rgba?\(\s*[+-]?(?:\d+|\d*\.\d+)%?\s*(?:,|\s)\s*[+-]?(?:\d+|\d*\.\d+)%?\s*(?:,|\s)\s*[+-]?(?:\d+|\d*\.\d+)%?(?:\s*(?:,|\/)\s*(?:[01](?:\.\d+)?|\.\d+|\d+%))?\s*\)$/i.test(trimmed)) return trimmed;
+  if (/^hsla?\(\s*[+-]?(?:\d+|\d*\.\d+)(?:deg|grad|rad|turn)?\s*(?:,|\s)\s*[+-]?(?:\d+|\d*\.\d+)%\s*(?:,|\s)\s*[+-]?(?:\d+|\d*\.\d+)%(?:\s*(?:,|\/)\s*(?:[01](?:\.\d+)?|\.\d+|\d+%))?\s*\)$/i.test(trimmed)) return trimmed;
+
+  return undefined;
+}
+
+export function parseEventDescriptionJson(event) {
+  const raw = String(event?.description || '').trim();
+  if (!raw.startsWith('{') || !raw.endsWith('}')) return undefined;
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}
+
+export function buildDayBadgeResolutionContext(date, matchedEvent, { formatLocalDate } = {}) {
+  const event = matchedEvent && typeof matchedEvent === 'object' ? matchedEvent : {};
+  const calendar = event.entityId || event.entity_id || event.calendar;
+  const title = event.summary || event.title;
+  return {
+    date: date instanceof Date && !Number.isNaN(date.getTime()) ? formatLocalDate(date) : date,
+    calendar,
+    title,
+    event: {
+      ...event,
+      calendar,
+      entity_id: event.entity_id || event.entityId,
+      title,
+      summary: event.summary || event.title,
+      description_json: parseEventDescriptionJson(event)
+    }
+  };
+}
+
+export function resolveSafePath(path, context) {
+  if (typeof path !== 'string' || !path) return undefined;
+  const blockedSegments = new Set(['__proto__', 'prototype', 'constructor']);
+  const segments = path.split('.');
+  if (!segments.length) return undefined;
+
+  let current = context;
+  for (const segment of segments) {
+    if (!/^[A-Za-z0-9_-]+$/.test(segment) || blockedSegments.has(segment)) return undefined;
+    if (current === null || current === undefined || (typeof current !== 'object' && typeof current !== 'function')) return undefined;
+    if (!Object.prototype.hasOwnProperty.call(current, segment)) return undefined;
+    current = current[segment];
+  }
+
+  if (current === null || current === undefined) return undefined;
+  if (['string', 'number', 'boolean'].includes(typeof current)) return String(current);
+  return undefined;
+}
+
+export function resolveDayBadgeDisplayValue(value, context) {
+  if (typeof value !== 'string') return value;
+  const match = value.match(/^\s*\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}\s*$/);
+  if (!match) return value;
+  return resolveSafePath(match[1], context);
+}
+
+export function resolveDayBadgeForRender(rule, date, matchedEvent, {
+  formatLocalDate,
+  normalizeResolvedDayBadgeDisplayColor
+} = {}) {
+  const context = buildDayBadgeResolutionContext(date, matchedEvent, { formatLocalDate });
+  const resolved = { ...rule };
+  ['icon', 'text', 'background_color', 'color'].forEach((field) => {
+    const value = resolveDayBadgeDisplayValue(rule[field], context);
+    if (value === undefined || value === null || String(value).trim() === '') {
+      delete resolved[field];
+      return;
+    }
+
+    if (field === 'background_color' || field === 'color') {
+      const normalizedColor = normalizeResolvedDayBadgeDisplayColor(value);
+      if (normalizedColor) {
+        resolved[field] = normalizedColor;
+      } else {
+        delete resolved[field];
+      }
+      return;
+    }
+
+    resolved[field] = String(value).trim();
+  });
+  return resolved;
+}
+
+export function normalizeDayBadgeConditions(rawConditions, { normalizeEventMatchConditions } = {}) {
+  return normalizeEventMatchConditions(rawConditions);
+}
+
+export function normalizeDayBadges(rawRules, {
+  normalizeAdvancedRuleMatch,
+  normalizeDayBadgeBlock
+} = {}) {
+  if (!Array.isArray(rawRules)) return [];
+
+  return rawRules
+    .map((rule, index) => {
+      if (!rule || typeof rule !== 'object') return null;
+      const rawMatch = rule.match && typeof rule.match === 'object'
+        ? rule.match
+        : (rule.conditions && typeof rule.conditions === 'object' ? { event: rule.conditions } : null);
+      const match = normalizeAdvancedRuleMatch(rawMatch, 'event');
+      if (!match) return null;
+
+      const output = normalizeDayBadgeBlock(rule);
+      if (!output.text && !output.icon) return null;
+
+      const numericPriority = Number(rule.priority);
+      const priority = Number.isFinite(numericPriority) ? numericPriority : 0;
+      const normalized = {
+        id: typeof rule.id === 'string' && rule.id.trim() ? rule.id.trim() : `day-badge-${index + 1}`,
+        type: 'day_badge',
+        priority,
+        index,
+        match,
+        output,
+        conditions: match.event
+      };
+      Object.assign(normalized, output);
+      return normalized;
+    })
+    .filter(Boolean);
+}

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -32,6 +32,19 @@ import {
 } from './defaults.js';
 import { TRANSLATIONS } from './translations.js';
 import {
+  normalizeDayBadgeBlock as normalizeDayBadgeBlockHelper,
+  normalizeDayBadgeConditions as normalizeDayBadgeConditionsHelper,
+  normalizeDayBadgeDisplayColor as normalizeDayBadgeDisplayColorHelper,
+  normalizeDayBadges as normalizeDayBadgesHelper,
+  normalizeResolvedDayBadgeDisplayColor as normalizeResolvedDayBadgeDisplayColorHelper,
+  isFullValueTemplate as isFullValueTemplateHelper,
+  parseEventDescriptionJson as parseEventDescriptionJsonHelper,
+  buildDayBadgeResolutionContext as buildDayBadgeResolutionContextHelper,
+  resolveSafePath as resolveSafePathHelper,
+  resolveDayBadgeDisplayValue as resolveDayBadgeDisplayValueHelper,
+  resolveDayBadgeForRender as resolveDayBadgeForRenderHelper
+} from './badges/day-badges.js';
+import {
   formatLocalDate,
   getDateRangeChunks,
   getIsoWeekNumber,
@@ -1219,166 +1232,65 @@ class SkylightCalendarCard extends HTMLElement {
 
 
   normalizeDayBadgeBlock(rule = {}) {
-    const normalized = {};
-    const text = this.normalizeEventTextValue(rule.text);
-    const icon = this.normalizeEventTextValue(rule.icon);
-    const normalizedText = text || '';
-    const normalizedIcon = icon || '';
-    if (normalizedText) normalized.text = normalizedText;
-    if (normalizedIcon) normalized.icon = normalizedIcon;
-
-    const backgroundColor = this.normalizeDayBadgeDisplayColor(rule.background_color);
-    if (backgroundColor) normalized.background_color = backgroundColor;
-    const color = this.normalizeDayBadgeDisplayColor(rule.color);
-    if (color) normalized.color = color;
-
-    const size = this.normalizeStyleSizeValue(rule.size);
-    if (size) normalized.size = size;
-
-    const fontSize = this.normalizeStyleSizeValue(rule.font_size);
-    if (fontSize) normalized.font_size = fontSize;
-    return normalized;
+    return normalizeDayBadgeBlockHelper(rule, {
+      normalizeEventTextValue: this.normalizeEventTextValue.bind(this),
+      normalizeDayBadgeDisplayColor: this.normalizeDayBadgeDisplayColor.bind(this),
+      normalizeStyleSizeValue: this.normalizeStyleSizeValue.bind(this)
+    });
   }
 
   isFullValueTemplate(value) {
-    return typeof value === 'string' && /^\s*\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}\s*$/.test(value);
+    return isFullValueTemplateHelper(value);
   }
 
   normalizeDayBadgeDisplayColor(value) {
-    if (this.isFullValueTemplate(value)) return String(value).trim();
-    return this.normalizeSingleColor(value);
+    return normalizeDayBadgeDisplayColorHelper(value, {
+      normalizeSingleColor: this.normalizeSingleColor.bind(this)
+    });
   }
 
   normalizeResolvedDayBadgeDisplayColor(value) {
-    const normalized = this.normalizeSingleColor(value);
-    if (typeof normalized !== 'string') return undefined;
-    const trimmed = normalized.trim();
-    if (!trimmed) return undefined;
-
-    if (/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(trimmed)) return trimmed;
-    if (/^rgba?\(\s*[+-]?(?:\d+|\d*\.\d+)%?\s*(?:,|\s)\s*[+-]?(?:\d+|\d*\.\d+)%?\s*(?:,|\s)\s*[+-]?(?:\d+|\d*\.\d+)%?(?:\s*(?:,|\/)\s*(?:[01](?:\.\d+)?|\.\d+|\d+%))?\s*\)$/i.test(trimmed)) return trimmed;
-    if (/^hsla?\(\s*[+-]?(?:\d+|\d*\.\d+)(?:deg|grad|rad|turn)?\s*(?:,|\s)\s*[+-]?(?:\d+|\d*\.\d+)%\s*(?:,|\s)\s*[+-]?(?:\d+|\d*\.\d+)%(?:\s*(?:,|\/)\s*(?:[01](?:\.\d+)?|\.\d+|\d+%))?\s*\)$/i.test(trimmed)) return trimmed;
-
-    return undefined;
+    return normalizeResolvedDayBadgeDisplayColorHelper(value, {
+      normalizeSingleColor: this.normalizeSingleColor.bind(this)
+    });
   }
 
   parseEventDescriptionJson(event) {
-    const raw = String(event?.description || '').trim();
-    if (!raw.startsWith('{') || !raw.endsWith('}')) return undefined;
-
-    try {
-      const parsed = JSON.parse(raw);
-      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
-      return parsed;
-    } catch {
-      return undefined;
-    }
+    return parseEventDescriptionJsonHelper(event);
   }
 
   buildDayBadgeResolutionContext(date, matchedEvent) {
-    const event = matchedEvent && typeof matchedEvent === 'object' ? matchedEvent : {};
-    const calendar = event.entityId || event.entity_id || event.calendar;
-    const title = event.summary || event.title;
-    return {
-      date: date instanceof Date && !Number.isNaN(date.getTime()) ? this.formatLocalDate(date) : date,
-      calendar,
-      title,
-      event: {
-        ...event,
-        calendar,
-        entity_id: event.entity_id || event.entityId,
-        title,
-        summary: event.summary || event.title,
-        description_json: this.parseEventDescriptionJson(event)
-      }
-    };
+    return buildDayBadgeResolutionContextHelper(date, matchedEvent, {
+      formatLocalDate: this.formatLocalDate.bind(this)
+    });
   }
 
   resolveSafePath(path, context) {
-    if (typeof path !== 'string' || !path) return undefined;
-    const blockedSegments = new Set(['__proto__', 'prototype', 'constructor']);
-    const segments = path.split('.');
-    if (!segments.length) return undefined;
-
-    let current = context;
-    for (const segment of segments) {
-      if (!/^[A-Za-z0-9_-]+$/.test(segment) || blockedSegments.has(segment)) return undefined;
-      if (current === null || current === undefined || (typeof current !== 'object' && typeof current !== 'function')) return undefined;
-      if (!Object.prototype.hasOwnProperty.call(current, segment)) return undefined;
-      current = current[segment];
-    }
-
-    if (current === null || current === undefined) return undefined;
-    if (['string', 'number', 'boolean'].includes(typeof current)) return String(current);
-    return undefined;
+    return resolveSafePathHelper(path, context);
   }
 
   resolveDayBadgeDisplayValue(value, context) {
-    if (typeof value !== 'string') return value;
-    const match = value.match(/^\s*\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}\s*$/);
-    if (!match) return value;
-    return this.resolveSafePath(match[1], context);
+    return resolveDayBadgeDisplayValueHelper(value, context);
   }
 
   resolveDayBadgeForRender(rule, date, matchedEvent) {
-    const context = this.buildDayBadgeResolutionContext(date, matchedEvent);
-    const resolved = { ...rule };
-    ['icon', 'text', 'background_color', 'color'].forEach((field) => {
-      const value = this.resolveDayBadgeDisplayValue(rule[field], context);
-      if (value === undefined || value === null || String(value).trim() === '') {
-        delete resolved[field];
-        return;
-      }
-
-      if (field === 'background_color' || field === 'color') {
-        const normalizedColor = this.normalizeResolvedDayBadgeDisplayColor(value);
-        if (normalizedColor) {
-          resolved[field] = normalizedColor;
-        } else {
-          delete resolved[field];
-        }
-        return;
-      }
-
-      resolved[field] = String(value).trim();
+    return resolveDayBadgeForRenderHelper(rule, date, matchedEvent, {
+      formatLocalDate: this.formatLocalDate.bind(this),
+      normalizeResolvedDayBadgeDisplayColor: this.normalizeResolvedDayBadgeDisplayColor.bind(this)
     });
-    return resolved;
   }
 
   normalizeDayBadgeConditions(rawConditions) {
-    return this.normalizeEventMatchConditions(rawConditions);
+    return normalizeDayBadgeConditionsHelper(rawConditions, {
+      normalizeEventMatchConditions: this.normalizeEventMatchConditions.bind(this)
+    });
   }
 
   normalizeDayBadges(rawRules) {
-    if (!Array.isArray(rawRules)) return [];
-
-    return rawRules
-      .map((rule, index) => {
-        if (!rule || typeof rule !== 'object') return null;
-        const rawMatch = rule.match && typeof rule.match === 'object'
-          ? rule.match
-          : (rule.conditions && typeof rule.conditions === 'object' ? { event: rule.conditions } : null);
-        const match = this.normalizeAdvancedRuleMatch(rawMatch, 'event');
-        if (!match) return null;
-
-        const output = this.normalizeDayBadgeBlock(rule);
-        if (!output.text && !output.icon) return null;
-
-        const numericPriority = Number(rule.priority);
-        const priority = Number.isFinite(numericPriority) ? numericPriority : 0;
-        const normalized = {
-          id: typeof rule.id === 'string' && rule.id.trim() ? rule.id.trim() : `day-badge-${index + 1}`,
-          type: 'day_badge',
-          priority,
-          index,
-          match,
-          output,
-          conditions: match.event
-        };
-        Object.assign(normalized, output);
-        return normalized;
-      })
-      .filter(Boolean);
+    return normalizeDayBadgesHelper(rawRules, {
+      normalizeAdvancedRuleMatch: this.normalizeAdvancedRuleMatch.bind(this),
+      normalizeDayBadgeBlock: this.normalizeDayBadgeBlock.bind(this)
+    });
   }
 
 


### PR DESCRIPTION
## Summary
- Extracted non-rendering day-badge logic into a new module `src/badges/day-badges.js` and wired the main card to delegate to it.
- Moved these helpers: `normalizeDayBadgeConditions`, `normalizeDayBadges`, `normalizeDayBadgeBlock`, `isFullValueTemplate`, `normalizeDayBadgeDisplayColor`, `normalizeResolvedDayBadgeDisplayColor`, `parseEventDescriptionJson`, `buildDayBadgeResolutionContext`, `resolveSafePath`, `resolveDayBadgeDisplayValue`, and `resolveDayBadgeForRender`.
- Kept rendering and DOM code in `src/skylight-calendar-card.js` as thin wrapper methods that pass explicit helper functions into the new module; no render methods or CSS/DOM/templates were moved or changed.
- Purpose is a behavior-preserving mechanical refactor to isolate data-only badge logic without changing public config syntax or runtime behaviour.

## Tests
- Ran dependency/install and build: `npm ci --no-audit --fund=false` and `npm run build`, and the build regenerated the shipped artifact successfully.
- Performed syntax checks: `node --check src/skylight-calendar-card.js`, `node --check src/badges/day-badges.js`, and `node --check skylight-calendar-card.js` all passed.
- Ran unit tests: `npm test` (all tests passed: 218 passing tests in the run observed).
- Ran visual tests: `npm run test:visual` (Playwright suite passed: 39 visual tests observed passing).

## Generated artifact
- Rollup regenerated the root `skylight-calendar-card.js` artifact from `src/` as part of the build, and the repository's generated artifact was updated to reflect the refactor.

## Notes / risks
- This is a mechanical refactor only; rendering, layout, DOM structure, CSS class names, and `day_badges` config syntax were intentionally not changed.
- The card retains thin wrapper methods to preserve existing internal call-sites and test expectations rather than passing the card instance into the new module.
- Tests (unit + visual) and node checks were executed and passed in the working environment used for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b18661c948331a4a578fd24e75f94)