### PR TITLE
Extract weather helpers into dedicated modules

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1983,6 +1983,122 @@ const normalizeLegacyDayStyleMatch = (rule, { localeOverride = null, normalizeDa
   return normalizeAdvancedRuleMatch({ day: dayMatch }, 'day', localeOverride);
 };
 
+function normalizeWeatherTemperature(value) {
+  const numericValue = Number(value);
+  if (!Number.isFinite(numericValue)) return null;
+  return `${Math.round(numericValue)}°`;
+}
+
+function mapWeatherConditionToIcon(conditionValue) {
+  const condition = String(conditionValue || '').trim().toLowerCase().replace(/_/g, '-');
+  if (!condition || condition === 'unknown' || condition === 'unavailable') return '';
+
+  const iconMap = {
+    sunny: 'mdi:weather-sunny',
+    clear: 'mdi:weather-sunny',
+    'clear-night': 'mdi:weather-night',
+    partlycloudy: 'mdi:weather-partly-cloudy',
+    cloudy: 'mdi:weather-cloudy',
+    overcast: 'mdi:weather-cloudy',
+    rainy: 'mdi:weather-rainy',
+    pouring: 'mdi:weather-pouring',
+    snow: 'mdi:weather-snowy',
+    snowy: 'mdi:weather-snowy',
+    'snowy-rainy': 'mdi:weather-snowy-rainy',
+    hail: 'mdi:weather-hail',
+    lightning: 'mdi:weather-lightning',
+    'lightning-rainy': 'mdi:weather-lightning-rainy',
+    windy: 'mdi:weather-windy',
+    'windy-variant': 'mdi:weather-windy-variant',
+    fog: 'mdi:weather-fog',
+    exceptional: 'mdi:alert-circle-outline'
+  };
+
+  return iconMap[condition] || '';
+}
+
+function normalizeHeaderWeatherData(weatherEntity) {
+  if (!weatherEntity) return null;
+
+  const attrs = weatherEntity.attributes || {};
+  const condition = attrs.condition || weatherEntity.state;
+  const conditionIcon = mapWeatherConditionToIcon(condition);
+  const temperature = normalizeWeatherTemperature(
+    attrs.temperature ?? attrs.current_temperature ?? attrs.temp ?? weatherEntity.state
+  );
+
+  if (!conditionIcon || !temperature) return null;
+  return { conditionIcon, temperature };
+}
+
+function normalizeForecastForDate(forecasts, date, getDateKey) {
+  if (!Array.isArray(forecasts) || forecasts.length === 0) return null;
+
+  const targetDateKey = getDateKey(date);
+  const match = forecasts.find((item) => {
+    const forecastDateValue = item?.datetime || item?.date;
+    if (!forecastDateValue) return false;
+    const forecastDate = new Date(forecastDateValue);
+    if (Number.isNaN(forecastDate.getTime())) return false;
+    return getDateKey(forecastDate) === targetDateKey;
+  });
+
+  if (!match) return null;
+
+  const highTemp = normalizeWeatherTemperature(match.temperature ?? match.temphigh ?? match.high);
+  const lowTemp = normalizeWeatherTemperature(match.templow ?? match.low ?? match.temperature_low);
+  const conditionIcon = mapWeatherConditionToIcon(match.condition);
+
+  if (!conditionIcon || !highTemp) return null;
+  return { conditionIcon, highTemp, lowTemp };
+}
+
+function getWeatherEntityForecast(weatherEntity, wsForecast) {
+  return Array.isArray(wsForecast) && wsForecast.length > 0
+    ? wsForecast
+    : weatherEntity?.attributes?.forecast;
+}
+
+function getHeaderWeatherEntityRenderSignature(entityState) {
+  if (!entityState) return '';
+  const attrs = entityState.attributes || {};
+  return JSON.stringify({
+    state: entityState.state,
+    temperature: attrs.temperature ?? attrs.current_temperature ?? attrs.temp ?? null,
+    condition: attrs.condition ?? null,
+    friendly_name: attrs.friendly_name ?? null,
+    entity_picture: attrs.entity_picture ?? null,
+    forecast: Array.isArray(attrs.forecast)
+      ? attrs.forecast.map((forecastItem) => ({
+        datetime: forecastItem?.datetime ?? forecastItem?.date ?? null,
+        condition: forecastItem?.condition ?? null,
+        high: forecastItem?.temperature ?? forecastItem?.temphigh ?? forecastItem?.high ?? null,
+        low: forecastItem?.templow ?? forecastItem?.low ?? forecastItem?.temperature_low ?? null
+      }))
+      : null
+  });
+}
+
+function isWeatherEntityId(entityId) {
+  return !!entityId && entityId.startsWith('weather.');
+}
+
+function buildWeatherForecastSubscriptionMessage(entityId, forecastType = 'daily') {
+  return {
+    type: 'weather/subscribe_forecast',
+    entity_id: entityId,
+    forecast_type: forecastType
+  };
+}
+
+function buildWeatherForecastRequestMessage(entityId, forecastType = 'daily') {
+  return {
+    type: 'weather/get_forecasts',
+    entity_ids: [entityId],
+    forecast_type: forecastType
+  };
+}
+
 const DAYLIGHT_CALENDAR_CARD_VERSION = 'v4.5.0';
 
 function getDaylightCalendarCardVersion() {
@@ -12393,7 +12509,7 @@ class SkylightCalendarCard extends HTMLElement {
 
   async ensureWeatherForecastSubscription() {
     const entityId = this._config?.header_weather_sensor;
-    if (!entityId || !entityId.startsWith('weather.')) {
+    if (!isWeatherEntityId(entityId)) {
       this.teardownWeatherForecastSubscription();
       return;
     }
@@ -12424,11 +12540,7 @@ class SkylightCalendarCard extends HTMLElement {
             this._pendingHeaderSensorRender = true;
           }
         },
-        {
-          type: 'weather/subscribe_forecast',
-          entity_id: entityId,
-          forecast_type: 'daily'
-        }
+        buildWeatherForecastSubscriptionMessage(entityId)
       )
       .then((unsubscribe) => {
         const generationMatches = subscriptionGeneration === this._weatherForecastSubscriptionGeneration;
@@ -12462,7 +12574,7 @@ class SkylightCalendarCard extends HTMLElement {
 
   async refreshWeatherForecastData() {
     const entityId = this._config?.header_weather_sensor;
-    if (!entityId || !entityId.startsWith('weather.')) return;
+    if (!isWeatherEntityId(entityId)) return;
     if (!this._hass || this._weatherForecastRefreshInFlight) return;
     if (this._weatherForecastByEntity.has(entityId)) return;
     const now = Date.now();
@@ -12471,11 +12583,7 @@ class SkylightCalendarCard extends HTMLElement {
 
     this._weatherForecastRefreshInFlight = true;
     try {
-      const wsResponse = await this._hass.callWS({
-        type: 'weather/get_forecasts',
-        entity_ids: [entityId],
-        forecast_type: 'daily'
-      });
+      const wsResponse = await this._hass.callWS(buildWeatherForecastRequestMessage(entityId));
 
       const dailyForecast = wsResponse?.[entityId]?.forecast;
       if (Array.isArray(dailyForecast)) {
@@ -12497,23 +12605,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getHeaderEntityRenderSignature(entityState) {
-    if (!entityState) return '';
-    const attrs = entityState.attributes || {};
-    return JSON.stringify({
-      state: entityState.state,
-      temperature: attrs.temperature ?? attrs.current_temperature ?? attrs.temp ?? null,
-      condition: attrs.condition ?? null,
-      friendly_name: attrs.friendly_name ?? null,
-      entity_picture: attrs.entity_picture ?? null,
-      forecast: Array.isArray(attrs.forecast)
-        ? attrs.forecast.map((forecastItem) => ({
-          datetime: forecastItem?.datetime ?? forecastItem?.date ?? null,
-          condition: forecastItem?.condition ?? null,
-          high: forecastItem?.temperature ?? forecastItem?.temphigh ?? forecastItem?.high ?? null,
-          low: forecastItem?.templow ?? forecastItem?.low ?? forecastItem?.temperature_low ?? null
-        }))
-        : null
-    });
+    return getHeaderWeatherEntityRenderSignature(entityState);
   }
 
   getFormattedHeaderSensorTime() {
@@ -12526,54 +12618,18 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   normalizeWeatherTemperature(value) {
-    const numericValue = Number(value);
-    if (!Number.isFinite(numericValue)) return null;
-    return `${Math.round(numericValue)}°`;
+    return normalizeWeatherTemperature(value);
   }
 
   mapWeatherConditionToIcon(conditionValue) {
-    const condition = String(conditionValue || '').trim().toLowerCase().replace(/_/g, '-');
-    if (!condition || condition === 'unknown' || condition === 'unavailable') return '';
-
-    const iconMap = {
-      sunny: 'mdi:weather-sunny',
-      clear: 'mdi:weather-sunny',
-      'clear-night': 'mdi:weather-night',
-      partlycloudy: 'mdi:weather-partly-cloudy',
-      cloudy: 'mdi:weather-cloudy',
-      overcast: 'mdi:weather-cloudy',
-      rainy: 'mdi:weather-rainy',
-      pouring: 'mdi:weather-pouring',
-      snow: 'mdi:weather-snowy',
-      snowy: 'mdi:weather-snowy',
-      'snowy-rainy': 'mdi:weather-snowy-rainy',
-      hail: 'mdi:weather-hail',
-      lightning: 'mdi:weather-lightning',
-      'lightning-rainy': 'mdi:weather-lightning-rainy',
-      windy: 'mdi:weather-windy',
-      'windy-variant': 'mdi:weather-windy-variant',
-      fog: 'mdi:weather-fog',
-      exceptional: 'mdi:alert-circle-outline'
-    };
-
-    return iconMap[condition] || '';
+    return mapWeatherConditionToIcon(conditionValue);
   }
 
   getHeaderWeatherData() {
     const sensorEntityId = this._config?.header_weather_sensor;
     if (!sensorEntityId) return null;
     const weatherEntity = this._hass?.states?.[sensorEntityId];
-    if (!weatherEntity) return null;
-
-    const attrs = weatherEntity.attributes || {};
-    const condition = attrs.condition || weatherEntity.state;
-    const conditionIcon = this.mapWeatherConditionToIcon(condition);
-    const temperature = this.normalizeWeatherTemperature(
-      attrs.temperature ?? attrs.current_temperature ?? attrs.temp ?? weatherEntity.state
-    );
-
-    if (!conditionIcon || !temperature) return null;
-    return { conditionIcon, temperature };
+    return normalizeHeaderWeatherData(weatherEntity);
   }
 
   getFormattedHeaderWeather() {
@@ -12587,28 +12643,8 @@ class SkylightCalendarCard extends HTMLElement {
     if (!sensorEntityId) return null;
     const weatherEntity = this._hass?.states?.[sensorEntityId];
     const wsForecast = this._weatherForecastByEntity.get(sensorEntityId);
-    const forecasts = Array.isArray(wsForecast) && wsForecast.length > 0
-      ? wsForecast
-      : weatherEntity?.attributes?.forecast;
-    if (!Array.isArray(forecasts) || forecasts.length === 0) return null;
-
-    const targetDateKey = this.getDateKey(date);
-    const match = forecasts.find((item) => {
-      const forecastDateValue = item?.datetime || item?.date;
-      if (!forecastDateValue) return false;
-      const forecastDate = new Date(forecastDateValue);
-      if (Number.isNaN(forecastDate.getTime())) return false;
-      return this.getDateKey(forecastDate) === targetDateKey;
-    });
-
-    if (!match) return null;
-
-    const highTemp = this.normalizeWeatherTemperature(match.temperature ?? match.temphigh ?? match.high);
-    const lowTemp = this.normalizeWeatherTemperature(match.templow ?? match.low ?? match.temperature_low);
-    const conditionIcon = this.mapWeatherConditionToIcon(match.condition);
-
-    if (!conditionIcon || !highTemp) return null;
-    return { conditionIcon, highTemp, lowTemp };
+    const forecasts = getWeatherEntityForecast(weatherEntity, wsForecast);
+    return normalizeForecastForDate(forecasts, date, (forecastDate) => this.getDateKey(forecastDate));
   }
 
   renderDayForecast(date, viewMode = 'week-compact') {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -1486,6 +1486,74 @@ test('weather renders Home Assistant mdi icons instead of emoji glyphs', () => {
   assert.doesNotMatch(forecastHtml, /☀️|⛅/);
 });
 
+
+test('weather utility maps Home Assistant conditions to mdi icons with fallback', async () => {
+  const { mapWeatherConditionToIcon } = await import('./src/weather/weather-utils.js');
+
+  assert.equal(mapWeatherConditionToIcon('sunny'), 'mdi:weather-sunny');
+  assert.equal(mapWeatherConditionToIcon('clear_night'), 'mdi:weather-night');
+  assert.equal(mapWeatherConditionToIcon('lightning-rainy'), 'mdi:weather-lightning-rainy');
+  assert.equal(mapWeatherConditionToIcon('unknown'), '');
+  assert.equal(mapWeatherConditionToIcon('unavailable'), '');
+  assert.equal(mapWeatherConditionToIcon('not-a-real-condition'), '');
+  assert.equal(mapWeatherConditionToIcon(null), '');
+});
+
+test('weather utility normalizes header weather data and preserves temperature unit display', async () => {
+  const { normalizeHeaderWeatherData } = await import('./src/weather/weather-utils.js');
+
+  assert.deepEqual(normalizeHeaderWeatherData({
+    state: 'sunny',
+    attributes: { temperature: 21.4 }
+  }), { conditionIcon: 'mdi:weather-sunny', temperature: '21°' });
+  assert.deepEqual(normalizeHeaderWeatherData({
+    state: 'cloudy',
+    attributes: { condition: 'rainy', current_temperature: 18.6 }
+  }), { conditionIcon: 'mdi:weather-rainy', temperature: '19°' });
+  assert.equal(normalizeHeaderWeatherData({ state: 'unavailable', attributes: { temperature: 20 } }), null);
+  assert.equal(normalizeHeaderWeatherData({ state: 'sunny', attributes: {} }), null);
+  assert.equal(normalizeHeaderWeatherData(null), null);
+});
+
+test('weather utility normalizes forecast items and handles missing or empty data', async () => {
+  const { normalizeForecastForDate } = await import('./src/weather/weather-utils.js');
+  const getDateKey = (date) => date.toISOString().slice(0, 10);
+
+  assert.deepEqual(normalizeForecastForDate([
+    { datetime: '2026-05-13T12:00:00Z', condition: 'sunny', temperature: 22, templow: 11 },
+    { date: '2026-05-14', condition: 'partlycloudy', temphigh: 24.2, temperature_low: 12.4 }
+  ], new Date('2026-05-14T00:00:00Z'), getDateKey), {
+    conditionIcon: 'mdi:weather-partly-cloudy',
+    highTemp: '24°',
+    lowTemp: '12°'
+  });
+  assert.equal(normalizeForecastForDate([], new Date('2026-05-14T00:00:00Z'), getDateKey), null);
+  assert.equal(normalizeForecastForDate(null, new Date('2026-05-14T00:00:00Z'), getDateKey), null);
+  assert.equal(normalizeForecastForDate([{ date: '2026-05-14', condition: 'unknown', temperature: 20 }], new Date('2026-05-14T00:00:00Z'), getDateKey), null);
+  assert.equal(normalizeForecastForDate([{ date: '2026-05-14', condition: 'sunny' }], new Date('2026-05-14T00:00:00Z'), getDateKey), null);
+});
+
+test('weather service builds Home Assistant forecast websocket payloads', async () => {
+  const {
+    buildWeatherForecastRequestMessage,
+    buildWeatherForecastSubscriptionMessage,
+    isWeatherEntityId
+  } = await import('./src/weather/weather-service.js');
+
+  assert.deepEqual(buildWeatherForecastSubscriptionMessage('weather.home'), {
+    type: 'weather/subscribe_forecast',
+    entity_id: 'weather.home',
+    forecast_type: 'daily'
+  });
+  assert.deepEqual(buildWeatherForecastRequestMessage('weather.home'), {
+    type: 'weather/get_forecasts',
+    entity_ids: ['weather.home'],
+    forecast_type: 'daily'
+  });
+  assert.equal(isWeatherEntityId('weather.home'), true);
+  assert.equal(isWeatherEntityId('sensor.home'), false);
+  assert.equal(isWeatherEntityId(''), false);
+});
 test('agenda view renders daily weather forecast', () => {
   const card = makeCard({
     entities: ['calendar.family'],

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -82,6 +82,19 @@ import {
   normalizeEventMatchConditions as normalizeRuleEventMatchConditions,
   normalizeLegacyDayStyleMatch as normalizeRuleLegacyDayStyleMatch
 } from './rules/style-rules.js';
+import {
+  getHeaderWeatherEntityRenderSignature,
+  getWeatherEntityForecast,
+  mapWeatherConditionToIcon as mapWeatherConditionToIconHelper,
+  normalizeForecastForDate,
+  normalizeHeaderWeatherData,
+  normalizeWeatherTemperature as normalizeWeatherTemperatureHelper
+} from './weather/weather-utils.js';
+import {
+  buildWeatherForecastRequestMessage,
+  buildWeatherForecastSubscriptionMessage,
+  isWeatherEntityId
+} from './weather/weather-service.js';
 
 const DAYLIGHT_CALENDAR_CARD_VERSION = 'v4.5.0';
 
@@ -10493,7 +10506,7 @@ class SkylightCalendarCard extends HTMLElement {
 
   async ensureWeatherForecastSubscription() {
     const entityId = this._config?.header_weather_sensor;
-    if (!entityId || !entityId.startsWith('weather.')) {
+    if (!isWeatherEntityId(entityId)) {
       this.teardownWeatherForecastSubscription();
       return;
     }
@@ -10524,11 +10537,7 @@ class SkylightCalendarCard extends HTMLElement {
             this._pendingHeaderSensorRender = true;
           }
         },
-        {
-          type: 'weather/subscribe_forecast',
-          entity_id: entityId,
-          forecast_type: 'daily'
-        }
+        buildWeatherForecastSubscriptionMessage(entityId)
       )
       .then((unsubscribe) => {
         const generationMatches = subscriptionGeneration === this._weatherForecastSubscriptionGeneration;
@@ -10562,7 +10571,7 @@ class SkylightCalendarCard extends HTMLElement {
 
   async refreshWeatherForecastData() {
     const entityId = this._config?.header_weather_sensor;
-    if (!entityId || !entityId.startsWith('weather.')) return;
+    if (!isWeatherEntityId(entityId)) return;
     if (!this._hass || this._weatherForecastRefreshInFlight) return;
     if (this._weatherForecastByEntity.has(entityId)) return;
     const now = Date.now();
@@ -10571,11 +10580,7 @@ class SkylightCalendarCard extends HTMLElement {
 
     this._weatherForecastRefreshInFlight = true;
     try {
-      const wsResponse = await this._hass.callWS({
-        type: 'weather/get_forecasts',
-        entity_ids: [entityId],
-        forecast_type: 'daily'
-      });
+      const wsResponse = await this._hass.callWS(buildWeatherForecastRequestMessage(entityId));
 
       const dailyForecast = wsResponse?.[entityId]?.forecast;
       if (Array.isArray(dailyForecast)) {
@@ -10597,23 +10602,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getHeaderEntityRenderSignature(entityState) {
-    if (!entityState) return '';
-    const attrs = entityState.attributes || {};
-    return JSON.stringify({
-      state: entityState.state,
-      temperature: attrs.temperature ?? attrs.current_temperature ?? attrs.temp ?? null,
-      condition: attrs.condition ?? null,
-      friendly_name: attrs.friendly_name ?? null,
-      entity_picture: attrs.entity_picture ?? null,
-      forecast: Array.isArray(attrs.forecast)
-        ? attrs.forecast.map((forecastItem) => ({
-          datetime: forecastItem?.datetime ?? forecastItem?.date ?? null,
-          condition: forecastItem?.condition ?? null,
-          high: forecastItem?.temperature ?? forecastItem?.temphigh ?? forecastItem?.high ?? null,
-          low: forecastItem?.templow ?? forecastItem?.low ?? forecastItem?.temperature_low ?? null
-        }))
-        : null
-    });
+    return getHeaderWeatherEntityRenderSignature(entityState);
   }
 
   getFormattedHeaderSensorTime() {
@@ -10626,54 +10615,18 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   normalizeWeatherTemperature(value) {
-    const numericValue = Number(value);
-    if (!Number.isFinite(numericValue)) return null;
-    return `${Math.round(numericValue)}°`;
+    return normalizeWeatherTemperatureHelper(value);
   }
 
   mapWeatherConditionToIcon(conditionValue) {
-    const condition = String(conditionValue || '').trim().toLowerCase().replace(/_/g, '-');
-    if (!condition || condition === 'unknown' || condition === 'unavailable') return '';
-
-    const iconMap = {
-      sunny: 'mdi:weather-sunny',
-      clear: 'mdi:weather-sunny',
-      'clear-night': 'mdi:weather-night',
-      partlycloudy: 'mdi:weather-partly-cloudy',
-      cloudy: 'mdi:weather-cloudy',
-      overcast: 'mdi:weather-cloudy',
-      rainy: 'mdi:weather-rainy',
-      pouring: 'mdi:weather-pouring',
-      snow: 'mdi:weather-snowy',
-      snowy: 'mdi:weather-snowy',
-      'snowy-rainy': 'mdi:weather-snowy-rainy',
-      hail: 'mdi:weather-hail',
-      lightning: 'mdi:weather-lightning',
-      'lightning-rainy': 'mdi:weather-lightning-rainy',
-      windy: 'mdi:weather-windy',
-      'windy-variant': 'mdi:weather-windy-variant',
-      fog: 'mdi:weather-fog',
-      exceptional: 'mdi:alert-circle-outline'
-    };
-
-    return iconMap[condition] || '';
+    return mapWeatherConditionToIconHelper(conditionValue);
   }
 
   getHeaderWeatherData() {
     const sensorEntityId = this._config?.header_weather_sensor;
     if (!sensorEntityId) return null;
     const weatherEntity = this._hass?.states?.[sensorEntityId];
-    if (!weatherEntity) return null;
-
-    const attrs = weatherEntity.attributes || {};
-    const condition = attrs.condition || weatherEntity.state;
-    const conditionIcon = this.mapWeatherConditionToIcon(condition);
-    const temperature = this.normalizeWeatherTemperature(
-      attrs.temperature ?? attrs.current_temperature ?? attrs.temp ?? weatherEntity.state
-    );
-
-    if (!conditionIcon || !temperature) return null;
-    return { conditionIcon, temperature };
+    return normalizeHeaderWeatherData(weatherEntity);
   }
 
   getFormattedHeaderWeather() {
@@ -10687,28 +10640,8 @@ class SkylightCalendarCard extends HTMLElement {
     if (!sensorEntityId) return null;
     const weatherEntity = this._hass?.states?.[sensorEntityId];
     const wsForecast = this._weatherForecastByEntity.get(sensorEntityId);
-    const forecasts = Array.isArray(wsForecast) && wsForecast.length > 0
-      ? wsForecast
-      : weatherEntity?.attributes?.forecast;
-    if (!Array.isArray(forecasts) || forecasts.length === 0) return null;
-
-    const targetDateKey = this.getDateKey(date);
-    const match = forecasts.find((item) => {
-      const forecastDateValue = item?.datetime || item?.date;
-      if (!forecastDateValue) return false;
-      const forecastDate = new Date(forecastDateValue);
-      if (Number.isNaN(forecastDate.getTime())) return false;
-      return this.getDateKey(forecastDate) === targetDateKey;
-    });
-
-    if (!match) return null;
-
-    const highTemp = this.normalizeWeatherTemperature(match.temperature ?? match.temphigh ?? match.high);
-    const lowTemp = this.normalizeWeatherTemperature(match.templow ?? match.low ?? match.temperature_low);
-    const conditionIcon = this.mapWeatherConditionToIcon(match.condition);
-
-    if (!conditionIcon || !highTemp) return null;
-    return { conditionIcon, highTemp, lowTemp };
+    const forecasts = getWeatherEntityForecast(weatherEntity, wsForecast);
+    return normalizeForecastForDate(forecasts, date, (forecastDate) => this.getDateKey(forecastDate));
   }
 
   renderDayForecast(date, viewMode = 'week-compact') {

--- a/src/weather/weather-service.js
+++ b/src/weather/weather-service.js
@@ -1,0 +1,19 @@
+export function isWeatherEntityId(entityId) {
+  return !!entityId && entityId.startsWith('weather.');
+}
+
+export function buildWeatherForecastSubscriptionMessage(entityId, forecastType = 'daily') {
+  return {
+    type: 'weather/subscribe_forecast',
+    entity_id: entityId,
+    forecast_type: forecastType
+  };
+}
+
+export function buildWeatherForecastRequestMessage(entityId, forecastType = 'daily') {
+  return {
+    type: 'weather/get_forecasts',
+    entity_ids: [entityId],
+    forecast_type: forecastType
+  };
+}

--- a/src/weather/weather-utils.js
+++ b/src/weather/weather-utils.js
@@ -1,0 +1,95 @@
+export function normalizeWeatherTemperature(value) {
+  const numericValue = Number(value);
+  if (!Number.isFinite(numericValue)) return null;
+  return `${Math.round(numericValue)}°`;
+}
+
+export function mapWeatherConditionToIcon(conditionValue) {
+  const condition = String(conditionValue || '').trim().toLowerCase().replace(/_/g, '-');
+  if (!condition || condition === 'unknown' || condition === 'unavailable') return '';
+
+  const iconMap = {
+    sunny: 'mdi:weather-sunny',
+    clear: 'mdi:weather-sunny',
+    'clear-night': 'mdi:weather-night',
+    partlycloudy: 'mdi:weather-partly-cloudy',
+    cloudy: 'mdi:weather-cloudy',
+    overcast: 'mdi:weather-cloudy',
+    rainy: 'mdi:weather-rainy',
+    pouring: 'mdi:weather-pouring',
+    snow: 'mdi:weather-snowy',
+    snowy: 'mdi:weather-snowy',
+    'snowy-rainy': 'mdi:weather-snowy-rainy',
+    hail: 'mdi:weather-hail',
+    lightning: 'mdi:weather-lightning',
+    'lightning-rainy': 'mdi:weather-lightning-rainy',
+    windy: 'mdi:weather-windy',
+    'windy-variant': 'mdi:weather-windy-variant',
+    fog: 'mdi:weather-fog',
+    exceptional: 'mdi:alert-circle-outline'
+  };
+
+  return iconMap[condition] || '';
+}
+
+export function normalizeHeaderWeatherData(weatherEntity) {
+  if (!weatherEntity) return null;
+
+  const attrs = weatherEntity.attributes || {};
+  const condition = attrs.condition || weatherEntity.state;
+  const conditionIcon = mapWeatherConditionToIcon(condition);
+  const temperature = normalizeWeatherTemperature(
+    attrs.temperature ?? attrs.current_temperature ?? attrs.temp ?? weatherEntity.state
+  );
+
+  if (!conditionIcon || !temperature) return null;
+  return { conditionIcon, temperature };
+}
+
+export function normalizeForecastForDate(forecasts, date, getDateKey) {
+  if (!Array.isArray(forecasts) || forecasts.length === 0) return null;
+
+  const targetDateKey = getDateKey(date);
+  const match = forecasts.find((item) => {
+    const forecastDateValue = item?.datetime || item?.date;
+    if (!forecastDateValue) return false;
+    const forecastDate = new Date(forecastDateValue);
+    if (Number.isNaN(forecastDate.getTime())) return false;
+    return getDateKey(forecastDate) === targetDateKey;
+  });
+
+  if (!match) return null;
+
+  const highTemp = normalizeWeatherTemperature(match.temperature ?? match.temphigh ?? match.high);
+  const lowTemp = normalizeWeatherTemperature(match.templow ?? match.low ?? match.temperature_low);
+  const conditionIcon = mapWeatherConditionToIcon(match.condition);
+
+  if (!conditionIcon || !highTemp) return null;
+  return { conditionIcon, highTemp, lowTemp };
+}
+
+export function getWeatherEntityForecast(weatherEntity, wsForecast) {
+  return Array.isArray(wsForecast) && wsForecast.length > 0
+    ? wsForecast
+    : weatherEntity?.attributes?.forecast;
+}
+
+export function getHeaderWeatherEntityRenderSignature(entityState) {
+  if (!entityState) return '';
+  const attrs = entityState.attributes || {};
+  return JSON.stringify({
+    state: entityState.state,
+    temperature: attrs.temperature ?? attrs.current_temperature ?? attrs.temp ?? null,
+    condition: attrs.condition ?? null,
+    friendly_name: attrs.friendly_name ?? null,
+    entity_picture: attrs.entity_picture ?? null,
+    forecast: Array.isArray(attrs.forecast)
+      ? attrs.forecast.map((forecastItem) => ({
+        datetime: forecastItem?.datetime ?? forecastItem?.date ?? null,
+        condition: forecastItem?.condition ?? null,
+        high: forecastItem?.temperature ?? forecastItem?.temphigh ?? forecastItem?.high ?? null,
+        low: forecastItem?.templow ?? forecastItem?.low ?? forecastItem?.temperature_low ?? null
+      }))
+      : null
+  });
+}


### PR DESCRIPTION
### Motivation
- Phase 8 of the modularization refactor extracts non-rendering weather logic into dedicated modules to separate pure data/service helpers from the main card while preserving runtime behavior. 
- Keep the changes mechanical and behavior-preserving so weather visuals, rendering, DOM, CSS, public config options, translations, and card versioning are unchanged.

### Description
- Added `src/weather/weather-utils.js` and moved pure weather helpers into it: `normalizeWeatherTemperature`, `mapWeatherConditionToIcon`, `normalizeHeaderWeatherData`, `normalizeForecastForDate`, `getWeatherEntityForecast`, and `getHeaderWeatherEntityRenderSignature`.
- Added `src/weather/weather-service.js` and moved small service/validation helpers into it: `isWeatherEntityId`, `buildWeatherForecastSubscriptionMessage`, and `buildWeatherForecastRequestMessage`.
- Updated `src/skylight-calendar-card.js` to import and delegate to the new modules where appropriate while preserving all render methods and card lifecycle orchestration; left subscription setup/teardown and render scheduling in the main card because they depend on instance state.
- Did not change weather rendering templates, CSS, DOM structure, public config syntax, custom element names, translations, or `DAYLIGHT_CALENDAR_CARD_VERSION`, and preserved Home Assistant forecast semantics.

### Testing
- Ran `npm ci --no-audit --fund=false` successfully.
- Ran `npm run build` successfully and regenerated the root artifact `skylight-calendar-card.js`, then verified `git diff --exit-code -- skylight-calendar-card.js` (clean after committing the regenerated artifact).
- Ran `node --check` on `src/skylight-calendar-card.js`, `src/weather/weather-utils.js`, `src/weather/weather-service.js`, and `skylight-calendar-card.js` with no errors.
- Ran unit tests with `npm test` and all tests passed (222 tests, 0 failures).
- Ran visual tests with `npm run test:visual` and all visual snapshots passed (39 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b2161624c8331ada3cc95043b51e4)