### PR TITLE
Extract event form validation and HA service payload builders into event modules (Phase 9)

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -2099,6 +2099,251 @@ function buildWeatherForecastRequestMessage(entityId, forecastType = 'daily') {
   };
 }
 
+const resolveTimedEventRange = (startValue, endValue, fallbackDurationMs = 60 * 60 * 1000) => {
+  const start = parsePossiblyLocalDateTime(startValue);
+  if (!(start instanceof Date) || Number.isNaN(start.getTime())) {
+    return { start: null, end: null };
+  }
+
+  const parsedEnd = endValue ? parsePossiblyLocalDateTime(endValue) : null;
+  if (parsedEnd instanceof Date && !Number.isNaN(parsedEnd.getTime())) {
+    return { start, end: parsedEnd };
+  }
+
+  return {
+    start,
+    end: new Date(start.getTime() + fallbackDurationMs)
+  };
+};
+
+const buildRRuleFromInputs = ({ frequency, interval, untilDate, count, byDay }) => {
+  const parts = [`FREQ=${frequency}`];
+  const parsedInterval = parseInt(interval, 10);
+
+  if (!Number.isNaN(parsedInterval) && parsedInterval > 1) {
+    parts.push(`INTERVAL=${parsedInterval}`);
+  }
+
+  if (Array.isArray(byDay) && byDay.length > 0) {
+    parts.push(`BYDAY=${byDay.join(',')}`);
+  }
+
+  const parsedCount = parseInt(count, 10);
+  if (!Number.isNaN(parsedCount) && parsedCount > 0) {
+    parts.push(`COUNT=${parsedCount}`);
+  } else if (untilDate) {
+    const until = new Date(`${untilDate}T23:59:59`);
+    if (!Number.isNaN(until.getTime())) {
+      const compactUntil = until.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+      parts.push(`UNTIL=${compactUntil}`);
+    }
+  }
+
+  return parts.join(';');
+};
+
+const normalizeEventFormData = ({
+  title,
+  location,
+  description,
+  isAllDay,
+  startDate,
+  endDate,
+  startDateTime,
+  endDateTime,
+  fallbackDurationMs = 60 * 60 * 1000,
+  recurrence = null
+}) => {
+  if (!title) {
+    return { valid: false, errorKey: 'eventTitleRequired' };
+  }
+
+  const eventData = {
+    summary: title,
+    location: location || undefined,
+    description: description || undefined
+  };
+
+  if (isAllDay) {
+    if (!startDate || !endDate) {
+      return { valid: false, errorKey: 'startEndDatesRequired' };
+    }
+
+    const start = parseLocalDate(startDate);
+    const end = parseLocalDate(endDate);
+
+    if (end < start) {
+      return { valid: false, errorKey: 'endDateBeforeStart' };
+    }
+
+    const exclusiveEndDate = new Date(end);
+    exclusiveEndDate.setDate(exclusiveEndDate.getDate() + 1);
+    const exclusiveEndDateStr = formatLocalDate(exclusiveEndDate);
+
+    eventData.start = { date: startDate };
+    eventData.end = { date: exclusiveEndDateStr };
+  } else {
+    if (!startDateTime) {
+      return { valid: false, errorKey: 'startEndTimesRequired' };
+    }
+
+    const { start, end } = resolveTimedEventRange(startDateTime, endDateTime, fallbackDurationMs);
+
+    if (end <= start) {
+      return { valid: false, errorKey: 'endTimeBeforeStart' };
+    }
+
+    eventData.start = { dateTime: start.toISOString() };
+    eventData.end = { dateTime: end.toISOString() };
+  }
+
+  if (recurrence?.enabled) {
+    if (recurrence.frequency === 'WEEKLY' && (!Array.isArray(recurrence.byDay) || recurrence.byDay.length === 0)) {
+      return { valid: false, errorKey: 'recurrenceSelectWeekday' };
+    }
+
+    eventData.rrule = buildRRuleFromInputs({
+      frequency: recurrence.frequency,
+      interval: recurrence.interval,
+      untilDate: recurrence.untilDate,
+      count: recurrence.count,
+      byDay: recurrence.frequency === 'WEEKLY' ? recurrence.byDay : []
+    });
+  }
+
+  return { valid: true, eventData };
+};
+
+const buildEventServiceData = (calendarId, eventData) => {
+  const baseData = {
+    entity_id: calendarId,
+    summary: eventData.summary
+  };
+
+  if (eventData.location) {
+    baseData.location = eventData.location;
+  }
+
+  if (eventData.description) {
+    baseData.description = eventData.description;
+  }
+
+  if (eventData.start.date) {
+    baseData.start_date = eventData.start.date;
+    baseData.end_date = eventData.end.date;
+  } else {
+    baseData.start_date_time = eventData.start.dateTime;
+    baseData.end_date_time = eventData.end.dateTime;
+  }
+
+  if (eventData.rrule) {
+    baseData.rrule = eventData.rrule;
+  }
+
+  return baseData;
+};
+
+const buildCreateEventWebSocketPayload = (calendarId, eventData) => ({
+  type: 'calendar/event/create',
+  entity_id: calendarId,
+  event: {
+    summary: eventData.summary,
+    location: eventData.location,
+    description: eventData.description,
+    rrule: eventData.rrule,
+    dtstart: eventData.start.dateTime || eventData.start.date,
+    dtend: eventData.end.dateTime || eventData.end.date
+  }
+});
+
+const getRecurringUpdateControls = (originalEvent, eventData, editScope = 'this') => {
+  const isRecurringUpdate = !!eventData.rrule || !!originalEvent.rrule;
+  return {
+    isRecurringUpdate,
+    recurrenceId: (isRecurringUpdate && editScope !== 'all') ? originalEvent.recurrence_id : null,
+    recurrenceRange: (isRecurringUpdate && editScope === 'future' && originalEvent.recurrence_id) ? 'THISANDFUTURE' : null
+  };
+};
+
+const buildUpdateEventServiceData = (originalEvent, eventData, recurrenceId = null, recurrenceRange = null) => {
+  const serviceData = {
+    ...buildEventServiceData(originalEvent.entityId, eventData),
+    uid: originalEvent.uid
+  };
+
+  if (recurrenceId) {
+    serviceData.recurrence_id = recurrenceId;
+  }
+
+  if (recurrenceRange) {
+    serviceData.recurrence_range = recurrenceRange;
+  }
+
+  return serviceData;
+};
+
+const buildUpdateEventWebSocketPayload = (originalEvent, eventData, recurrenceId = null, recurrenceRange = null) => {
+  const dtstart = eventData.start.dateTime || eventData.start.date;
+  const dtend = eventData.end.dateTime || eventData.end.date;
+
+  const eventPayload = {
+    summary: eventData.summary,
+    dtstart,
+    dtend
+  };
+
+  if (eventData.location) {
+    eventPayload.location = eventData.location;
+  }
+
+  if (eventData.description) {
+    eventPayload.description = eventData.description;
+  }
+
+  if (eventData.rrule) {
+    eventPayload.rrule = eventData.rrule;
+  }
+
+  const wsPayload = {
+    type: 'calendar/event/update',
+    entity_id: originalEvent.entityId,
+    uid: originalEvent.uid,
+    event: eventPayload
+  };
+
+  if (recurrenceId) {
+    wsPayload.recurrence_id = recurrenceId;
+  }
+
+  if (recurrenceRange) {
+    wsPayload.recurrence_range = recurrenceRange;
+  }
+
+  return wsPayload;
+};
+
+const buildDeleteEventPayload = (calendarId, uid, recurrenceId = null, recurrenceRange = null) => {
+  const payload = {
+    entity_id: calendarId,
+    uid: uid
+  };
+
+  if (recurrenceId) {
+    payload.recurrence_id = recurrenceId;
+  }
+
+  if (recurrenceRange) {
+    payload.recurrence_range = recurrenceRange;
+  }
+
+  return payload;
+};
+
+const buildDeleteEventWebSocketPayload = (calendarId, uid, recurrenceId = null, recurrenceRange = null) => ({
+  type: 'calendar/event/delete',
+  ...buildDeleteEventPayload(calendarId, uid, recurrenceId, recurrenceRange)
+});
+
 const DAYLIGHT_CALENDAR_CARD_VERSION = 'v4.5.0';
 
 function getDaylightCalendarCardVersion() {
@@ -10469,29 +10714,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   buildRRuleFromInputs({ frequency, interval, untilDate, count, byDay }) {
-    const parts = [`FREQ=${frequency}`];
-    const parsedInterval = parseInt(interval, 10);
-
-    if (!Number.isNaN(parsedInterval) && parsedInterval > 1) {
-      parts.push(`INTERVAL=${parsedInterval}`);
-    }
-
-    if (Array.isArray(byDay) && byDay.length > 0) {
-      parts.push(`BYDAY=${byDay.join(',')}`);
-    }
-
-    const parsedCount = parseInt(count, 10);
-    if (!Number.isNaN(parsedCount) && parsedCount > 0) {
-      parts.push(`COUNT=${parsedCount}`);
-    } else if (untilDate) {
-      const until = new Date(`${untilDate}T23:59:59`);
-      if (!Number.isNaN(until.getTime())) {
-        const compactUntil = until.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
-        parts.push(`UNTIL=${compactUntil}`);
-      }
-    }
-
-    return parts.join(';');
+    return buildRRuleFromInputs({ frequency, interval, untilDate, count, byDay });
   }
 
   parseRRule(rrule = '') {
@@ -10611,20 +10834,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   resolveTimedEventRange(startValue, endValue, fallbackDurationMs = 60 * 60 * 1000) {
-    const start = this.parsePossiblyLocalDateTime(startValue);
-    if (!(start instanceof Date) || Number.isNaN(start.getTime())) {
-      return { start: null, end: null };
-    }
-
-    const parsedEnd = endValue ? this.parsePossiblyLocalDateTime(endValue) : null;
-    if (parsedEnd instanceof Date && !Number.isNaN(parsedEnd.getTime())) {
-      return { start, end: parsedEnd };
-    }
-
-    return {
-      start,
-      end: new Date(start.getTime() + fallbackDurationMs)
-    };
+    return resolveTimedEventRange(startValue, endValue, fallbackDurationMs);
   }
 
   showCreateEventModal(defaultDate = null, defaultTime = null, options = {}) {
@@ -10937,61 +11147,23 @@ class SkylightCalendarCard extends HTMLElement {
         return;
       }
 
-      if (!title) {
-        this.showFormError(errorDiv, this.t('eventTitleRequired'));
+      const formResult = normalizeEventFormData({
+        title,
+        location,
+        description,
+        isAllDay,
+        startDate: this.getRootElementById('event-start-date').value,
+        endDate: this.getRootElementById('event-end-date').value,
+        startDateTime: this.getRootElementById('event-start').value,
+        endDateTime: this.getRootElementById('event-end').value
+      });
+
+      if (!formResult.valid) {
+        this.showFormError(errorDiv, this.t(formResult.errorKey));
         return;
       }
 
-      let eventData = {
-        summary: title,
-        location: location || undefined,
-        description: description || undefined
-      };
-
-      if (isAllDay) {
-        const startDate = this.getRootElementById('event-start-date').value;
-        const endDate = this.getRootElementById('event-end-date').value;
-
-        if (!startDate || !endDate) {
-          this.showFormError(errorDiv, this.t('startEndDatesRequired'));
-          return;
-        }
-
-        // Validate that end date is on or after start date
-        const start = this.parseLocalDate(startDate);
-        const end = this.parseLocalDate(endDate);
-
-        if (end < start) {
-          this.showFormError(errorDiv, this.t('endDateBeforeStart'));
-          return;
-        }
-
-        // For Home Assistant, end date is exclusive, so add 1 day
-        const exclusiveEndDate = new Date(end);
-        exclusiveEndDate.setDate(exclusiveEndDate.getDate() + 1);
-        const exclusiveEndDateStr = this.formatLocalDate(exclusiveEndDate);
-
-        eventData.start = { date: startDate };
-        eventData.end = { date: exclusiveEndDateStr };
-      } else {
-        const startDateTime = this.getRootElementById('event-start').value;
-        const endDateTime = this.getRootElementById('event-end').value;
-
-        if (!startDateTime) {
-          this.showFormError(errorDiv, this.t('startEndTimesRequired'));
-          return;
-        }
-
-        const { start, end } = this.resolveTimedEventRange(startDateTime, endDateTime);
-
-        if (end <= start) {
-          this.showFormError(errorDiv, this.t('endTimeBeforeStart'));
-          return;
-        }
-
-        eventData.start = { dateTime: start.toISOString() };
-        eventData.end = { dateTime: end.toISOString() };
-      }
+      let eventData = formResult.eventData;
 
       if (recurringCheckbox.checked) {
         const frequency = this.getRootElementById('event-recurrence-frequency').value;
@@ -11002,19 +11174,31 @@ class SkylightCalendarCard extends HTMLElement {
         const untilDate = recurrenceEndMode === 'on' ? untilDateRaw : '';
         const recurrenceCount = recurrenceEndMode === 'after' ? recurrenceCountRaw : '';
         const byDay = Array.from(this._root.querySelectorAll('.event-recurrence-weekday:checked')).map((el) => el.value);
+        const recurrenceResult = normalizeEventFormData({
+          title,
+          location,
+          description,
+          isAllDay,
+          startDate: this.getRootElementById('event-start-date').value,
+          endDate: this.getRootElementById('event-end-date').value,
+          startDateTime: this.getRootElementById('event-start').value,
+          endDateTime: this.getRootElementById('event-end').value,
+          recurrence: {
+            enabled: true,
+            frequency,
+            interval,
+            untilDate,
+            count: recurrenceCount,
+            byDay
+          }
+        });
 
-        if (frequency === 'WEEKLY' && byDay.length === 0) {
-          this.showFormError(errorDiv, this.t('recurrenceSelectWeekday'));
+        if (!recurrenceResult.valid) {
+          this.showFormError(errorDiv, this.t(recurrenceResult.errorKey));
           return;
         }
 
-        eventData.rrule = this.buildRRuleFromInputs({
-          frequency,
-          interval,
-          untilDate,
-          count: recurrenceCount,
-          byDay: frequency === 'WEEKLY' ? byDay : []
-        });
+        eventData = recurrenceResult.eventData;
       }
 
       // Disable submit button
@@ -11321,62 +11505,24 @@ class SkylightCalendarCard extends HTMLElement {
       const location = this.getRootElementById('event-location').value.trim();
       const description = this.getRootElementById('event-description').value.trim();
 
-      if (!title) {
-        this.showFormError(errorDiv, this.t('eventTitleRequired'));
+      const formResult = normalizeEventFormData({
+        title,
+        location,
+        description,
+        isAllDay: isAllDayChecked,
+        startDate: this.getRootElementById('event-start-date').value,
+        endDate: this.getRootElementById('event-end-date').value,
+        startDateTime: this.getRootElementById('event-start').value,
+        endDateTime: this.getRootElementById('event-end').value,
+        fallbackDurationMs: Math.max(endDate.getTime() - startDate.getTime(), 60 * 1000)
+      });
+
+      if (!formResult.valid) {
+        this.showFormError(errorDiv, this.t(formResult.errorKey));
         return;
       }
 
-      let eventData = {
-        summary: title,
-        location: location || undefined,
-        description: description || undefined
-      };
-
-      if (isAllDayChecked) {
-        const startDateStr = this.getRootElementById('event-start-date').value;
-        const endDateStr = this.getRootElementById('event-end-date').value;
-
-        if (!startDateStr || !endDateStr) {
-          this.showFormError(errorDiv, this.t('startEndDatesRequired'));
-          return;
-        }
-
-        // Validate that end date is on or after start date
-        const start = this.parseLocalDate(startDateStr);
-        const end = this.parseLocalDate(endDateStr);
-
-        if (end < start) {
-          this.showFormError(errorDiv, this.t('endDateBeforeStart'));
-          return;
-        }
-
-        // For Home Assistant, end date is exclusive, so add 1 day
-        const exclusiveEndDate = new Date(end);
-        exclusiveEndDate.setDate(exclusiveEndDate.getDate() + 1);
-        const exclusiveEndDateStr = this.formatLocalDate(exclusiveEndDate);
-
-        eventData.start = { date: startDateStr };
-        eventData.end = { date: exclusiveEndDateStr };
-      } else {
-        const startDateTime = this.getRootElementById('event-start').value;
-        const endDateTime = this.getRootElementById('event-end').value;
-        const existingDurationMs = Math.max(endDate.getTime() - startDate.getTime(), 60 * 1000);
-
-        if (!startDateTime) {
-          this.showFormError(errorDiv, this.t('startEndTimesRequired'));
-          return;
-        }
-
-        const { start, end } = this.resolveTimedEventRange(startDateTime, endDateTime, existingDurationMs);
-
-        if (end <= start) {
-          this.showFormError(errorDiv, this.t('endTimeBeforeStart'));
-          return;
-        }
-
-        eventData.start = { dateTime: start.toISOString() };
-        eventData.end = { dateTime: end.toISOString() };
-      }
+      let eventData = formResult.eventData;
 
       if (recurringCheckbox.checked) {
         const frequency = this.getRootElementById('event-recurrence-frequency').value;
@@ -11387,19 +11533,32 @@ class SkylightCalendarCard extends HTMLElement {
         const untilDate = recurrenceEndMode === 'on' ? untilDateRaw : '';
         const recurrenceCount = recurrenceEndMode === 'after' ? recurrenceCountRaw : '';
         const byDay = Array.from(this._root.querySelectorAll('.event-recurrence-weekday:checked')).map((el) => el.value);
+        const recurrenceResult = normalizeEventFormData({
+          title,
+          location,
+          description,
+          isAllDay: isAllDayChecked,
+          startDate: this.getRootElementById('event-start-date').value,
+          endDate: this.getRootElementById('event-end-date').value,
+          startDateTime: this.getRootElementById('event-start').value,
+          endDateTime: this.getRootElementById('event-end').value,
+          fallbackDurationMs: Math.max(endDate.getTime() - startDate.getTime(), 60 * 1000),
+          recurrence: {
+            enabled: true,
+            frequency,
+            interval,
+            untilDate,
+            count: recurrenceCount,
+            byDay
+          }
+        });
 
-        if (frequency === 'WEEKLY' && byDay.length === 0) {
-          this.showFormError(errorDiv, this.t('recurrenceSelectWeekday'));
+        if (!recurrenceResult.valid) {
+          this.showFormError(errorDiv, this.t(recurrenceResult.errorKey));
           return;
         }
 
-        eventData.rrule = this.buildRRuleFromInputs({
-          frequency,
-          interval,
-          untilDate,
-          count: recurrenceCount,
-          byDay: frequency === 'WEEKLY' ? byDay : []
-        });
+        eventData = recurrenceResult.eventData;
       }
 
       // Disable submit button
@@ -11470,47 +11629,10 @@ class SkylightCalendarCard extends HTMLElement {
       throw new Error(this.t('missingUidError'));
     }
 
-    const isRecurringUpdate = !!eventData.rrule || !!originalEvent.rrule;
-
-    const recurrenceId = (isRecurringUpdate && editScope !== 'all') ? originalEvent.recurrence_id : null;
-    const recurrenceRange = (isRecurringUpdate && editScope === 'future' && originalEvent.recurrence_id) ? 'THISANDFUTURE' : null;
+    const { isRecurringUpdate, recurrenceId, recurrenceRange } = getRecurringUpdateControls(originalEvent, eventData, editScope);
 
     if (isRecurringUpdate && !movingCalendar && this._hass.connection?.sendMessagePromise) {
-      const dtstart = eventData.start.dateTime || eventData.start.date;
-      const dtend = eventData.end.dateTime || eventData.end.date;
-
-      const eventPayload = {
-        summary: eventData.summary,
-        dtstart,
-        dtend
-      };
-
-      if (eventData.location) {
-        eventPayload.location = eventData.location;
-      }
-
-      if (eventData.description) {
-        eventPayload.description = eventData.description;
-      }
-
-      if (eventData.rrule) {
-        eventPayload.rrule = eventData.rrule;
-      }
-
-      const wsPayload = {
-        type: 'calendar/event/update',
-        entity_id: originalEvent.entityId,
-        uid: originalEvent.uid,
-        event: eventPayload
-      };
-
-      if (recurrenceId) {
-        wsPayload.recurrence_id = recurrenceId;
-      }
-
-      if (recurrenceRange) {
-        wsPayload.recurrence_range = recurrenceRange;
-      }
+      const wsPayload = buildUpdateEventWebSocketPayload(originalEvent, eventData, recurrenceId, recurrenceRange);
 
       try {
         await this._hass.connection.sendMessagePromise(wsPayload);
@@ -11524,43 +11646,7 @@ class SkylightCalendarCard extends HTMLElement {
     const hasUpdateService = !!this._hass.services?.calendar?.update_event;
     if (capabilities.canUpdate && !movingCalendar && hasUpdateService) {
       try {
-        const serviceData = {
-          entity_id: originalEvent.entityId,
-          uid: originalEvent.uid,
-          summary: eventData.summary
-        };
-
-        // Add location if provided
-        if (eventData.location) {
-          serviceData.location = eventData.location;
-        }
-
-        // Add description if provided
-        if (eventData.description) {
-          serviceData.description = eventData.description;
-        }
-
-        // Add date/time fields
-        if (eventData.start.date) {
-          serviceData.start_date = eventData.start.date;
-          serviceData.end_date = eventData.end.date;
-        } else {
-          serviceData.start_date_time = eventData.start.dateTime;
-          serviceData.end_date_time = eventData.end.dateTime;
-        }
-
-        if (eventData.rrule) {
-          serviceData.rrule = eventData.rrule;
-        }
-
-        // Add recurrence controls for recurring event edits
-        if (recurrenceId) {
-          serviceData.recurrence_id = recurrenceId;
-        }
-
-        if (recurrenceRange) {
-          serviceData.recurrence_range = recurrenceRange;
-        }
+        const serviceData = buildUpdateEventServiceData(originalEvent, eventData, recurrenceId, recurrenceRange);
 
         await this._hass.callService('calendar', 'update_event', serviceData);
         return;
@@ -11598,21 +11684,7 @@ class SkylightCalendarCard extends HTMLElement {
     // This is the official Calendar WebSocket API that the HA Calendar UI uses
     try {
       if (this._hass.connection && this._hass.connection.sendMessagePromise && uid) {
-        const payload = {
-          type: 'calendar/event/delete',
-          entity_id: calendarId,
-          uid: uid
-        };
-
-        // Add recurrence_id if deleting a specific instance
-        if (recurrenceId) {
-          payload.recurrence_id = recurrenceId;
-        }
-
-        // Add recurrence_range if deleting this and future events
-        if (recurrenceRange) {
-          payload.recurrence_range = recurrenceRange;
-        }
+        const payload = buildDeleteEventWebSocketPayload(calendarId, uid, recurrenceId, recurrenceRange);
 
         await this._hass.connection.sendMessagePromise(payload);
         return; // Success via WebSocket
@@ -11623,20 +11695,7 @@ class SkylightCalendarCard extends HTMLElement {
     }
 
     // Fallback to service call (works for Local Calendar and some others)
-    const serviceData = {
-      entity_id: calendarId,
-      uid: uid
-    };
-
-    // Add recurrence_id if deleting a specific instance
-    if (recurrenceId) {
-      serviceData.recurrence_id = recurrenceId;
-    }
-
-    // Add recurrence_range if deleting this and future events
-    if (recurrenceRange) {
-      serviceData.recurrence_range = recurrenceRange;
-    }
+    const serviceData = buildDeleteEventPayload(calendarId, uid, recurrenceId, recurrenceRange);
 
     try {
       await this._hass.callService('calendar', 'delete_event', serviceData);
@@ -11654,44 +11713,14 @@ class SkylightCalendarCard extends HTMLElement {
     const isRecurring = !!eventData.rrule;
 
     // Build service-style data (used by both API variants)
-    const baseData = {
-      entity_id: calendarId,
-      summary: eventData.summary
-    };
-
-    if (eventData.location) {
-      baseData.location = eventData.location;
-    }
-
-    if (eventData.description) {
-      baseData.description = eventData.description;
-    }
-
-    if (eventData.start.date) {
-      baseData.start_date = eventData.start.date;
-      baseData.end_date = eventData.end.date;
-    } else {
-      baseData.start_date_time = eventData.start.dateTime;
-      baseData.end_date_time = eventData.end.dateTime;
-    }
+    const baseData = buildEventServiceData(calendarId, eventData);
 
     if (isRecurring) {
       baseData.rrule = eventData.rrule;
 
       // HA recurring event support is exposed through Calendar WebSocket API.
       // WebSocket schema expects event.dtstart / event.dtend (not start/end keys).
-      const wsPayload = {
-        type: 'calendar/event/create',
-        entity_id: calendarId,
-        event: {
-          summary: baseData.summary,
-          location: baseData.location,
-          description: baseData.description,
-          rrule: baseData.rrule,
-          dtstart: eventData.start.dateTime || eventData.start.date,
-          dtend: eventData.end.dateTime || eventData.end.date
-        }
-      };
+      const wsPayload = buildCreateEventWebSocketPayload(calendarId, eventData);
 
       try {
         if (this._hass.connection?.sendMessagePromise) {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -4209,3 +4209,140 @@ test('day badge module preserves normalization, safe resolution, and render prep
   assert.equal(normalizedRules[0].conditions.title_contains, 'helper');
   assert.equal(normalizedRules[1].match.event.title, 'Helper');
 });
+
+test('event form helper preserves validation message keys and normalized data', async () => {
+  const { normalizeEventFormData } = await import('./src/events/event-form.js');
+
+  assert.deepEqual(normalizeEventFormData({ title: '', isAllDay: true }), { valid: false, errorKey: 'eventTitleRequired' });
+  assert.deepEqual(normalizeEventFormData({ title: 'Event', isAllDay: true, startDate: '', endDate: '2026-05-01' }), { valid: false, errorKey: 'startEndDatesRequired' });
+  assert.deepEqual(normalizeEventFormData({ title: 'Event', isAllDay: false, startDateTime: '', endDateTime: '2026-05-01T11:00' }), { valid: false, errorKey: 'startEndTimesRequired' });
+  assert.deepEqual(normalizeEventFormData({ title: 'Event', isAllDay: true, startDate: '2026-05-02', endDate: '2026-05-01' }), { valid: false, errorKey: 'endDateBeforeStart' });
+  assert.deepEqual(normalizeEventFormData({ title: 'Event', isAllDay: false, startDateTime: '2026-05-01T11:00', endDateTime: '2026-05-01T10:00' }), { valid: false, errorKey: 'endTimeBeforeStart' });
+
+  const allDay = normalizeEventFormData({
+    title: 'All day',
+    location: '',
+    description: 'Notes',
+    isAllDay: true,
+    startDate: '2026-05-01',
+    endDate: '2026-05-01'
+  });
+  assert.equal(allDay.valid, true);
+  assert.deepEqual(allDay.eventData, {
+    summary: 'All day',
+    location: undefined,
+    description: 'Notes',
+    start: { date: '2026-05-01' },
+    end: { date: '2026-05-02' }
+  });
+
+  const timed = normalizeEventFormData({
+    title: 'Timed',
+    location: 'Room',
+    description: '',
+    isAllDay: false,
+    startDateTime: '2026-05-01T10:00',
+    endDateTime: '2026-05-01T11:00'
+  });
+  assert.equal(timed.valid, true);
+  assert.equal(timed.eventData.summary, 'Timed');
+  assert.equal(timed.eventData.location, 'Room');
+  assert.equal(timed.eventData.description, undefined);
+  assert.equal(timed.eventData.start.dateTime, new Date('2026-05-01T10:00').toISOString());
+  assert.equal(timed.eventData.end.dateTime, new Date('2026-05-01T11:00').toISOString());
+});
+
+test('event service helpers preserve create update and delete payload shapes', async () => {
+  const {
+    buildCreateEventWebSocketPayload,
+    buildDeleteEventPayload,
+    buildDeleteEventWebSocketPayload,
+    buildEventServiceData,
+    buildUpdateEventServiceData,
+    buildUpdateEventWebSocketPayload,
+    getRecurringUpdateControls
+  } = await import('./src/events/event-service.js');
+
+  const allDayEventData = {
+    summary: 'All day',
+    location: 'Home',
+    description: 'Desc',
+    start: { date: '2026-05-01' },
+    end: { date: '2026-05-02' }
+  };
+  assert.deepEqual(buildEventServiceData('calendar.home', allDayEventData), {
+    entity_id: 'calendar.home',
+    summary: 'All day',
+    location: 'Home',
+    description: 'Desc',
+    start_date: '2026-05-01',
+    end_date: '2026-05-02'
+  });
+
+  const timedEventData = {
+    summary: 'Timed',
+    start: { dateTime: '2026-05-01T10:00:00.000Z' },
+    end: { dateTime: '2026-05-01T11:00:00.000Z' },
+    rrule: 'FREQ=WEEKLY;BYDAY=FR'
+  };
+  assert.deepEqual(buildEventServiceData('calendar.work', timedEventData), {
+    entity_id: 'calendar.work',
+    summary: 'Timed',
+    start_date_time: '2026-05-01T10:00:00.000Z',
+    end_date_time: '2026-05-01T11:00:00.000Z',
+    rrule: 'FREQ=WEEKLY;BYDAY=FR'
+  });
+
+  assert.deepEqual(buildCreateEventWebSocketPayload('calendar.work', timedEventData), {
+    type: 'calendar/event/create',
+    entity_id: 'calendar.work',
+    event: {
+      summary: 'Timed',
+      location: undefined,
+      description: undefined,
+      rrule: 'FREQ=WEEKLY;BYDAY=FR',
+      dtstart: '2026-05-01T10:00:00.000Z',
+      dtend: '2026-05-01T11:00:00.000Z'
+    }
+  });
+
+  const originalEvent = { entityId: 'calendar.work', uid: 'uid-1', recurrence_id: 'rid-1', rrule: 'FREQ=WEEKLY' };
+  const controls = getRecurringUpdateControls(originalEvent, timedEventData, 'future');
+  assert.deepEqual(controls, { isRecurringUpdate: true, recurrenceId: 'rid-1', recurrenceRange: 'THISANDFUTURE' });
+  assert.deepEqual(buildUpdateEventServiceData(originalEvent, timedEventData, controls.recurrenceId, controls.recurrenceRange), {
+    entity_id: 'calendar.work',
+    summary: 'Timed',
+    start_date_time: '2026-05-01T10:00:00.000Z',
+    end_date_time: '2026-05-01T11:00:00.000Z',
+    rrule: 'FREQ=WEEKLY;BYDAY=FR',
+    uid: 'uid-1',
+    recurrence_id: 'rid-1',
+    recurrence_range: 'THISANDFUTURE'
+  });
+  assert.deepEqual(buildUpdateEventWebSocketPayload(originalEvent, timedEventData, controls.recurrenceId, controls.recurrenceRange), {
+    type: 'calendar/event/update',
+    entity_id: 'calendar.work',
+    uid: 'uid-1',
+    event: {
+      summary: 'Timed',
+      dtstart: '2026-05-01T10:00:00.000Z',
+      dtend: '2026-05-01T11:00:00.000Z',
+      rrule: 'FREQ=WEEKLY;BYDAY=FR'
+    },
+    recurrence_id: 'rid-1',
+    recurrence_range: 'THISANDFUTURE'
+  });
+  assert.deepEqual(buildDeleteEventPayload('calendar.work', 'uid-1', 'rid-1', 'THISANDFUTURE'), {
+    entity_id: 'calendar.work',
+    uid: 'uid-1',
+    recurrence_id: 'rid-1',
+    recurrence_range: 'THISANDFUTURE'
+  });
+  assert.deepEqual(buildDeleteEventWebSocketPayload('calendar.work', 'uid-1', 'rid-1', 'THISANDFUTURE'), {
+    type: 'calendar/event/delete',
+    entity_id: 'calendar.work',
+    uid: 'uid-1',
+    recurrence_id: 'rid-1',
+    recurrence_range: 'THISANDFUTURE'
+  });
+});

--- a/src/events/event-form.js
+++ b/src/events/event-form.js
@@ -1,0 +1,116 @@
+import { formatLocalDate, parseLocalDate, parsePossiblyLocalDateTime } from '../utils/date-utils.js';
+
+export const resolveTimedEventRange = (startValue, endValue, fallbackDurationMs = 60 * 60 * 1000) => {
+  const start = parsePossiblyLocalDateTime(startValue);
+  if (!(start instanceof Date) || Number.isNaN(start.getTime())) {
+    return { start: null, end: null };
+  }
+
+  const parsedEnd = endValue ? parsePossiblyLocalDateTime(endValue) : null;
+  if (parsedEnd instanceof Date && !Number.isNaN(parsedEnd.getTime())) {
+    return { start, end: parsedEnd };
+  }
+
+  return {
+    start,
+    end: new Date(start.getTime() + fallbackDurationMs)
+  };
+};
+
+export const buildRRuleFromInputs = ({ frequency, interval, untilDate, count, byDay }) => {
+  const parts = [`FREQ=${frequency}`];
+  const parsedInterval = parseInt(interval, 10);
+
+  if (!Number.isNaN(parsedInterval) && parsedInterval > 1) {
+    parts.push(`INTERVAL=${parsedInterval}`);
+  }
+
+  if (Array.isArray(byDay) && byDay.length > 0) {
+    parts.push(`BYDAY=${byDay.join(',')}`);
+  }
+
+  const parsedCount = parseInt(count, 10);
+  if (!Number.isNaN(parsedCount) && parsedCount > 0) {
+    parts.push(`COUNT=${parsedCount}`);
+  } else if (untilDate) {
+    const until = new Date(`${untilDate}T23:59:59`);
+    if (!Number.isNaN(until.getTime())) {
+      const compactUntil = until.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+      parts.push(`UNTIL=${compactUntil}`);
+    }
+  }
+
+  return parts.join(';');
+};
+
+export const normalizeEventFormData = ({
+  title,
+  location,
+  description,
+  isAllDay,
+  startDate,
+  endDate,
+  startDateTime,
+  endDateTime,
+  fallbackDurationMs = 60 * 60 * 1000,
+  recurrence = null
+}) => {
+  if (!title) {
+    return { valid: false, errorKey: 'eventTitleRequired' };
+  }
+
+  const eventData = {
+    summary: title,
+    location: location || undefined,
+    description: description || undefined
+  };
+
+  if (isAllDay) {
+    if (!startDate || !endDate) {
+      return { valid: false, errorKey: 'startEndDatesRequired' };
+    }
+
+    const start = parseLocalDate(startDate);
+    const end = parseLocalDate(endDate);
+
+    if (end < start) {
+      return { valid: false, errorKey: 'endDateBeforeStart' };
+    }
+
+    const exclusiveEndDate = new Date(end);
+    exclusiveEndDate.setDate(exclusiveEndDate.getDate() + 1);
+    const exclusiveEndDateStr = formatLocalDate(exclusiveEndDate);
+
+    eventData.start = { date: startDate };
+    eventData.end = { date: exclusiveEndDateStr };
+  } else {
+    if (!startDateTime) {
+      return { valid: false, errorKey: 'startEndTimesRequired' };
+    }
+
+    const { start, end } = resolveTimedEventRange(startDateTime, endDateTime, fallbackDurationMs);
+
+    if (end <= start) {
+      return { valid: false, errorKey: 'endTimeBeforeStart' };
+    }
+
+    eventData.start = { dateTime: start.toISOString() };
+    eventData.end = { dateTime: end.toISOString() };
+  }
+
+  if (recurrence?.enabled) {
+    if (recurrence.frequency === 'WEEKLY' && (!Array.isArray(recurrence.byDay) || recurrence.byDay.length === 0)) {
+      return { valid: false, errorKey: 'recurrenceSelectWeekday' };
+    }
+
+    eventData.rrule = buildRRuleFromInputs({
+      frequency: recurrence.frequency,
+      interval: recurrence.interval,
+      untilDate: recurrence.untilDate,
+      count: recurrence.count,
+      byDay: recurrence.frequency === 'WEEKLY' ? recurrence.byDay : []
+    });
+  }
+
+  return { valid: true, eventData };
+};

--- a/src/events/event-service.js
+++ b/src/events/event-service.js
@@ -1,0 +1,129 @@
+export const buildEventServiceData = (calendarId, eventData) => {
+  const baseData = {
+    entity_id: calendarId,
+    summary: eventData.summary
+  };
+
+  if (eventData.location) {
+    baseData.location = eventData.location;
+  }
+
+  if (eventData.description) {
+    baseData.description = eventData.description;
+  }
+
+  if (eventData.start.date) {
+    baseData.start_date = eventData.start.date;
+    baseData.end_date = eventData.end.date;
+  } else {
+    baseData.start_date_time = eventData.start.dateTime;
+    baseData.end_date_time = eventData.end.dateTime;
+  }
+
+  if (eventData.rrule) {
+    baseData.rrule = eventData.rrule;
+  }
+
+  return baseData;
+};
+
+export const buildCreateEventWebSocketPayload = (calendarId, eventData) => ({
+  type: 'calendar/event/create',
+  entity_id: calendarId,
+  event: {
+    summary: eventData.summary,
+    location: eventData.location,
+    description: eventData.description,
+    rrule: eventData.rrule,
+    dtstart: eventData.start.dateTime || eventData.start.date,
+    dtend: eventData.end.dateTime || eventData.end.date
+  }
+});
+
+export const getRecurringUpdateControls = (originalEvent, eventData, editScope = 'this') => {
+  const isRecurringUpdate = !!eventData.rrule || !!originalEvent.rrule;
+  return {
+    isRecurringUpdate,
+    recurrenceId: (isRecurringUpdate && editScope !== 'all') ? originalEvent.recurrence_id : null,
+    recurrenceRange: (isRecurringUpdate && editScope === 'future' && originalEvent.recurrence_id) ? 'THISANDFUTURE' : null
+  };
+};
+
+export const buildUpdateEventServiceData = (originalEvent, eventData, recurrenceId = null, recurrenceRange = null) => {
+  const serviceData = {
+    ...buildEventServiceData(originalEvent.entityId, eventData),
+    uid: originalEvent.uid
+  };
+
+  if (recurrenceId) {
+    serviceData.recurrence_id = recurrenceId;
+  }
+
+  if (recurrenceRange) {
+    serviceData.recurrence_range = recurrenceRange;
+  }
+
+  return serviceData;
+};
+
+export const buildUpdateEventWebSocketPayload = (originalEvent, eventData, recurrenceId = null, recurrenceRange = null) => {
+  const dtstart = eventData.start.dateTime || eventData.start.date;
+  const dtend = eventData.end.dateTime || eventData.end.date;
+
+  const eventPayload = {
+    summary: eventData.summary,
+    dtstart,
+    dtend
+  };
+
+  if (eventData.location) {
+    eventPayload.location = eventData.location;
+  }
+
+  if (eventData.description) {
+    eventPayload.description = eventData.description;
+  }
+
+  if (eventData.rrule) {
+    eventPayload.rrule = eventData.rrule;
+  }
+
+  const wsPayload = {
+    type: 'calendar/event/update',
+    entity_id: originalEvent.entityId,
+    uid: originalEvent.uid,
+    event: eventPayload
+  };
+
+  if (recurrenceId) {
+    wsPayload.recurrence_id = recurrenceId;
+  }
+
+  if (recurrenceRange) {
+    wsPayload.recurrence_range = recurrenceRange;
+  }
+
+  return wsPayload;
+};
+
+export const buildDeleteEventPayload = (calendarId, uid, recurrenceId = null, recurrenceRange = null) => {
+  const payload = {
+    entity_id: calendarId,
+    uid: uid
+  };
+
+  if (recurrenceId) {
+    payload.recurrence_id = recurrenceId;
+  }
+
+  if (recurrenceRange) {
+    payload.recurrence_range = recurrenceRange;
+  }
+
+  return payload;
+};
+
+export const buildDeleteEventWebSocketPayload = (calendarId, uid, recurrenceId = null, recurrenceRange = null) => ({
+  type: 'calendar/event/delete',
+  ...buildDeleteEventPayload(calendarId, uid, recurrenceId, recurrenceRange)
+});

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -95,6 +95,20 @@ import {
   buildWeatherForecastSubscriptionMessage,
   isWeatherEntityId
 } from './weather/weather-service.js';
+import {
+  buildRRuleFromInputs as buildRRuleFromInputsHelper,
+  normalizeEventFormData,
+  resolveTimedEventRange as resolveTimedEventRangeHelper
+} from './events/event-form.js';
+import {
+  buildCreateEventWebSocketPayload,
+  buildDeleteEventPayload,
+  buildDeleteEventWebSocketPayload,
+  buildEventServiceData,
+  buildUpdateEventServiceData,
+  buildUpdateEventWebSocketPayload,
+  getRecurringUpdateControls
+} from './events/event-service.js';
 
 const DAYLIGHT_CALENDAR_CARD_VERSION = 'v4.5.0';
 
@@ -8466,29 +8480,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   buildRRuleFromInputs({ frequency, interval, untilDate, count, byDay }) {
-    const parts = [`FREQ=${frequency}`];
-    const parsedInterval = parseInt(interval, 10);
-
-    if (!Number.isNaN(parsedInterval) && parsedInterval > 1) {
-      parts.push(`INTERVAL=${parsedInterval}`);
-    }
-
-    if (Array.isArray(byDay) && byDay.length > 0) {
-      parts.push(`BYDAY=${byDay.join(',')}`);
-    }
-
-    const parsedCount = parseInt(count, 10);
-    if (!Number.isNaN(parsedCount) && parsedCount > 0) {
-      parts.push(`COUNT=${parsedCount}`);
-    } else if (untilDate) {
-      const until = new Date(`${untilDate}T23:59:59`);
-      if (!Number.isNaN(until.getTime())) {
-        const compactUntil = until.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
-        parts.push(`UNTIL=${compactUntil}`);
-      }
-    }
-
-    return parts.join(';');
+    return buildRRuleFromInputsHelper({ frequency, interval, untilDate, count, byDay });
   }
 
   parseRRule(rrule = '') {
@@ -8608,20 +8600,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   resolveTimedEventRange(startValue, endValue, fallbackDurationMs = 60 * 60 * 1000) {
-    const start = this.parsePossiblyLocalDateTime(startValue);
-    if (!(start instanceof Date) || Number.isNaN(start.getTime())) {
-      return { start: null, end: null };
-    }
-
-    const parsedEnd = endValue ? this.parsePossiblyLocalDateTime(endValue) : null;
-    if (parsedEnd instanceof Date && !Number.isNaN(parsedEnd.getTime())) {
-      return { start, end: parsedEnd };
-    }
-
-    return {
-      start,
-      end: new Date(start.getTime() + fallbackDurationMs)
-    };
+    return resolveTimedEventRangeHelper(startValue, endValue, fallbackDurationMs);
   }
 
   showCreateEventModal(defaultDate = null, defaultTime = null, options = {}) {
@@ -8934,61 +8913,23 @@ class SkylightCalendarCard extends HTMLElement {
         return;
       }
 
-      if (!title) {
-        this.showFormError(errorDiv, this.t('eventTitleRequired'));
+      const formResult = normalizeEventFormData({
+        title,
+        location,
+        description,
+        isAllDay,
+        startDate: this.getRootElementById('event-start-date').value,
+        endDate: this.getRootElementById('event-end-date').value,
+        startDateTime: this.getRootElementById('event-start').value,
+        endDateTime: this.getRootElementById('event-end').value
+      });
+
+      if (!formResult.valid) {
+        this.showFormError(errorDiv, this.t(formResult.errorKey));
         return;
       }
 
-      let eventData = {
-        summary: title,
-        location: location || undefined,
-        description: description || undefined
-      };
-
-      if (isAllDay) {
-        const startDate = this.getRootElementById('event-start-date').value;
-        const endDate = this.getRootElementById('event-end-date').value;
-
-        if (!startDate || !endDate) {
-          this.showFormError(errorDiv, this.t('startEndDatesRequired'));
-          return;
-        }
-
-        // Validate that end date is on or after start date
-        const start = this.parseLocalDate(startDate);
-        const end = this.parseLocalDate(endDate);
-
-        if (end < start) {
-          this.showFormError(errorDiv, this.t('endDateBeforeStart'));
-          return;
-        }
-
-        // For Home Assistant, end date is exclusive, so add 1 day
-        const exclusiveEndDate = new Date(end);
-        exclusiveEndDate.setDate(exclusiveEndDate.getDate() + 1);
-        const exclusiveEndDateStr = this.formatLocalDate(exclusiveEndDate);
-
-        eventData.start = { date: startDate };
-        eventData.end = { date: exclusiveEndDateStr };
-      } else {
-        const startDateTime = this.getRootElementById('event-start').value;
-        const endDateTime = this.getRootElementById('event-end').value;
-
-        if (!startDateTime) {
-          this.showFormError(errorDiv, this.t('startEndTimesRequired'));
-          return;
-        }
-
-        const { start, end } = this.resolveTimedEventRange(startDateTime, endDateTime);
-
-        if (end <= start) {
-          this.showFormError(errorDiv, this.t('endTimeBeforeStart'));
-          return;
-        }
-
-        eventData.start = { dateTime: start.toISOString() };
-        eventData.end = { dateTime: end.toISOString() };
-      }
+      let eventData = formResult.eventData;
 
       if (recurringCheckbox.checked) {
         const frequency = this.getRootElementById('event-recurrence-frequency').value;
@@ -8999,19 +8940,31 @@ class SkylightCalendarCard extends HTMLElement {
         const untilDate = recurrenceEndMode === 'on' ? untilDateRaw : '';
         const recurrenceCount = recurrenceEndMode === 'after' ? recurrenceCountRaw : '';
         const byDay = Array.from(this._root.querySelectorAll('.event-recurrence-weekday:checked')).map((el) => el.value);
+        const recurrenceResult = normalizeEventFormData({
+          title,
+          location,
+          description,
+          isAllDay,
+          startDate: this.getRootElementById('event-start-date').value,
+          endDate: this.getRootElementById('event-end-date').value,
+          startDateTime: this.getRootElementById('event-start').value,
+          endDateTime: this.getRootElementById('event-end').value,
+          recurrence: {
+            enabled: true,
+            frequency,
+            interval,
+            untilDate,
+            count: recurrenceCount,
+            byDay
+          }
+        });
 
-        if (frequency === 'WEEKLY' && byDay.length === 0) {
-          this.showFormError(errorDiv, this.t('recurrenceSelectWeekday'));
+        if (!recurrenceResult.valid) {
+          this.showFormError(errorDiv, this.t(recurrenceResult.errorKey));
           return;
         }
 
-        eventData.rrule = this.buildRRuleFromInputs({
-          frequency,
-          interval,
-          untilDate,
-          count: recurrenceCount,
-          byDay: frequency === 'WEEKLY' ? byDay : []
-        });
+        eventData = recurrenceResult.eventData;
       }
 
       // Disable submit button
@@ -9318,62 +9271,24 @@ class SkylightCalendarCard extends HTMLElement {
       const location = this.getRootElementById('event-location').value.trim();
       const description = this.getRootElementById('event-description').value.trim();
 
-      if (!title) {
-        this.showFormError(errorDiv, this.t('eventTitleRequired'));
+      const formResult = normalizeEventFormData({
+        title,
+        location,
+        description,
+        isAllDay: isAllDayChecked,
+        startDate: this.getRootElementById('event-start-date').value,
+        endDate: this.getRootElementById('event-end-date').value,
+        startDateTime: this.getRootElementById('event-start').value,
+        endDateTime: this.getRootElementById('event-end').value,
+        fallbackDurationMs: Math.max(endDate.getTime() - startDate.getTime(), 60 * 1000)
+      });
+
+      if (!formResult.valid) {
+        this.showFormError(errorDiv, this.t(formResult.errorKey));
         return;
       }
 
-      let eventData = {
-        summary: title,
-        location: location || undefined,
-        description: description || undefined
-      };
-
-      if (isAllDayChecked) {
-        const startDateStr = this.getRootElementById('event-start-date').value;
-        const endDateStr = this.getRootElementById('event-end-date').value;
-
-        if (!startDateStr || !endDateStr) {
-          this.showFormError(errorDiv, this.t('startEndDatesRequired'));
-          return;
-        }
-
-        // Validate that end date is on or after start date
-        const start = this.parseLocalDate(startDateStr);
-        const end = this.parseLocalDate(endDateStr);
-
-        if (end < start) {
-          this.showFormError(errorDiv, this.t('endDateBeforeStart'));
-          return;
-        }
-
-        // For Home Assistant, end date is exclusive, so add 1 day
-        const exclusiveEndDate = new Date(end);
-        exclusiveEndDate.setDate(exclusiveEndDate.getDate() + 1);
-        const exclusiveEndDateStr = this.formatLocalDate(exclusiveEndDate);
-
-        eventData.start = { date: startDateStr };
-        eventData.end = { date: exclusiveEndDateStr };
-      } else {
-        const startDateTime = this.getRootElementById('event-start').value;
-        const endDateTime = this.getRootElementById('event-end').value;
-        const existingDurationMs = Math.max(endDate.getTime() - startDate.getTime(), 60 * 1000);
-
-        if (!startDateTime) {
-          this.showFormError(errorDiv, this.t('startEndTimesRequired'));
-          return;
-        }
-
-        const { start, end } = this.resolveTimedEventRange(startDateTime, endDateTime, existingDurationMs);
-
-        if (end <= start) {
-          this.showFormError(errorDiv, this.t('endTimeBeforeStart'));
-          return;
-        }
-
-        eventData.start = { dateTime: start.toISOString() };
-        eventData.end = { dateTime: end.toISOString() };
-      }
+      let eventData = formResult.eventData;
 
       if (recurringCheckbox.checked) {
         const frequency = this.getRootElementById('event-recurrence-frequency').value;
@@ -9384,19 +9299,32 @@ class SkylightCalendarCard extends HTMLElement {
         const untilDate = recurrenceEndMode === 'on' ? untilDateRaw : '';
         const recurrenceCount = recurrenceEndMode === 'after' ? recurrenceCountRaw : '';
         const byDay = Array.from(this._root.querySelectorAll('.event-recurrence-weekday:checked')).map((el) => el.value);
+        const recurrenceResult = normalizeEventFormData({
+          title,
+          location,
+          description,
+          isAllDay: isAllDayChecked,
+          startDate: this.getRootElementById('event-start-date').value,
+          endDate: this.getRootElementById('event-end-date').value,
+          startDateTime: this.getRootElementById('event-start').value,
+          endDateTime: this.getRootElementById('event-end').value,
+          fallbackDurationMs: Math.max(endDate.getTime() - startDate.getTime(), 60 * 1000),
+          recurrence: {
+            enabled: true,
+            frequency,
+            interval,
+            untilDate,
+            count: recurrenceCount,
+            byDay
+          }
+        });
 
-        if (frequency === 'WEEKLY' && byDay.length === 0) {
-          this.showFormError(errorDiv, this.t('recurrenceSelectWeekday'));
+        if (!recurrenceResult.valid) {
+          this.showFormError(errorDiv, this.t(recurrenceResult.errorKey));
           return;
         }
 
-        eventData.rrule = this.buildRRuleFromInputs({
-          frequency,
-          interval,
-          untilDate,
-          count: recurrenceCount,
-          byDay: frequency === 'WEEKLY' ? byDay : []
-        });
+        eventData = recurrenceResult.eventData;
       }
 
       // Disable submit button
@@ -9467,47 +9395,10 @@ class SkylightCalendarCard extends HTMLElement {
       throw new Error(this.t('missingUidError'));
     }
 
-    const isRecurringUpdate = !!eventData.rrule || !!originalEvent.rrule;
-
-    const recurrenceId = (isRecurringUpdate && editScope !== 'all') ? originalEvent.recurrence_id : null;
-    const recurrenceRange = (isRecurringUpdate && editScope === 'future' && originalEvent.recurrence_id) ? 'THISANDFUTURE' : null;
+    const { isRecurringUpdate, recurrenceId, recurrenceRange } = getRecurringUpdateControls(originalEvent, eventData, editScope);
 
     if (isRecurringUpdate && !movingCalendar && this._hass.connection?.sendMessagePromise) {
-      const dtstart = eventData.start.dateTime || eventData.start.date;
-      const dtend = eventData.end.dateTime || eventData.end.date;
-
-      const eventPayload = {
-        summary: eventData.summary,
-        dtstart,
-        dtend
-      };
-
-      if (eventData.location) {
-        eventPayload.location = eventData.location;
-      }
-
-      if (eventData.description) {
-        eventPayload.description = eventData.description;
-      }
-
-      if (eventData.rrule) {
-        eventPayload.rrule = eventData.rrule;
-      }
-
-      const wsPayload = {
-        type: 'calendar/event/update',
-        entity_id: originalEvent.entityId,
-        uid: originalEvent.uid,
-        event: eventPayload
-      };
-
-      if (recurrenceId) {
-        wsPayload.recurrence_id = recurrenceId;
-      }
-
-      if (recurrenceRange) {
-        wsPayload.recurrence_range = recurrenceRange;
-      }
+      const wsPayload = buildUpdateEventWebSocketPayload(originalEvent, eventData, recurrenceId, recurrenceRange);
 
       try {
         await this._hass.connection.sendMessagePromise(wsPayload);
@@ -9521,43 +9412,7 @@ class SkylightCalendarCard extends HTMLElement {
     const hasUpdateService = !!this._hass.services?.calendar?.update_event;
     if (capabilities.canUpdate && !movingCalendar && hasUpdateService) {
       try {
-        const serviceData = {
-          entity_id: originalEvent.entityId,
-          uid: originalEvent.uid,
-          summary: eventData.summary
-        };
-
-        // Add location if provided
-        if (eventData.location) {
-          serviceData.location = eventData.location;
-        }
-
-        // Add description if provided
-        if (eventData.description) {
-          serviceData.description = eventData.description;
-        }
-
-        // Add date/time fields
-        if (eventData.start.date) {
-          serviceData.start_date = eventData.start.date;
-          serviceData.end_date = eventData.end.date;
-        } else {
-          serviceData.start_date_time = eventData.start.dateTime;
-          serviceData.end_date_time = eventData.end.dateTime;
-        }
-
-        if (eventData.rrule) {
-          serviceData.rrule = eventData.rrule;
-        }
-
-        // Add recurrence controls for recurring event edits
-        if (recurrenceId) {
-          serviceData.recurrence_id = recurrenceId;
-        }
-
-        if (recurrenceRange) {
-          serviceData.recurrence_range = recurrenceRange;
-        }
+        const serviceData = buildUpdateEventServiceData(originalEvent, eventData, recurrenceId, recurrenceRange);
 
         await this._hass.callService('calendar', 'update_event', serviceData);
         return;
@@ -9595,21 +9450,7 @@ class SkylightCalendarCard extends HTMLElement {
     // This is the official Calendar WebSocket API that the HA Calendar UI uses
     try {
       if (this._hass.connection && this._hass.connection.sendMessagePromise && uid) {
-        const payload = {
-          type: 'calendar/event/delete',
-          entity_id: calendarId,
-          uid: uid
-        };
-
-        // Add recurrence_id if deleting a specific instance
-        if (recurrenceId) {
-          payload.recurrence_id = recurrenceId;
-        }
-
-        // Add recurrence_range if deleting this and future events
-        if (recurrenceRange) {
-          payload.recurrence_range = recurrenceRange;
-        }
+        const payload = buildDeleteEventWebSocketPayload(calendarId, uid, recurrenceId, recurrenceRange);
 
         await this._hass.connection.sendMessagePromise(payload);
         return; // Success via WebSocket
@@ -9620,20 +9461,7 @@ class SkylightCalendarCard extends HTMLElement {
     }
 
     // Fallback to service call (works for Local Calendar and some others)
-    const serviceData = {
-      entity_id: calendarId,
-      uid: uid
-    };
-
-    // Add recurrence_id if deleting a specific instance
-    if (recurrenceId) {
-      serviceData.recurrence_id = recurrenceId;
-    }
-
-    // Add recurrence_range if deleting this and future events
-    if (recurrenceRange) {
-      serviceData.recurrence_range = recurrenceRange;
-    }
+    const serviceData = buildDeleteEventPayload(calendarId, uid, recurrenceId, recurrenceRange);
 
     try {
       await this._hass.callService('calendar', 'delete_event', serviceData);
@@ -9651,44 +9479,14 @@ class SkylightCalendarCard extends HTMLElement {
     const isRecurring = !!eventData.rrule;
 
     // Build service-style data (used by both API variants)
-    const baseData = {
-      entity_id: calendarId,
-      summary: eventData.summary
-    };
-
-    if (eventData.location) {
-      baseData.location = eventData.location;
-    }
-
-    if (eventData.description) {
-      baseData.description = eventData.description;
-    }
-
-    if (eventData.start.date) {
-      baseData.start_date = eventData.start.date;
-      baseData.end_date = eventData.end.date;
-    } else {
-      baseData.start_date_time = eventData.start.dateTime;
-      baseData.end_date_time = eventData.end.dateTime;
-    }
+    const baseData = buildEventServiceData(calendarId, eventData);
 
     if (isRecurring) {
       baseData.rrule = eventData.rrule;
 
       // HA recurring event support is exposed through Calendar WebSocket API.
       // WebSocket schema expects event.dtstart / event.dtend (not start/end keys).
-      const wsPayload = {
-        type: 'calendar/event/create',
-        entity_id: calendarId,
-        event: {
-          summary: baseData.summary,
-          location: baseData.location,
-          description: baseData.description,
-          rrule: baseData.rrule,
-          dtstart: eventData.start.dateTime || eventData.start.date,
-          dtend: eventData.end.dateTime || eventData.end.date
-        }
-      };
+      const wsPayload = buildCreateEventWebSocketPayload(calendarId, eventData);
 
       try {
         if (this._hass.connection?.sendMessagePromise) {


### PR DESCRIPTION
### Motivation
- Separate pure, data-only event handling (form validation/normalization and HA service payload construction) from modal rendering to progress the modularization refactor while preserving runtime behavior.
- Keep DOM, rendering, focus, and card lifecycle in the main card so modal visuals and user flows remain unchanged.

### Description
- Added `src/events/event-form.js` exporting `resolveTimedEventRange`, `buildRRuleFromInputs`, and `normalizeEventFormData`, which encapsulate timed-range fallback, RRULE construction, title/date/time validation, all-day normalization (exclusive end date), and recurrence validation.
- Added `src/events/event-service.js` exporting `buildEventServiceData`, `buildCreateEventWebSocketPayload`, `getRecurringUpdateControls`, `buildUpdateEventServiceData`, `buildUpdateEventWebSocketPayload`, `buildDeleteEventPayload`, and `buildDeleteEventWebSocketPayload` to centralize calendar service/WebSocket payload shapes for create/update/delete and recurring controls.
- Updated `src/skylight-calendar-card.js` to import and delegate to the new helpers while preserving existing thin wrapper methods (`buildRRuleFromInputs`, `resolveTimedEventRange`) and leaving all DOM reads/writes, modal rendering, focus handling, dialog open/close behavior, and service orchestration in the main card because those are tightly coupled to modal DOM/state and lifecycle.
- Kept `skylight-calendar-card.js` root artifact regenerated and committed; no public API, CSS, DOM structure, or runtime event flows were changed.

### Testing
- Ran `npm ci --no-audit --fund=false` and `npm run build`, which regenerated `skylight-calendar-card.js` successfully and was committed.
- Ran `node --check` on `src/skylight-calendar-card.js`, `src/events/event-form.js`, `src/events/event-service.js`, and `skylight-calendar-card.js` with no errors.
- Ran `npm test` (unit tests) and all tests passed: 224 passed, 0 failed.
- Ran `npm run test:visual` (Playwright visual tests) and all visual checks passed: 39 passed, 0 failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b272569408331a35d7d56a5207493)