### PR TITLE
Extract view-model date preparation helpers (Phase 11)

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -2491,6 +2491,198 @@ const buildDeleteEventWebSocketPayload = (calendarId, uid, recurrenceId = null, 
   ...buildDeleteEventPayload(calendarId, uid, recurrenceId, recurrenceRange)
 });
 
+function getMonthGridDates(currentDate, firstDayOfWeek) {
+  const year = currentDate.getFullYear();
+  const month = currentDate.getMonth();
+  const firstDay = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const daysInPrevMonth = new Date(year, month, 0).getDate();
+  const startDay = (firstDay - firstDayOfWeek + 7) % 7;
+  const days = [];
+
+  for (let i = startDay - 1; i >= 0; i--) {
+    const day = daysInPrevMonth - i;
+    days.push({ day, date: new Date(year, month - 1, day), isOtherMonth: true });
+  }
+
+  for (let day = 1; day <= daysInMonth; day++) {
+    days.push({ day, date: new Date(year, month, day), isOtherMonth: false });
+  }
+
+  const totalCells = startDay + daysInMonth;
+  const remainingCells = totalCells % 7 === 0 ? 0 : 7 - (totalCells % 7);
+  for (let day = 1; day <= remainingCells; day++) {
+    days.push({ day, date: new Date(year, month + 1, day), isOtherMonth: true });
+  }
+
+  return days;
+}
+
+function getRollingMonthGridDates(currentDate, firstDayOfWeek, rollingWeeks) {
+  const anchorDate = new Date(currentDate);
+  anchorDate.setHours(0, 0, 0, 0);
+
+  const currentDay = anchorDate.getDay();
+  const diff = (currentDay - firstDayOfWeek + 7) % 7;
+  const weekStart = new Date(anchorDate);
+  weekStart.setDate(anchorDate.getDate() - diff);
+
+  const totalWeeks = rollingWeeks + 1;
+  const totalDays = totalWeeks * 7;
+  const currentMonthStart = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1);
+  const days = [];
+
+  for (let i = 0; i < totalDays; i++) {
+    const date = new Date(weekStart);
+    date.setDate(weekStart.getDate() + i);
+    days.push({ day: date.getDate(), date, isOtherMonth: date < currentMonthStart });
+  }
+
+  return days;
+}
+
+function getMonthVisibleDateRange(currentDate, firstDayOfWeek, rollingWeeks = null) {
+  if (rollingWeeks !== null) {
+    const days = getRollingMonthGridDates(currentDate, firstDayOfWeek, rollingWeeks);
+    const startDate = new Date(days[0].date);
+    startDate.setHours(0, 0, 0, 0);
+    const endDate = new Date(days[days.length - 1].date);
+    endDate.setHours(23, 59, 59, 999);
+    return { startDate, endDate };
+  }
+
+  const days = getMonthGridDates(currentDate, firstDayOfWeek);
+  const startDate = new Date(days[0].date);
+  startDate.setHours(0, 0, 0, 0);
+  const endDate = new Date(days[days.length - 1].date);
+  endDate.setHours(23, 59, 59, 999);
+  return { startDate, endDate };
+}
+
+function getRollingDaysForView(viewMode, config) {
+  if (viewMode === 'week-compact' && config.rolling_days_week_compact !== null) {
+    return config.rolling_days_week_compact;
+  }
+
+  if (viewMode === 'week-standard' && config.rolling_days_schedule !== null) {
+    return config.rolling_days_schedule;
+  }
+
+  return null;
+}
+
+function getWeekDays({ currentDate, weekStart, weekDays, rollingDays }) {
+  if (rollingDays !== null) {
+    const days = [];
+    const startDate = new Date(currentDate);
+    startDate.setHours(0, 0, 0, 0);
+
+    for (let i = 0; i <= rollingDays; i++) {
+      const date = new Date(startDate);
+      date.setDate(startDate.getDate() + i);
+      days.push(date);
+    }
+    return days;
+  }
+
+  const days = [];
+  for (let i = 0; i < 7; i++) {
+    const date = new Date(weekStart);
+    date.setDate(weekStart.getDate() + i);
+    if (weekDays.includes(date.getDay())) {
+      days.push(date);
+    }
+  }
+  return days;
+}
+
+function getWeekVisibleDateRange(weekDays) {
+  const startDate = new Date(weekDays[0]);
+  startDate.setHours(0, 0, 0, 0);
+  const endDate = new Date(weekDays[weekDays.length - 1]);
+  endDate.setHours(23, 59, 59, 999);
+  return { startDate, endDate };
+}
+
+function getAgendaRollingDays(config) {
+  if (config?.rolling_days_agenda !== null && config?.rolling_days_agenda !== undefined) {
+    return config.rolling_days_agenda;
+  }
+
+  return null;
+}
+
+function getAgendaPeriodDaySpan(config) {
+  const rollingDays = getAgendaRollingDays(config);
+  return rollingDays !== null ? rollingDays : 14;
+}
+
+function createAgendaWindow(today, daySpan) {
+  const startDate = new Date(today);
+  startDate.setHours(0, 0, 0, 0);
+  const endDate = new Date(startDate);
+  endDate.setDate(endDate.getDate() + daySpan);
+  endDate.setHours(23, 59, 59, 999);
+  const visibleStartDate = new Date(startDate);
+  const visibleEndDate = new Date(endDate);
+  visibleEndDate.setHours(23, 59, 59, 999);
+  return { startDate, endDate, visibleStartDate, visibleEndDate };
+}
+
+function getAgendaDays(startDate, endDate) {
+  const days = [];
+  const cursor = new Date(startDate);
+  cursor.setHours(0, 0, 0, 0);
+  const end = new Date(endDate);
+  end.setHours(0, 0, 0, 0);
+
+  while (cursor <= end) {
+    days.push(new Date(cursor));
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  return days;
+}
+
+function getAgendaVisibleDateRange(startDate, endDate) {
+  const visibleStartDate = new Date(startDate);
+  visibleStartDate.setHours(0, 0, 0, 0);
+  const visibleEndDate = new Date(endDate);
+  visibleEndDate.setHours(23, 59, 59, 999);
+  return { startDate: visibleStartDate, endDate: visibleEndDate };
+}
+
+function isAgendaRangeWithinWindow(range, windowStartDate, windowEndDate) {
+  if (!range?.startDate || !range?.endDate || !windowStartDate || !windowEndDate) {
+    return false;
+  }
+
+  const rangeStart = new Date(range.startDate);
+  rangeStart.setHours(0, 0, 0, 0);
+  const rangeEnd = new Date(range.endDate);
+  rangeEnd.setHours(23, 59, 59, 999);
+  const windowStart = new Date(windowStartDate);
+  windowStart.setHours(0, 0, 0, 0);
+  const windowEnd = new Date(windowEndDate);
+  windowEnd.setHours(23, 59, 59, 999);
+
+  return rangeStart >= windowStart && rangeEnd <= windowEnd;
+}
+
+function buildAgendaDayEntries(agendaDays, { getEventsForDay, isEventHiddenByStyle, sortEventsForDate, hideEmptyDays }) {
+  return agendaDays
+    .map((date) => ({
+      date,
+      matchingEvents: getEventsForDay(date, { includeHiddenStyledEvents: true }),
+      events: null
+    }))
+    .map((entry) => ({
+      ...entry,
+      events: sortEventsForDate(entry.matchingEvents.filter((event) => !isEventHiddenByStyle(event)), entry.date)
+    }))
+    .filter((entry) => !hideEmptyDays || entry.events.length > 0);
+}
+
 const DAYLIGHT_CALENDAR_CARD_VERSION = 'v4.5.0';
 
 function getDaylightCalendarCardVersion() {
@@ -4365,56 +4557,15 @@ class SkylightCalendarCard extends HTMLElement {
   getVisibleDateRange() {
     if (this._viewMode === 'agenda') {
       this.ensureAgendaWindowInitialized();
-      const startDate = new Date(this._agendaStartDate);
-      startDate.setHours(0, 0, 0, 0);
-      const endDate = new Date(this._agendaEndDate);
-      endDate.setHours(23, 59, 59, 999);
-      return { startDate, endDate };
+      return getAgendaVisibleDateRange(this._agendaStartDate, this._agendaEndDate);
     }
 
-    // Month rolling-weeks mode: from start of anchor week through configured weeks.
-    if (this._viewMode === 'month' && this._config.rolling_weeks !== null) {
-      const anchorDate = new Date(this._currentDate);
-      anchorDate.setHours(0, 0, 0, 0);
-      const currentDay = anchorDate.getDay();
-      const diff = (currentDay - this._config.firstDayOfWeek + 7) % 7;
-
-      const startDate = new Date(anchorDate);
-      startDate.setDate(anchorDate.getDate() - diff);
-      startDate.setHours(0, 0, 0, 0);
-
-      const endDate = new Date(startDate);
-      endDate.setDate(startDate.getDate() + ((this._config.rolling_weeks + 1) * 7) - 1);
-      endDate.setHours(23, 59, 59, 999);
-      return { startDate, endDate };
-    }
-
-    // Standard month mode: full rendered grid (including adjacent month cells).
     if (this._viewMode === 'month') {
-      const year = this._currentDate.getFullYear();
-      const month = this._currentDate.getMonth();
-      const firstDay = new Date(year, month, 1).getDay();
-      const daysInMonth = new Date(year, month + 1, 0).getDate();
-      const startOffset = (firstDay - this._config.firstDayOfWeek + 7) % 7;
-      const totalCells = startOffset + daysInMonth;
-      const trailingCells = totalCells % 7 === 0 ? 0 : 7 - (totalCells % 7);
-
-      const startDate = new Date(year, month, 1 - startOffset);
-      startDate.setHours(0, 0, 0, 0);
-
-      const endDate = new Date(year, month, daysInMonth + trailingCells);
-      endDate.setHours(23, 59, 59, 999);
-
-      return { startDate, endDate };
+      return getMonthVisibleDateRange(this._currentDate, this._config.firstDayOfWeek, this._config.rolling_weeks);
     }
 
     // Week views: from first shown day to last shown day.
-    const weekDays = this.getWeekDays();
-    const startDate = new Date(weekDays[0]);
-    startDate.setHours(0, 0, 0, 0);
-    const endDate = new Date(weekDays[weekDays.length - 1]);
-    endDate.setHours(23, 59, 59, 999);
-    return { startDate, endDate };
+    return getWeekVisibleDateRange(this.getWeekDays());
   }
 
   getDateRangeChunks(startDate, endDate, chunkDays = 30) {
@@ -5028,16 +5179,11 @@ class SkylightCalendarCard extends HTMLElement {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
     this._currentDate = new Date(today);
-    this._agendaStartDate = new Date(today);
-
-    const endDate = new Date(today);
-    endDate.setDate(endDate.getDate() + this.getAgendaPeriodDaySpan());
-    endDate.setHours(23, 59, 59, 999);
-    this._agendaEndDate = endDate;
-    this._agendaVisibleStartDate = new Date(today);
-    const visibleEndDate = new Date(endDate);
-    visibleEndDate.setHours(23, 59, 59, 999);
-    this._agendaVisibleEndDate = visibleEndDate;
+    const agendaWindow = createAgendaWindow(today, this.getAgendaPeriodDaySpan());
+    this._agendaStartDate = agendaWindow.startDate;
+    this._agendaEndDate = agendaWindow.endDate;
+    this._agendaVisibleStartDate = agendaWindow.visibleStartDate;
+    this._agendaVisibleEndDate = agendaWindow.visibleEndDate;
   }
 
   ensureAgendaWindowInitialized() {
@@ -5047,18 +5193,7 @@ class SkylightCalendarCard extends HTMLElement {
 
   getAgendaDays() {
     this.ensureAgendaWindowInitialized();
-    const days = [];
-    const cursor = new Date(this._agendaStartDate);
-    cursor.setHours(0, 0, 0, 0);
-    const end = new Date(this._agendaEndDate);
-    end.setHours(0, 0, 0, 0);
-
-    while (cursor <= end) {
-      days.push(new Date(cursor));
-      cursor.setDate(cursor.getDate() + 1);
-    }
-
-    return days;
+    return getAgendaDays(this._agendaStartDate, this._agendaEndDate);
   }
 
   getAgendaVisibleDateRangeFromDom() {
@@ -5107,20 +5242,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   isAgendaRangeWithinCurrentWindow(range) {
-    if (!range?.startDate || !range?.endDate || !this._agendaStartDate || !this._agendaEndDate) {
-      return false;
-    }
-
-    const rangeStart = new Date(range.startDate);
-    rangeStart.setHours(0, 0, 0, 0);
-    const rangeEnd = new Date(range.endDate);
-    rangeEnd.setHours(23, 59, 59, 999);
-    const windowStart = new Date(this._agendaStartDate);
-    windowStart.setHours(0, 0, 0, 0);
-    const windowEnd = new Date(this._agendaEndDate);
-    windowEnd.setHours(23, 59, 59, 999);
-
-    return rangeStart >= windowStart && rangeEnd <= windowEnd;
+    return isAgendaRangeWithinWindow(range, this._agendaStartDate, this._agendaEndDate);
   }
 
   updateAgendaPeriodLabelInDom() {
@@ -5174,57 +5296,24 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getAgendaRollingDays() {
-    if (this._config?.rolling_days_agenda !== null && this._config?.rolling_days_agenda !== undefined) {
-      return this._config.rolling_days_agenda;
-    }
-
-    return null;
+    return getAgendaRollingDays(this._config);
   }
 
   getAgendaPeriodDaySpan() {
-    const rollingDays = this.getAgendaRollingDays();
-    return rollingDays !== null ? rollingDays : 14;
+    return getAgendaPeriodDaySpan(this._config);
   }
 
   getRollingDaysForView(viewMode = this._viewMode) {
-    if (viewMode === 'week-compact' && this._config.rolling_days_week_compact !== null) {
-      return this._config.rolling_days_week_compact;
-    }
-
-    if (viewMode === 'week-standard' && this._config.rolling_days_schedule !== null) {
-      return this._config.rolling_days_schedule;
-    }
-
-    return null;
+    return getRollingDaysForView(viewMode, this._config);
   }
 
   getWeekDays(viewMode = this._viewMode) {
-    const rollingDays = this.getRollingDaysForView(viewMode);
-
-    // If rolling days are set, show current date + N days
-    if (rollingDays !== null) {
-      const days = [];
-      const startDate = new Date(this._currentDate);
-      startDate.setHours(0, 0, 0, 0);
-
-      for (let i = 0; i <= rollingDays; i++) {
-        const date = new Date(startDate);
-        date.setDate(startDate.getDate() + i);
-        days.push(date);
-      }
-      return days;
-    }
-
-    // Otherwise use the week-based approach
-    const days = [];
-    for (let i = 0; i < 7; i++) {
-      const date = new Date(this._weekStart);
-      date.setDate(this._weekStart.getDate() + i);
-      if (this._config.week_days.includes(date.getDay())) {
-        days.push(date);
-      }
-    }
-    return days;
+    return getWeekDays({
+      currentDate: this._currentDate,
+      weekStart: this._weekStart,
+      weekDays: this._config.week_days,
+      rollingDays: this.getRollingDaysForView(viewMode)
+    });
   }
 
   getStyles() {
@@ -8551,17 +8640,12 @@ class SkylightCalendarCard extends HTMLElement {
     const monthFormatter = new Intl.DateTimeFormat(this.getLocale(), this.withTimeZone({ month: 'long', year: 'numeric' }));
     const agendaRows = [];
     const shouldHideEmptyDays = this._viewMode === 'agenda' && !!this._config.hide_empty_days;
-    const agendaDayEntries = agendaDays
-      .map((date) => ({
-        date,
-        matchingEvents: this.getEventsForDay(date, { includeHiddenStyledEvents: true }),
-        events: null
-      }))
-      .map((entry) => ({
-        ...entry,
-        events: this.sortEventsForDate(entry.matchingEvents.filter((event) => !this.isEventHiddenByStyle(event)), entry.date)
-      }))
-      .filter((entry) => !shouldHideEmptyDays || entry.events.length > 0);
+    const agendaDayEntries = buildAgendaDayEntries(agendaDays, {
+      getEventsForDay: this.getEventsForDay.bind(this),
+      isEventHiddenByStyle: this.isEventHiddenByStyle.bind(this),
+      sortEventsForDate: this.sortEventsForDate.bind(this),
+      hideEmptyDays: shouldHideEmptyDays
+    });
 
     agendaDayEntries.forEach((entry, index) => {
       const { date, events } = entry;
@@ -9479,98 +9563,35 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   renderDays() {
-    const year = this._currentDate.getFullYear();
-    const month = this._currentDate.getMonth();
-
     // If rolling_weeks is set, show current week + N additional weeks
     if (this._config.rolling_weeks !== null && this._viewMode === 'month') {
       return this.renderRollingWeeks();
     }
 
-    const firstDay = new Date(year, month, 1).getDay();
-    const daysInMonth = new Date(year, month + 1, 0).getDate();
-    const daysInPrevMonth = new Date(year, month, 0).getDate();
-
-    const today = new Date();
-    const isToday = (d) => {
-      return d.getDate() === today.getDate() &&
-             d.getMonth() === today.getMonth() &&
-             d.getFullYear() === today.getFullYear();
-    };
-
     const shouldShowWeekNumbers = this.shouldShowMonthWeekNumbers();
     let html = '';
-    let dayIndex = 0;
-    const startDay = (firstDay - this._config.firstDayOfWeek + 7) % 7;
 
-    // Previous month days
-    for (let i = startDay - 1; i >= 0; i--) {
-      const day = daysInPrevMonth - i;
-      const date = new Date(year, month - 1, day);
+    getMonthGridDates(this._currentDate, this._config.firstDayOfWeek).forEach((dayEntry, dayIndex) => {
       if (shouldShowWeekNumbers && dayIndex % 7 === 0) {
-        html += this.renderMonthWeekNumberCell(date);
+        html += this.renderMonthWeekNumberCell(dayEntry.date);
       }
-      html += this.renderDay(day, date, true);
-      dayIndex++;
-    }
-
-    // Current month days
-    for (let day = 1; day <= daysInMonth; day++) {
-      const date = new Date(year, month, day);
-      if (shouldShowWeekNumbers && dayIndex % 7 === 0) {
-        html += this.renderMonthWeekNumberCell(date);
-      }
-      html += this.renderDay(day, date, false);
-      dayIndex++;
-    }
-
-    // Next month days
-    const totalCells = startDay + daysInMonth;
-    const remainingCells = totalCells % 7 === 0 ? 0 : 7 - (totalCells % 7);
-    for (let day = 1; day <= remainingCells; day++) {
-      const date = new Date(year, month + 1, day);
-      if (shouldShowWeekNumbers && dayIndex % 7 === 0) {
-        html += this.renderMonthWeekNumberCell(date);
-      }
-      html += this.renderDay(day, date, true);
-      dayIndex++;
-    }
+      html += this.renderDay(dayEntry.day, dayEntry.date, dayEntry.isOtherMonth);
+    });
 
     return html;
   }
 
   renderRollingWeeks() {
-    const anchorDate = new Date(this._currentDate);
-    anchorDate.setHours(0, 0, 0, 0);
-
-    // Find the start of the current week based on firstDayOfWeek
-    const currentDay = anchorDate.getDay();
-    const diff = (currentDay - this._config.firstDayOfWeek + 7) % 7;
-    const weekStart = new Date(anchorDate);
-    weekStart.setDate(anchorDate.getDate() - diff);
-
-    // Calculate total days to show: (rolling_weeks + 1) * 7 days
-    const totalWeeks = this._config.rolling_weeks + 1;
-    const totalDays = totalWeeks * 7;
-
     const shouldShowWeekNumbers = this.shouldShowMonthWeekNumbers();
     let html = '';
 
-    // Render all days in the rolling weeks
-    for (let i = 0; i < totalDays; i++) {
-      const date = new Date(weekStart);
-      date.setDate(weekStart.getDate() + i);
-      if (shouldShowWeekNumbers && i % 7 === 0) {
-        html += this.renderMonthWeekNumberCell(date);
+    getRollingMonthGridDates(this._currentDate, this._config.firstDayOfWeek, this._config.rolling_weeks).forEach((dayEntry, dayIndex) => {
+      if (shouldShowWeekNumbers && dayIndex % 7 === 0) {
+        html += this.renderMonthWeekNumberCell(dayEntry.date);
       }
 
-      // In rolling-weeks month view, keep trailing (next-month) days visually active
-      // while still dimming any leading days from the previous month.
-      const currentMonthStart = new Date(this._currentDate.getFullYear(), this._currentDate.getMonth(), 1);
-      const isOtherMonth = date < currentMonthStart;
-
-      html += this.renderDay(date.getDate(), date, isOtherMonth);
-    }
+      html += this.renderDay(dayEntry.day, dayEntry.date, dayEntry.isOtherMonth);
+    });
 
     return html;
   }

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -1088,6 +1088,50 @@ test('rolling_weeks month mode renders configured rolling rows from first day of
   assert.ok(daysHtml.includes(`data-date="${localDateDataAttribute('2026-05-24')}"`));
 });
 
+
+test('month grid includes leading and trailing days and range boundaries', () => {
+  const card = makeCard({ entities: ['calendar.family'], default_view: 'month', first_day_of_week: 1 });
+  card._currentDate = new Date(2026, 1, 10); // February 2026 starts on Sunday.
+  card._events = [];
+
+  assert.deepEqual(
+    Object.fromEntries(Object.entries(card.getVisibleDateRange()).map(([key, value]) => [key, localDateKey(value)])),
+    { startDate: '2026-01-26', endDate: '2026-03-01' }
+  );
+
+  const daysHtml = card.renderDays();
+  assert.equal((daysHtml.match(/class="day-cell/g) || []).length, 35);
+  assert.ok(daysHtml.includes(`data-date="${localDateDataAttribute('2026-01-26')}"`));
+  assert.ok(daysHtml.includes(`data-date="${localDateDataAttribute('2026-03-01')}"`));
+});
+
+test('week visible date range follows configured week days and week start', () => {
+  const card = makeCard({
+    entities: ['calendar.family'],
+    default_view: 'week-compact',
+    first_day_of_week: 0,
+    week_days: [0, 2, 4]
+  });
+  card._currentDate = new Date(2026, 4, 13, 12);
+  card.setWeekStart();
+
+  assert.deepEqual(dateKeys(card.getWeekDays('week-compact')), ['2026-05-10', '2026-05-12', '2026-05-14']);
+  assert.deepEqual(
+    Object.fromEntries(Object.entries(card.getVisibleDateRange()).map(([key, value]) => [key, localDateKey(value)])),
+    { startDate: '2026-05-10', endDate: '2026-05-14' }
+  );
+});
+
+test('agenda window generation preserves inclusive current day plus default span', () => {
+  const card = makeCard({ entities: ['calendar.family'], default_view: 'agenda' });
+  card._agendaStartDate = new Date(2026, 2, 7);
+  card._agendaEndDate = new Date(2026, 2, 21, 23, 59, 59, 999);
+
+  assert.equal(card.getAgendaPeriodDaySpan(), 14);
+  assert.equal(card.getAgendaDays().length, 15);
+  assert.deepEqual([card.getAgendaDays()[0], card.getAgendaDays().at(-1)].map(localDateKey), ['2026-03-07', '2026-03-21']);
+});
+
 test('show_week_numbers_month adds month-only week number headers and cells', () => {
   const card = makeCard({ entities: ['calendar.family'], show_week_numbers_month: true });
   card._currentDate = new Date('2026-05-13T12:00:00Z');

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -116,6 +116,25 @@ import {
   buildUpdateEventWebSocketPayload,
   getRecurringUpdateControls
 } from './events/event-service.js';
+import {
+  getMonthGridDates,
+  getMonthVisibleDateRange,
+  getRollingMonthGridDates
+} from './views/month-view-model.js';
+import {
+  getRollingDaysForView as getRollingDaysForViewModel,
+  getWeekDays as getWeekDaysViewModel,
+  getWeekVisibleDateRange
+} from './views/week-view-model.js';
+import {
+  buildAgendaDayEntries,
+  createAgendaWindow,
+  getAgendaDays as getAgendaDaysViewModel,
+  getAgendaPeriodDaySpan as getAgendaPeriodDaySpanViewModel,
+  getAgendaRollingDays as getAgendaRollingDaysViewModel,
+  getAgendaVisibleDateRange,
+  isAgendaRangeWithinWindow
+} from './views/agenda-view-model.js';
 
 const DAYLIGHT_CALENDAR_CARD_VERSION = 'v4.5.0';
 
@@ -1991,56 +2010,15 @@ class SkylightCalendarCard extends HTMLElement {
   getVisibleDateRange() {
     if (this._viewMode === 'agenda') {
       this.ensureAgendaWindowInitialized();
-      const startDate = new Date(this._agendaStartDate);
-      startDate.setHours(0, 0, 0, 0);
-      const endDate = new Date(this._agendaEndDate);
-      endDate.setHours(23, 59, 59, 999);
-      return { startDate, endDate };
+      return getAgendaVisibleDateRange(this._agendaStartDate, this._agendaEndDate);
     }
 
-    // Month rolling-weeks mode: from start of anchor week through configured weeks.
-    if (this._viewMode === 'month' && this._config.rolling_weeks !== null) {
-      const anchorDate = new Date(this._currentDate);
-      anchorDate.setHours(0, 0, 0, 0);
-      const currentDay = anchorDate.getDay();
-      const diff = (currentDay - this._config.firstDayOfWeek + 7) % 7;
-
-      const startDate = new Date(anchorDate);
-      startDate.setDate(anchorDate.getDate() - diff);
-      startDate.setHours(0, 0, 0, 0);
-
-      const endDate = new Date(startDate);
-      endDate.setDate(startDate.getDate() + ((this._config.rolling_weeks + 1) * 7) - 1);
-      endDate.setHours(23, 59, 59, 999);
-      return { startDate, endDate };
-    }
-
-    // Standard month mode: full rendered grid (including adjacent month cells).
     if (this._viewMode === 'month') {
-      const year = this._currentDate.getFullYear();
-      const month = this._currentDate.getMonth();
-      const firstDay = new Date(year, month, 1).getDay();
-      const daysInMonth = new Date(year, month + 1, 0).getDate();
-      const startOffset = (firstDay - this._config.firstDayOfWeek + 7) % 7;
-      const totalCells = startOffset + daysInMonth;
-      const trailingCells = totalCells % 7 === 0 ? 0 : 7 - (totalCells % 7);
-
-      const startDate = new Date(year, month, 1 - startOffset);
-      startDate.setHours(0, 0, 0, 0);
-
-      const endDate = new Date(year, month, daysInMonth + trailingCells);
-      endDate.setHours(23, 59, 59, 999);
-
-      return { startDate, endDate };
+      return getMonthVisibleDateRange(this._currentDate, this._config.firstDayOfWeek, this._config.rolling_weeks);
     }
 
     // Week views: from first shown day to last shown day.
-    const weekDays = this.getWeekDays();
-    const startDate = new Date(weekDays[0]);
-    startDate.setHours(0, 0, 0, 0);
-    const endDate = new Date(weekDays[weekDays.length - 1]);
-    endDate.setHours(23, 59, 59, 999);
-    return { startDate, endDate };
+    return getWeekVisibleDateRange(this.getWeekDays());
   }
 
   getDateRangeChunks(startDate, endDate, chunkDays = 30) {
@@ -2654,16 +2632,11 @@ class SkylightCalendarCard extends HTMLElement {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
     this._currentDate = new Date(today);
-    this._agendaStartDate = new Date(today);
-
-    const endDate = new Date(today);
-    endDate.setDate(endDate.getDate() + this.getAgendaPeriodDaySpan());
-    endDate.setHours(23, 59, 59, 999);
-    this._agendaEndDate = endDate;
-    this._agendaVisibleStartDate = new Date(today);
-    const visibleEndDate = new Date(endDate);
-    visibleEndDate.setHours(23, 59, 59, 999);
-    this._agendaVisibleEndDate = visibleEndDate;
+    const agendaWindow = createAgendaWindow(today, this.getAgendaPeriodDaySpan());
+    this._agendaStartDate = agendaWindow.startDate;
+    this._agendaEndDate = agendaWindow.endDate;
+    this._agendaVisibleStartDate = agendaWindow.visibleStartDate;
+    this._agendaVisibleEndDate = agendaWindow.visibleEndDate;
   }
 
   ensureAgendaWindowInitialized() {
@@ -2673,18 +2646,7 @@ class SkylightCalendarCard extends HTMLElement {
 
   getAgendaDays() {
     this.ensureAgendaWindowInitialized();
-    const days = [];
-    const cursor = new Date(this._agendaStartDate);
-    cursor.setHours(0, 0, 0, 0);
-    const end = new Date(this._agendaEndDate);
-    end.setHours(0, 0, 0, 0);
-
-    while (cursor <= end) {
-      days.push(new Date(cursor));
-      cursor.setDate(cursor.getDate() + 1);
-    }
-
-    return days;
+    return getAgendaDaysViewModel(this._agendaStartDate, this._agendaEndDate);
   }
 
   getAgendaVisibleDateRangeFromDom() {
@@ -2733,20 +2695,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   isAgendaRangeWithinCurrentWindow(range) {
-    if (!range?.startDate || !range?.endDate || !this._agendaStartDate || !this._agendaEndDate) {
-      return false;
-    }
-
-    const rangeStart = new Date(range.startDate);
-    rangeStart.setHours(0, 0, 0, 0);
-    const rangeEnd = new Date(range.endDate);
-    rangeEnd.setHours(23, 59, 59, 999);
-    const windowStart = new Date(this._agendaStartDate);
-    windowStart.setHours(0, 0, 0, 0);
-    const windowEnd = new Date(this._agendaEndDate);
-    windowEnd.setHours(23, 59, 59, 999);
-
-    return rangeStart >= windowStart && rangeEnd <= windowEnd;
+    return isAgendaRangeWithinWindow(range, this._agendaStartDate, this._agendaEndDate);
   }
 
   updateAgendaPeriodLabelInDom() {
@@ -2800,57 +2749,24 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getAgendaRollingDays() {
-    if (this._config?.rolling_days_agenda !== null && this._config?.rolling_days_agenda !== undefined) {
-      return this._config.rolling_days_agenda;
-    }
-
-    return null;
+    return getAgendaRollingDaysViewModel(this._config);
   }
 
   getAgendaPeriodDaySpan() {
-    const rollingDays = this.getAgendaRollingDays();
-    return rollingDays !== null ? rollingDays : 14;
+    return getAgendaPeriodDaySpanViewModel(this._config);
   }
 
   getRollingDaysForView(viewMode = this._viewMode) {
-    if (viewMode === 'week-compact' && this._config.rolling_days_week_compact !== null) {
-      return this._config.rolling_days_week_compact;
-    }
-
-    if (viewMode === 'week-standard' && this._config.rolling_days_schedule !== null) {
-      return this._config.rolling_days_schedule;
-    }
-
-    return null;
+    return getRollingDaysForViewModel(viewMode, this._config);
   }
 
   getWeekDays(viewMode = this._viewMode) {
-    const rollingDays = this.getRollingDaysForView(viewMode);
-
-    // If rolling days are set, show current date + N days
-    if (rollingDays !== null) {
-      const days = [];
-      const startDate = new Date(this._currentDate);
-      startDate.setHours(0, 0, 0, 0);
-
-      for (let i = 0; i <= rollingDays; i++) {
-        const date = new Date(startDate);
-        date.setDate(startDate.getDate() + i);
-        days.push(date);
-      }
-      return days;
-    }
-
-    // Otherwise use the week-based approach
-    const days = [];
-    for (let i = 0; i < 7; i++) {
-      const date = new Date(this._weekStart);
-      date.setDate(this._weekStart.getDate() + i);
-      if (this._config.week_days.includes(date.getDay())) {
-        days.push(date);
-      }
-    }
-    return days;
+    return getWeekDaysViewModel({
+      currentDate: this._currentDate,
+      weekStart: this._weekStart,
+      weekDays: this._config.week_days,
+      rollingDays: this.getRollingDaysForView(viewMode)
+    });
   }
 
   getStyles() {
@@ -6177,17 +6093,12 @@ class SkylightCalendarCard extends HTMLElement {
     const monthFormatter = new Intl.DateTimeFormat(this.getLocale(), this.withTimeZone({ month: 'long', year: 'numeric' }));
     const agendaRows = [];
     const shouldHideEmptyDays = this._viewMode === 'agenda' && !!this._config.hide_empty_days;
-    const agendaDayEntries = agendaDays
-      .map((date) => ({
-        date,
-        matchingEvents: this.getEventsForDay(date, { includeHiddenStyledEvents: true }),
-        events: null
-      }))
-      .map((entry) => ({
-        ...entry,
-        events: this.sortEventsForDate(entry.matchingEvents.filter((event) => !this.isEventHiddenByStyle(event)), entry.date)
-      }))
-      .filter((entry) => !shouldHideEmptyDays || entry.events.length > 0);
+    const agendaDayEntries = buildAgendaDayEntries(agendaDays, {
+      getEventsForDay: this.getEventsForDay.bind(this),
+      isEventHiddenByStyle: this.isEventHiddenByStyle.bind(this),
+      sortEventsForDate: this.sortEventsForDate.bind(this),
+      hideEmptyDays: shouldHideEmptyDays
+    });
 
     agendaDayEntries.forEach((entry, index) => {
       const { date, events } = entry;
@@ -7105,98 +7016,35 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   renderDays() {
-    const year = this._currentDate.getFullYear();
-    const month = this._currentDate.getMonth();
-
     // If rolling_weeks is set, show current week + N additional weeks
     if (this._config.rolling_weeks !== null && this._viewMode === 'month') {
       return this.renderRollingWeeks();
     }
 
-    const firstDay = new Date(year, month, 1).getDay();
-    const daysInMonth = new Date(year, month + 1, 0).getDate();
-    const daysInPrevMonth = new Date(year, month, 0).getDate();
-
-    const today = new Date();
-    const isToday = (d) => {
-      return d.getDate() === today.getDate() &&
-             d.getMonth() === today.getMonth() &&
-             d.getFullYear() === today.getFullYear();
-    };
-
     const shouldShowWeekNumbers = this.shouldShowMonthWeekNumbers();
     let html = '';
-    let dayIndex = 0;
-    const startDay = (firstDay - this._config.firstDayOfWeek + 7) % 7;
 
-    // Previous month days
-    for (let i = startDay - 1; i >= 0; i--) {
-      const day = daysInPrevMonth - i;
-      const date = new Date(year, month - 1, day);
+    getMonthGridDates(this._currentDate, this._config.firstDayOfWeek).forEach((dayEntry, dayIndex) => {
       if (shouldShowWeekNumbers && dayIndex % 7 === 0) {
-        html += this.renderMonthWeekNumberCell(date);
+        html += this.renderMonthWeekNumberCell(dayEntry.date);
       }
-      html += this.renderDay(day, date, true);
-      dayIndex++;
-    }
-
-    // Current month days
-    for (let day = 1; day <= daysInMonth; day++) {
-      const date = new Date(year, month, day);
-      if (shouldShowWeekNumbers && dayIndex % 7 === 0) {
-        html += this.renderMonthWeekNumberCell(date);
-      }
-      html += this.renderDay(day, date, false);
-      dayIndex++;
-    }
-
-    // Next month days
-    const totalCells = startDay + daysInMonth;
-    const remainingCells = totalCells % 7 === 0 ? 0 : 7 - (totalCells % 7);
-    for (let day = 1; day <= remainingCells; day++) {
-      const date = new Date(year, month + 1, day);
-      if (shouldShowWeekNumbers && dayIndex % 7 === 0) {
-        html += this.renderMonthWeekNumberCell(date);
-      }
-      html += this.renderDay(day, date, true);
-      dayIndex++;
-    }
+      html += this.renderDay(dayEntry.day, dayEntry.date, dayEntry.isOtherMonth);
+    });
 
     return html;
   }
 
   renderRollingWeeks() {
-    const anchorDate = new Date(this._currentDate);
-    anchorDate.setHours(0, 0, 0, 0);
-
-    // Find the start of the current week based on firstDayOfWeek
-    const currentDay = anchorDate.getDay();
-    const diff = (currentDay - this._config.firstDayOfWeek + 7) % 7;
-    const weekStart = new Date(anchorDate);
-    weekStart.setDate(anchorDate.getDate() - diff);
-
-    // Calculate total days to show: (rolling_weeks + 1) * 7 days
-    const totalWeeks = this._config.rolling_weeks + 1;
-    const totalDays = totalWeeks * 7;
-
     const shouldShowWeekNumbers = this.shouldShowMonthWeekNumbers();
     let html = '';
 
-    // Render all days in the rolling weeks
-    for (let i = 0; i < totalDays; i++) {
-      const date = new Date(weekStart);
-      date.setDate(weekStart.getDate() + i);
-      if (shouldShowWeekNumbers && i % 7 === 0) {
-        html += this.renderMonthWeekNumberCell(date);
+    getRollingMonthGridDates(this._currentDate, this._config.firstDayOfWeek, this._config.rolling_weeks).forEach((dayEntry, dayIndex) => {
+      if (shouldShowWeekNumbers && dayIndex % 7 === 0) {
+        html += this.renderMonthWeekNumberCell(dayEntry.date);
       }
 
-      // In rolling-weeks month view, keep trailing (next-month) days visually active
-      // while still dimming any leading days from the previous month.
-      const currentMonthStart = new Date(this._currentDate.getFullYear(), this._currentDate.getMonth(), 1);
-      const isOtherMonth = date < currentMonthStart;
-
-      html += this.renderDay(date.getDate(), date, isOtherMonth);
-    }
+      html += this.renderDay(dayEntry.day, dayEntry.date, dayEntry.isOtherMonth);
+    });
 
     return html;
   }

--- a/src/views/agenda-view-model.js
+++ b/src/views/agenda-view-model.js
@@ -1,0 +1,78 @@
+export function getAgendaRollingDays(config) {
+  if (config?.rolling_days_agenda !== null && config?.rolling_days_agenda !== undefined) {
+    return config.rolling_days_agenda;
+  }
+
+  return null;
+}
+
+export function getAgendaPeriodDaySpan(config) {
+  const rollingDays = getAgendaRollingDays(config);
+  return rollingDays !== null ? rollingDays : 14;
+}
+
+export function createAgendaWindow(today, daySpan) {
+  const startDate = new Date(today);
+  startDate.setHours(0, 0, 0, 0);
+  const endDate = new Date(startDate);
+  endDate.setDate(endDate.getDate() + daySpan);
+  endDate.setHours(23, 59, 59, 999);
+  const visibleStartDate = new Date(startDate);
+  const visibleEndDate = new Date(endDate);
+  visibleEndDate.setHours(23, 59, 59, 999);
+  return { startDate, endDate, visibleStartDate, visibleEndDate };
+}
+
+export function getAgendaDays(startDate, endDate) {
+  const days = [];
+  const cursor = new Date(startDate);
+  cursor.setHours(0, 0, 0, 0);
+  const end = new Date(endDate);
+  end.setHours(0, 0, 0, 0);
+
+  while (cursor <= end) {
+    days.push(new Date(cursor));
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  return days;
+}
+
+export function getAgendaVisibleDateRange(startDate, endDate) {
+  const visibleStartDate = new Date(startDate);
+  visibleStartDate.setHours(0, 0, 0, 0);
+  const visibleEndDate = new Date(endDate);
+  visibleEndDate.setHours(23, 59, 59, 999);
+  return { startDate: visibleStartDate, endDate: visibleEndDate };
+}
+
+export function isAgendaRangeWithinWindow(range, windowStartDate, windowEndDate) {
+  if (!range?.startDate || !range?.endDate || !windowStartDate || !windowEndDate) {
+    return false;
+  }
+
+  const rangeStart = new Date(range.startDate);
+  rangeStart.setHours(0, 0, 0, 0);
+  const rangeEnd = new Date(range.endDate);
+  rangeEnd.setHours(23, 59, 59, 999);
+  const windowStart = new Date(windowStartDate);
+  windowStart.setHours(0, 0, 0, 0);
+  const windowEnd = new Date(windowEndDate);
+  windowEnd.setHours(23, 59, 59, 999);
+
+  return rangeStart >= windowStart && rangeEnd <= windowEnd;
+}
+
+export function buildAgendaDayEntries(agendaDays, { getEventsForDay, isEventHiddenByStyle, sortEventsForDate, hideEmptyDays }) {
+  return agendaDays
+    .map((date) => ({
+      date,
+      matchingEvents: getEventsForDay(date, { includeHiddenStyledEvents: true }),
+      events: null
+    }))
+    .map((entry) => ({
+      ...entry,
+      events: sortEventsForDate(entry.matchingEvents.filter((event) => !isEventHiddenByStyle(event)), entry.date)
+    }))
+    .filter((entry) => !hideEmptyDays || entry.events.length > 0);
+}

--- a/src/views/month-view-model.js
+++ b/src/views/month-view-model.js
@@ -1,0 +1,67 @@
+export function getMonthGridDates(currentDate, firstDayOfWeek) {
+  const year = currentDate.getFullYear();
+  const month = currentDate.getMonth();
+  const firstDay = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const daysInPrevMonth = new Date(year, month, 0).getDate();
+  const startDay = (firstDay - firstDayOfWeek + 7) % 7;
+  const days = [];
+
+  for (let i = startDay - 1; i >= 0; i--) {
+    const day = daysInPrevMonth - i;
+    days.push({ day, date: new Date(year, month - 1, day), isOtherMonth: true });
+  }
+
+  for (let day = 1; day <= daysInMonth; day++) {
+    days.push({ day, date: new Date(year, month, day), isOtherMonth: false });
+  }
+
+  const totalCells = startDay + daysInMonth;
+  const remainingCells = totalCells % 7 === 0 ? 0 : 7 - (totalCells % 7);
+  for (let day = 1; day <= remainingCells; day++) {
+    days.push({ day, date: new Date(year, month + 1, day), isOtherMonth: true });
+  }
+
+  return days;
+}
+
+export function getRollingMonthGridDates(currentDate, firstDayOfWeek, rollingWeeks) {
+  const anchorDate = new Date(currentDate);
+  anchorDate.setHours(0, 0, 0, 0);
+
+  const currentDay = anchorDate.getDay();
+  const diff = (currentDay - firstDayOfWeek + 7) % 7;
+  const weekStart = new Date(anchorDate);
+  weekStart.setDate(anchorDate.getDate() - diff);
+
+  const totalWeeks = rollingWeeks + 1;
+  const totalDays = totalWeeks * 7;
+  const currentMonthStart = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1);
+  const days = [];
+
+  for (let i = 0; i < totalDays; i++) {
+    const date = new Date(weekStart);
+    date.setDate(weekStart.getDate() + i);
+    days.push({ day: date.getDate(), date, isOtherMonth: date < currentMonthStart });
+  }
+
+  return days;
+}
+
+export function getMonthVisibleDateRange(currentDate, firstDayOfWeek, rollingWeeks = null) {
+  if (rollingWeeks !== null) {
+    const days = getRollingMonthGridDates(currentDate, firstDayOfWeek, rollingWeeks);
+    const startDate = new Date(days[0].date);
+    startDate.setHours(0, 0, 0, 0);
+    const endDate = new Date(days[days.length - 1].date);
+    endDate.setHours(23, 59, 59, 999);
+    return { startDate, endDate };
+  }
+
+  const days = getMonthGridDates(currentDate, firstDayOfWeek);
+  const startDate = new Date(days[0].date);
+  startDate.setHours(0, 0, 0, 0);
+  const endDate = new Date(days[days.length - 1].date);
+  endDate.setHours(23, 59, 59, 999);
+  return { startDate, endDate };
+}

--- a/src/views/week-view-model.js
+++ b/src/views/week-view-model.js
@@ -1,0 +1,44 @@
+export function getRollingDaysForView(viewMode, config) {
+  if (viewMode === 'week-compact' && config.rolling_days_week_compact !== null) {
+    return config.rolling_days_week_compact;
+  }
+
+  if (viewMode === 'week-standard' && config.rolling_days_schedule !== null) {
+    return config.rolling_days_schedule;
+  }
+
+  return null;
+}
+
+export function getWeekDays({ currentDate, weekStart, weekDays, rollingDays }) {
+  if (rollingDays !== null) {
+    const days = [];
+    const startDate = new Date(currentDate);
+    startDate.setHours(0, 0, 0, 0);
+
+    for (let i = 0; i <= rollingDays; i++) {
+      const date = new Date(startDate);
+      date.setDate(startDate.getDate() + i);
+      days.push(date);
+    }
+    return days;
+  }
+
+  const days = [];
+  for (let i = 0; i < 7; i++) {
+    const date = new Date(weekStart);
+    date.setDate(weekStart.getDate() + i);
+    if (weekDays.includes(date.getDay())) {
+      days.push(date);
+    }
+  }
+  return days;
+}
+
+export function getWeekVisibleDateRange(weekDays) {
+  const startDate = new Date(weekDays[0]);
+  startDate.setHours(0, 0, 0, 0);
+  const endDate = new Date(weekDays[weekDays.length - 1]);
+  endDate.setHours(23, 59, 59, 999);
+  return { startDate, endDate };
+}


### PR DESCRIPTION
### Motivation
- Move pure, data-only view preparation for month/week/agenda into dedicated modules to continue the modularization effort while preserving runtime and visual behavior. 
- Keep rendering, DOM, measurement, scroll restoration, and CSS inside the main card so no rendering or DOM semantics change.

### Description
- Created `src/views/month-view-model.js` and moved month helpers: `getMonthGridDates`, `getRollingMonthGridDates`, and `getMonthVisibleDateRange` to compute month grids and visible ranges. 
- Created `src/views/week-view-model.js` and moved week helpers: `getRollingDaysForView`, `getWeekDays`, and `getWeekVisibleDateRange` to compute week/rolling-day logic and visible ranges. 
- Created `src/views/agenda-view-model.js` and moved agenda helpers: `getAgendaRollingDays`, `getAgendaPeriodDaySpan`, `createAgendaWindow`, `getAgendaDays`, `getAgendaVisibleDateRange`, `isAgendaRangeWithinWindow`, and `buildAgendaDayEntries` for agenda window and day-entry preparation. 
- Updated `src/skylight-calendar-card.js` to import and call the new view-model functions while preserving all render methods (`renderMonth`/`renderDays`/`renderRollingWeeks`/`renderWeekCompact`/`renderWeekStandard`/`renderAgenda`), DOM interactions, CSS, ResizeObserver, scroll handling, and compact-height logic. 
- Added focused unit tests covering month grid leading/trailing days and range boundaries, week day generation/range handling, and agenda inclusive window generation, without altering existing tests that exercise rendering or DOM behavior.

### Testing
- Ran `npm ci --no-audit --fund=false` successfully and then `npm run build`, which regenerated the root `skylight-calendar-card.js` artifact and was committed. 
- Verified build artifact consistency with `git diff --exit-code -- skylight-calendar-card.js` after committing (clean). 
- Performed static checks with `node --check` against `src/skylight-calendar-card.js`, the three new `src/views/*.js` files, and the generated `skylight-calendar-card.js` file (all OK). 
- Ran unit tests with `npm test` (all tests passed: 228 passed, 0 failed). 
- Ran visual tests with `npm run test:visual` (all Playwright visual tests passed: 39 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b50f028f88331a42aac21ed8ba7ef)