### PR TITLE
Extract calendar/entity metadata helpers (Phase 12)

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -2683,6 +2683,164 @@ function buildAgendaDayEntries(agendaDays, { getEventsForDay, isEventHiddenBySty
     .filter((entry) => !hideEmptyDays || entry.events.length > 0);
 }
 
+function normalizeVirtualCalendars(virtualCalendars, { normalizeSingleColor }) {
+  if (!Array.isArray(virtualCalendars)) return [];
+
+  return virtualCalendars
+    .map((entry, index) => {
+      if (!entry || typeof entry !== 'object') return null;
+      const id = typeof entry.id === 'string' && entry.id.trim()
+        ? entry.id.trim()
+        : `virtual_${index + 1}`;
+      const entities = Array.isArray(entry.entities)
+        ? Array.from(new Set(entry.entities
+          .map((entityId) => typeof entityId === 'string' ? entityId.trim() : '')
+          .filter(Boolean)))
+        : [];
+      if (entities.length === 0) return null;
+      return {
+        id,
+        name: typeof entry.name === 'string' && entry.name.trim() ? entry.name.trim() : id,
+        icon: typeof entry.icon === 'string' && entry.icon.trim() ? entry.icon.trim() : null,
+        color: normalizeSingleColor(entry.color),
+        entities
+      };
+    })
+    .filter(Boolean);
+}
+
+function getVirtualBadgeById(virtualCalendars = [], virtualId) {
+  return (virtualCalendars || []).find((virtualCalendar) => virtualCalendar.id === virtualId) || null;
+}
+
+function getVirtualBadgeForEntity(virtualCalendars = [], entityId) {
+  return (virtualCalendars || []).find((virtualCalendar) => virtualCalendar.entities.includes(entityId)) || null;
+}
+
+function getVirtualBadgeForEvent(virtualCalendars = [], event) {
+  if (!event) return null;
+
+  if (event.isCombinedCalendarEvent && Array.isArray(event.sourceEntityIds) && event.sourceEntityIds.length > 0) {
+    const matchedVirtualCalendars = event.sourceEntityIds
+      .map((entityId) => getVirtualBadgeForEntity(virtualCalendars, entityId))
+      .filter(Boolean);
+    if (matchedVirtualCalendars.length > 0) {
+      return matchedVirtualCalendars[0];
+    }
+    return null;
+  }
+
+  return getVirtualBadgeForEntity(virtualCalendars, event.entityId);
+}
+
+function getCalendarColor(entityId, index = 0, { colors = {}, getDefaultColor, normalizeSingleColor }) {
+  return normalizeSingleColor(
+    colors?.[entityId] ||
+    getDefaultColor(index)
+  );
+}
+
+function getCalendarName(entityId, { calendarNames = {}, hassStates = {}, virtualCalendars = [] } = {}) {
+  if (!entityId) {
+    return '';
+  }
+
+  if (entityId.startsWith('virtual:')) {
+    const virtualId = entityId.replace('virtual:', '');
+    const virtualBadge = getVirtualBadgeById(virtualCalendars, virtualId);
+    if (virtualBadge?.name) {
+      return virtualBadge.name;
+    }
+    return virtualId;
+  }
+
+  // Check if there's a custom name mapping
+  if (calendarNames && calendarNames[entityId]) {
+    return calendarNames[entityId];
+  }
+
+  // Otherwise use friendly_name from entity or entity ID
+  const entity = hassStates?.[entityId];
+  const fallbackName = entityId.includes('.') ? entityId.split('.').slice(1).join('.') : entityId;
+  return entity?.attributes?.friendly_name || fallbackName;
+}
+
+function getVirtualBadgeItems({
+  entities = [],
+  virtualCalendars = [],
+  hideBadgeCalendars = [],
+  hiddenCalendars = new Set(),
+  getCalendarColor,
+  getCalendarName,
+  getCalendarBadgeIcon
+}) {
+  const hiddenBadgeCalendars = new Set(hideBadgeCalendars || []);
+  const items = [];
+  const insertedVirtualIds = new Set();
+
+  entities.forEach((entityId, originalIndex) => {
+    const virtualCalendar = getVirtualBadgeForEntity(virtualCalendars, entityId);
+    if (virtualCalendar && !insertedVirtualIds.has(virtualCalendar.id)) {
+      const configuredEntities = virtualCalendar.entities.filter((configuredEntityId) => entities.includes(configuredEntityId));
+      const hasVisibleEntity = configuredEntities.some((configuredEntityId) => !hiddenBadgeCalendars.has(configuredEntityId));
+      if (hasVisibleEntity) {
+        const color = virtualCalendar.color || getCalendarColor(entityId, originalIndex);
+        const isHidden = configuredEntities.every((configuredEntityId) => hiddenCalendars.has(configuredEntityId));
+        items.push({
+          id: virtualCalendar.id,
+          entityId: `virtual:${virtualCalendar.id}`,
+          name: virtualCalendar.name,
+          icon: virtualCalendar.icon,
+          color,
+          entities: configuredEntities,
+          isHidden,
+          type: 'virtual'
+        });
+      }
+      insertedVirtualIds.add(virtualCalendar.id);
+      return;
+    }
+
+    if (virtualCalendar || hiddenBadgeCalendars.has(entityId)) return;
+    const color = getCalendarColor(entityId, originalIndex);
+    items.push({
+      id: entityId,
+      entityId,
+      name: getCalendarName(entityId),
+      icon: getCalendarBadgeIcon(entityId),
+      color,
+      entities: [entityId],
+      isHidden: hiddenCalendars.has(entityId),
+      type: 'entity'
+    });
+  });
+
+  return items;
+}
+
+function getWritableCalendars(entities = [], calendarCapabilities = {}) {
+  return entities.filter(entityId => {
+    const caps = calendarCapabilities[entityId];
+    return caps && caps.canCreate && !caps.isReadonly;
+  });
+}
+
+function getCalendarBadgePersonEntityId(badgeEntityId, calendarPersonEntities = {}) {
+  const mappings = calendarPersonEntities || {};
+  if (!badgeEntityId) return null;
+
+  if (mappings[badgeEntityId]) {
+    return mappings[badgeEntityId];
+  }
+
+  if (badgeEntityId.startsWith('virtual:')) {
+    const virtualId = badgeEntityId.replace('virtual:', '');
+    return mappings[virtualId] || null;
+  }
+
+  return null;
+}
+
 const DAYLIGHT_CALENDAR_CARD_VERSION = 'v4.5.0';
 
 function getDaylightCalendarCardVersion() {
@@ -4173,105 +4331,37 @@ class SkylightCalendarCard extends HTMLElement {
 
 
   normalizeVirtualCalendars(virtualCalendars) {
-    if (!Array.isArray(virtualCalendars)) return [];
-
-    return virtualCalendars
-      .map((entry, index) => {
-        if (!entry || typeof entry !== 'object') return null;
-        const id = typeof entry.id === 'string' && entry.id.trim()
-          ? entry.id.trim()
-          : `virtual_${index + 1}`;
-        const entities = Array.isArray(entry.entities)
-          ? Array.from(new Set(entry.entities
-            .map((entityId) => typeof entityId === 'string' ? entityId.trim() : '')
-            .filter(Boolean)))
-          : [];
-        if (entities.length === 0) return null;
-        return {
-          id,
-          name: typeof entry.name === 'string' && entry.name.trim() ? entry.name.trim() : id,
-          icon: typeof entry.icon === 'string' && entry.icon.trim() ? entry.icon.trim() : null,
-          color: this.normalizeSingleColor(entry.color),
-          entities
-        };
-      })
-      .filter(Boolean);
+    return normalizeVirtualCalendars(virtualCalendars, {
+      normalizeSingleColor: this.normalizeSingleColor.bind(this)
+    });
   }
 
   getVirtualBadgeById(virtualId) {
-    return (this._config.virtual_calendars || []).find((virtualCalendar) => virtualCalendar.id === virtualId) || null;
+    return getVirtualBadgeById(this._config.virtual_calendars || [], virtualId);
   }
 
   getVirtualBadgeForEntity(entityId) {
-    return (this._config.virtual_calendars || []).find((virtualCalendar) => virtualCalendar.entities.includes(entityId)) || null;
+    return getVirtualBadgeForEntity(this._config.virtual_calendars || [], entityId);
   }
 
   getVirtualBadgeForEvent(event) {
-    if (!event) return null;
-
-    if (event.isCombinedCalendarEvent && Array.isArray(event.sourceEntityIds) && event.sourceEntityIds.length > 0) {
-      const virtualCalendars = event.sourceEntityIds
-        .map((entityId) => this.getVirtualBadgeForEntity(entityId))
-        .filter(Boolean);
-      if (virtualCalendars.length > 0) {
-        return virtualCalendars[0];
-      }
-      return null;
-    }
-
-    return this.getVirtualBadgeForEntity(event.entityId);
+    return getVirtualBadgeForEvent(this._config.virtual_calendars || [], event);
   }
 
   getVirtualBadgeItems() {
-    const hiddenBadgeCalendars = new Set(this._config.hide_badge_calendars || []);
-    const items = [];
-    const insertedVirtualIds = new Set();
-
-    this._config.entities.forEach((entityId, originalIndex) => {
-      const virtualCalendar = this.getVirtualBadgeForEntity(entityId);
-      if (virtualCalendar && !insertedVirtualIds.has(virtualCalendar.id)) {
-        const configuredEntities = virtualCalendar.entities.filter((configuredEntityId) => this._config.entities.includes(configuredEntityId));
-        const hasVisibleEntity = configuredEntities.some((configuredEntityId) => !hiddenBadgeCalendars.has(configuredEntityId));
-        if (hasVisibleEntity) {
-          const color = virtualCalendar.color || this.getCalendarColor(entityId, originalIndex);
-          const isHidden = configuredEntities.every((configuredEntityId) => this._hiddenCalendars.has(configuredEntityId));
-          items.push({
-            id: virtualCalendar.id,
-            entityId: `virtual:${virtualCalendar.id}`,
-            name: virtualCalendar.name,
-            icon: virtualCalendar.icon,
-            color,
-            entities: configuredEntities,
-            isHidden,
-            type: 'virtual'
-          });
-        }
-        insertedVirtualIds.add(virtualCalendar.id);
-        return;
-      }
-
-      if (virtualCalendar || hiddenBadgeCalendars.has(entityId)) return;
-      const color = this.getCalendarColor(entityId, originalIndex);
-      items.push({
-        id: entityId,
-        entityId,
-        name: this.getCalendarName(entityId),
-        icon: this.getCalendarBadgeIcon(entityId),
-        color,
-        entities: [entityId],
-        isHidden: this._hiddenCalendars.has(entityId),
-        type: 'entity'
-      });
+    return getVirtualBadgeItems({
+      entities: this._config.entities,
+      virtualCalendars: this._config.virtual_calendars || [],
+      hideBadgeCalendars: this._config.hide_badge_calendars || [],
+      hiddenCalendars: this._hiddenCalendars,
+      getCalendarColor: this.getCalendarColor.bind(this),
+      getCalendarName: this.getCalendarName.bind(this),
+      getCalendarBadgeIcon: this.getCalendarBadgeIcon.bind(this)
     });
-
-    return items;
   }
 
   getWritableCalendars() {
-    return this._config.entities.filter(entityId => {
-      const caps = this._calendarCapabilities[entityId];
-      return caps && caps.canCreate && !caps.isReadonly;
-    });
+    return getWritableCalendars(this._config.entities, this._calendarCapabilities);
   }
 
   getEventIdentityKey(entityId, event) {
@@ -4298,10 +4388,11 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getCalendarColor(entityId, index = 0) {
-    return this.normalizeSingleColor(
-      this._config?.colors?.[entityId] ||
-      this.getDefaultColor(index)
-    );
+    return getCalendarColor(entityId, index, {
+      colors: this._config?.colors || {},
+      getDefaultColor: this.getDefaultColor.bind(this),
+      normalizeSingleColor: this.normalizeSingleColor.bind(this)
+    });
   }
 
   async fetchEventsForCalendar(entityId, colorIndex, chunks) {
@@ -12817,28 +12908,11 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getCalendarName(entityId) {
-    if (!entityId) {
-      return '';
-    }
-
-    if (entityId.startsWith('virtual:')) {
-      const virtualId = entityId.replace('virtual:', '');
-      const virtualBadge = this.getVirtualBadgeById(virtualId);
-      if (virtualBadge?.name) {
-        return virtualBadge.name;
-      }
-      return virtualId;
-    }
-
-    // Check if there's a custom name mapping
-    if (this._config.calendar_names && this._config.calendar_names[entityId]) {
-      return this._config.calendar_names[entityId];
-    }
-
-    // Otherwise use friendly_name from entity or entity ID
-    const entity = this._hass?.states[entityId];
-    const fallbackName = entityId.includes('.') ? entityId.split('.').slice(1).join('.') : entityId;
-    return entity?.attributes?.friendly_name || fallbackName;
+    return getCalendarName(entityId, {
+      calendarNames: this._config.calendar_names || {},
+      hassStates: this._hass?.states || {},
+      virtualCalendars: this._config.virtual_calendars || []
+    });
   }
 
   getCalendarBadgeIcon(entityId) {
@@ -12852,19 +12926,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getCalendarBadgePersonEntityId(badgeEntityId) {
-    const mappings = this._config?.calendar_person_entities || {};
-    if (!badgeEntityId) return null;
-
-    if (mappings[badgeEntityId]) {
-      return mappings[badgeEntityId];
-    }
-
-    if (badgeEntityId.startsWith('virtual:')) {
-      const virtualId = badgeEntityId.replace('virtual:', '');
-      return mappings[virtualId] || null;
-    }
-
-    return null;
+    return getCalendarBadgePersonEntityId(badgeEntityId, this._config?.calendar_person_entities || {});
   }
 
   getCalendarBadgePersonState(badgeEntityId) {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -1206,6 +1206,76 @@ test('calendar_names overrides displayed calendar labels', () => {
   assert.doesNotMatch(card.renderCalendarBadges(), /Family Friendly Name/);
 });
 
+test('calendar entity helpers resolve names, colors, visibility, virtual badges, writable calendars, and person mappings', async () => {
+  const {
+    getCalendarBadgePersonEntityId,
+    getCalendarColor,
+    getCalendarName,
+    getVirtualBadgeItems,
+    getWritableCalendars,
+    normalizeVirtualCalendars
+  } = await import('./src/calendars/calendar-entities.js');
+  const normalizeSingleColor = (value) => value || null;
+  const virtualCalendars = normalizeVirtualCalendars([
+    {
+      id: 'family_group',
+      name: 'Family Group',
+      icon: 'mdi:account-group',
+      color: '#445566',
+      entities: ['calendar.family', 'calendar.work', 'calendar.family']
+    }
+  ], { normalizeSingleColor });
+
+  assert.equal(getCalendarName('calendar.family', {
+    hassStates: { 'calendar.family': { attributes: { friendly_name: 'Family Friendly Name' } } }
+  }), 'Family Friendly Name');
+  assert.equal(getCalendarName('calendar.family', {
+    calendarNames: { 'calendar.family': 'Household' },
+    hassStates: { 'calendar.family': { attributes: { friendly_name: 'Family Friendly Name' } } }
+  }), 'Household');
+  assert.equal(getCalendarName('calendar.school'), 'school');
+  assert.equal(getCalendarName('virtual:family_group', { virtualCalendars }), 'Family Group');
+
+  assert.equal(getCalendarColor('calendar.family', 0, {
+    colors: { 'calendar.family': '#112233' },
+    getDefaultColor: () => '#AABBCC',
+    normalizeSingleColor
+  }), '#112233');
+  assert.equal(getCalendarColor('calendar.work', 1, {
+    colors: {},
+    getDefaultColor: () => '#4ECDC4',
+    normalizeSingleColor
+  }), '#4ECDC4');
+
+  const badgeItems = getVirtualBadgeItems({
+    entities: ['calendar.family', 'calendar.work', 'calendar.school'],
+    virtualCalendars,
+    hideBadgeCalendars: ['calendar.school'],
+    hiddenCalendars: new Set(['calendar.family', 'calendar.work']),
+    getCalendarColor: (_entityId, index) => ['#111111', '#222222', '#333333'][index],
+    getCalendarName: (entityId) => entityId,
+    getCalendarBadgeIcon: () => null
+  });
+  assert.deepEqual(badgeItems, [{
+    id: 'family_group',
+    entityId: 'virtual:family_group',
+    name: 'Family Group',
+    icon: 'mdi:account-group',
+    color: '#445566',
+    entities: ['calendar.family', 'calendar.work'],
+    isHidden: true,
+    type: 'virtual'
+  }]);
+
+  assert.deepEqual(getWritableCalendars(['calendar.family', 'calendar.work', 'calendar.school'], {
+    'calendar.family': { canCreate: true, isReadonly: false },
+    'calendar.work': { canCreate: true, isReadonly: true },
+    'calendar.school': { canCreate: false, isReadonly: false }
+  }), ['calendar.family']);
+  assert.equal(getCalendarBadgePersonEntityId('calendar.family', { 'calendar.family': 'person.ian' }), 'person.ian');
+  assert.equal(getCalendarBadgePersonEntityId('virtual:family_group', { family_group: 'person.family' }), 'person.family');
+});
+
 test('preference_storage_key customizes persisted preference storage key', () => {
   const originalLocation = window.location;
   window.location = { pathname: '/lovelace-family/0', hash: '' };

--- a/src/calendars/calendar-entities.js
+++ b/src/calendars/calendar-entities.js
@@ -1,0 +1,157 @@
+export function normalizeVirtualCalendars(virtualCalendars, { normalizeSingleColor }) {
+  if (!Array.isArray(virtualCalendars)) return [];
+
+  return virtualCalendars
+    .map((entry, index) => {
+      if (!entry || typeof entry !== 'object') return null;
+      const id = typeof entry.id === 'string' && entry.id.trim()
+        ? entry.id.trim()
+        : `virtual_${index + 1}`;
+      const entities = Array.isArray(entry.entities)
+        ? Array.from(new Set(entry.entities
+          .map((entityId) => typeof entityId === 'string' ? entityId.trim() : '')
+          .filter(Boolean)))
+        : [];
+      if (entities.length === 0) return null;
+      return {
+        id,
+        name: typeof entry.name === 'string' && entry.name.trim() ? entry.name.trim() : id,
+        icon: typeof entry.icon === 'string' && entry.icon.trim() ? entry.icon.trim() : null,
+        color: normalizeSingleColor(entry.color),
+        entities
+      };
+    })
+    .filter(Boolean);
+}
+
+export function getVirtualBadgeById(virtualCalendars = [], virtualId) {
+  return (virtualCalendars || []).find((virtualCalendar) => virtualCalendar.id === virtualId) || null;
+}
+
+export function getVirtualBadgeForEntity(virtualCalendars = [], entityId) {
+  return (virtualCalendars || []).find((virtualCalendar) => virtualCalendar.entities.includes(entityId)) || null;
+}
+
+export function getVirtualBadgeForEvent(virtualCalendars = [], event) {
+  if (!event) return null;
+
+  if (event.isCombinedCalendarEvent && Array.isArray(event.sourceEntityIds) && event.sourceEntityIds.length > 0) {
+    const matchedVirtualCalendars = event.sourceEntityIds
+      .map((entityId) => getVirtualBadgeForEntity(virtualCalendars, entityId))
+      .filter(Boolean);
+    if (matchedVirtualCalendars.length > 0) {
+      return matchedVirtualCalendars[0];
+    }
+    return null;
+  }
+
+  return getVirtualBadgeForEntity(virtualCalendars, event.entityId);
+}
+
+export function getCalendarColor(entityId, index = 0, { colors = {}, getDefaultColor, normalizeSingleColor }) {
+  return normalizeSingleColor(
+    colors?.[entityId] ||
+    getDefaultColor(index)
+  );
+}
+
+export function getCalendarName(entityId, { calendarNames = {}, hassStates = {}, virtualCalendars = [] } = {}) {
+  if (!entityId) {
+    return '';
+  }
+
+  if (entityId.startsWith('virtual:')) {
+    const virtualId = entityId.replace('virtual:', '');
+    const virtualBadge = getVirtualBadgeById(virtualCalendars, virtualId);
+    if (virtualBadge?.name) {
+      return virtualBadge.name;
+    }
+    return virtualId;
+  }
+
+  // Check if there's a custom name mapping
+  if (calendarNames && calendarNames[entityId]) {
+    return calendarNames[entityId];
+  }
+
+  // Otherwise use friendly_name from entity or entity ID
+  const entity = hassStates?.[entityId];
+  const fallbackName = entityId.includes('.') ? entityId.split('.').slice(1).join('.') : entityId;
+  return entity?.attributes?.friendly_name || fallbackName;
+}
+
+export function getVirtualBadgeItems({
+  entities = [],
+  virtualCalendars = [],
+  hideBadgeCalendars = [],
+  hiddenCalendars = new Set(),
+  getCalendarColor,
+  getCalendarName,
+  getCalendarBadgeIcon
+}) {
+  const hiddenBadgeCalendars = new Set(hideBadgeCalendars || []);
+  const items = [];
+  const insertedVirtualIds = new Set();
+
+  entities.forEach((entityId, originalIndex) => {
+    const virtualCalendar = getVirtualBadgeForEntity(virtualCalendars, entityId);
+    if (virtualCalendar && !insertedVirtualIds.has(virtualCalendar.id)) {
+      const configuredEntities = virtualCalendar.entities.filter((configuredEntityId) => entities.includes(configuredEntityId));
+      const hasVisibleEntity = configuredEntities.some((configuredEntityId) => !hiddenBadgeCalendars.has(configuredEntityId));
+      if (hasVisibleEntity) {
+        const color = virtualCalendar.color || getCalendarColor(entityId, originalIndex);
+        const isHidden = configuredEntities.every((configuredEntityId) => hiddenCalendars.has(configuredEntityId));
+        items.push({
+          id: virtualCalendar.id,
+          entityId: `virtual:${virtualCalendar.id}`,
+          name: virtualCalendar.name,
+          icon: virtualCalendar.icon,
+          color,
+          entities: configuredEntities,
+          isHidden,
+          type: 'virtual'
+        });
+      }
+      insertedVirtualIds.add(virtualCalendar.id);
+      return;
+    }
+
+    if (virtualCalendar || hiddenBadgeCalendars.has(entityId)) return;
+    const color = getCalendarColor(entityId, originalIndex);
+    items.push({
+      id: entityId,
+      entityId,
+      name: getCalendarName(entityId),
+      icon: getCalendarBadgeIcon(entityId),
+      color,
+      entities: [entityId],
+      isHidden: hiddenCalendars.has(entityId),
+      type: 'entity'
+    });
+  });
+
+  return items;
+}
+
+export function getWritableCalendars(entities = [], calendarCapabilities = {}) {
+  return entities.filter(entityId => {
+    const caps = calendarCapabilities[entityId];
+    return caps && caps.canCreate && !caps.isReadonly;
+  });
+}
+
+export function getCalendarBadgePersonEntityId(badgeEntityId, calendarPersonEntities = {}) {
+  const mappings = calendarPersonEntities || {};
+  if (!badgeEntityId) return null;
+
+  if (mappings[badgeEntityId]) {
+    return mappings[badgeEntityId];
+  }
+
+  if (badgeEntityId.startsWith('virtual:')) {
+    const virtualId = badgeEntityId.replace('virtual:', '');
+    return mappings[virtualId] || null;
+  }
+
+  return null;
+}

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -135,6 +135,17 @@ import {
   getAgendaVisibleDateRange,
   isAgendaRangeWithinWindow
 } from './views/agenda-view-model.js';
+import {
+  getCalendarBadgePersonEntityId as getCalendarBadgePersonEntityIdHelper,
+  getCalendarColor as getCalendarColorHelper,
+  getCalendarName as getCalendarNameHelper,
+  getVirtualBadgeById as getVirtualBadgeByIdHelper,
+  getVirtualBadgeForEntity as getVirtualBadgeForEntityHelper,
+  getVirtualBadgeForEvent as getVirtualBadgeForEventHelper,
+  getVirtualBadgeItems as getVirtualBadgeItemsHelper,
+  getWritableCalendars as getWritableCalendarsHelper,
+  normalizeVirtualCalendars as normalizeVirtualCalendarsHelper
+} from './calendars/calendar-entities.js';
 
 const DAYLIGHT_CALENDAR_CARD_VERSION = 'v4.5.0';
 
@@ -1626,105 +1637,37 @@ class SkylightCalendarCard extends HTMLElement {
 
 
   normalizeVirtualCalendars(virtualCalendars) {
-    if (!Array.isArray(virtualCalendars)) return [];
-
-    return virtualCalendars
-      .map((entry, index) => {
-        if (!entry || typeof entry !== 'object') return null;
-        const id = typeof entry.id === 'string' && entry.id.trim()
-          ? entry.id.trim()
-          : `virtual_${index + 1}`;
-        const entities = Array.isArray(entry.entities)
-          ? Array.from(new Set(entry.entities
-            .map((entityId) => typeof entityId === 'string' ? entityId.trim() : '')
-            .filter(Boolean)))
-          : [];
-        if (entities.length === 0) return null;
-        return {
-          id,
-          name: typeof entry.name === 'string' && entry.name.trim() ? entry.name.trim() : id,
-          icon: typeof entry.icon === 'string' && entry.icon.trim() ? entry.icon.trim() : null,
-          color: this.normalizeSingleColor(entry.color),
-          entities
-        };
-      })
-      .filter(Boolean);
+    return normalizeVirtualCalendarsHelper(virtualCalendars, {
+      normalizeSingleColor: this.normalizeSingleColor.bind(this)
+    });
   }
 
   getVirtualBadgeById(virtualId) {
-    return (this._config.virtual_calendars || []).find((virtualCalendar) => virtualCalendar.id === virtualId) || null;
+    return getVirtualBadgeByIdHelper(this._config.virtual_calendars || [], virtualId);
   }
 
   getVirtualBadgeForEntity(entityId) {
-    return (this._config.virtual_calendars || []).find((virtualCalendar) => virtualCalendar.entities.includes(entityId)) || null;
+    return getVirtualBadgeForEntityHelper(this._config.virtual_calendars || [], entityId);
   }
 
   getVirtualBadgeForEvent(event) {
-    if (!event) return null;
-
-    if (event.isCombinedCalendarEvent && Array.isArray(event.sourceEntityIds) && event.sourceEntityIds.length > 0) {
-      const virtualCalendars = event.sourceEntityIds
-        .map((entityId) => this.getVirtualBadgeForEntity(entityId))
-        .filter(Boolean);
-      if (virtualCalendars.length > 0) {
-        return virtualCalendars[0];
-      }
-      return null;
-    }
-
-    return this.getVirtualBadgeForEntity(event.entityId);
+    return getVirtualBadgeForEventHelper(this._config.virtual_calendars || [], event);
   }
 
   getVirtualBadgeItems() {
-    const hiddenBadgeCalendars = new Set(this._config.hide_badge_calendars || []);
-    const items = [];
-    const insertedVirtualIds = new Set();
-
-    this._config.entities.forEach((entityId, originalIndex) => {
-      const virtualCalendar = this.getVirtualBadgeForEntity(entityId);
-      if (virtualCalendar && !insertedVirtualIds.has(virtualCalendar.id)) {
-        const configuredEntities = virtualCalendar.entities.filter((configuredEntityId) => this._config.entities.includes(configuredEntityId));
-        const hasVisibleEntity = configuredEntities.some((configuredEntityId) => !hiddenBadgeCalendars.has(configuredEntityId));
-        if (hasVisibleEntity) {
-          const color = virtualCalendar.color || this.getCalendarColor(entityId, originalIndex);
-          const isHidden = configuredEntities.every((configuredEntityId) => this._hiddenCalendars.has(configuredEntityId));
-          items.push({
-            id: virtualCalendar.id,
-            entityId: `virtual:${virtualCalendar.id}`,
-            name: virtualCalendar.name,
-            icon: virtualCalendar.icon,
-            color,
-            entities: configuredEntities,
-            isHidden,
-            type: 'virtual'
-          });
-        }
-        insertedVirtualIds.add(virtualCalendar.id);
-        return;
-      }
-
-      if (virtualCalendar || hiddenBadgeCalendars.has(entityId)) return;
-      const color = this.getCalendarColor(entityId, originalIndex);
-      items.push({
-        id: entityId,
-        entityId,
-        name: this.getCalendarName(entityId),
-        icon: this.getCalendarBadgeIcon(entityId),
-        color,
-        entities: [entityId],
-        isHidden: this._hiddenCalendars.has(entityId),
-        type: 'entity'
-      });
+    return getVirtualBadgeItemsHelper({
+      entities: this._config.entities,
+      virtualCalendars: this._config.virtual_calendars || [],
+      hideBadgeCalendars: this._config.hide_badge_calendars || [],
+      hiddenCalendars: this._hiddenCalendars,
+      getCalendarColor: this.getCalendarColor.bind(this),
+      getCalendarName: this.getCalendarName.bind(this),
+      getCalendarBadgeIcon: this.getCalendarBadgeIcon.bind(this)
     });
-
-    return items;
   }
 
   getWritableCalendars() {
-    return this._config.entities.filter(entityId => {
-      const caps = this._calendarCapabilities[entityId];
-      return caps && caps.canCreate && !caps.isReadonly;
-    });
+    return getWritableCalendarsHelper(this._config.entities, this._calendarCapabilities);
   }
 
   getEventIdentityKey(entityId, event) {
@@ -1751,10 +1694,11 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getCalendarColor(entityId, index = 0) {
-    return this.normalizeSingleColor(
-      this._config?.colors?.[entityId] ||
-      this.getDefaultColor(index)
-    );
+    return getCalendarColorHelper(entityId, index, {
+      colors: this._config?.colors || {},
+      getDefaultColor: this.getDefaultColor.bind(this),
+      normalizeSingleColor: this.normalizeSingleColor.bind(this)
+    });
   }
 
   async fetchEventsForCalendar(entityId, colorIndex, chunks) {
@@ -10270,28 +10214,11 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getCalendarName(entityId) {
-    if (!entityId) {
-      return '';
-    }
-
-    if (entityId.startsWith('virtual:')) {
-      const virtualId = entityId.replace('virtual:', '');
-      const virtualBadge = this.getVirtualBadgeById(virtualId);
-      if (virtualBadge?.name) {
-        return virtualBadge.name;
-      }
-      return virtualId;
-    }
-
-    // Check if there's a custom name mapping
-    if (this._config.calendar_names && this._config.calendar_names[entityId]) {
-      return this._config.calendar_names[entityId];
-    }
-
-    // Otherwise use friendly_name from entity or entity ID
-    const entity = this._hass?.states[entityId];
-    const fallbackName = entityId.includes('.') ? entityId.split('.').slice(1).join('.') : entityId;
-    return entity?.attributes?.friendly_name || fallbackName;
+    return getCalendarNameHelper(entityId, {
+      calendarNames: this._config.calendar_names || {},
+      hassStates: this._hass?.states || {},
+      virtualCalendars: this._config.virtual_calendars || []
+    });
   }
 
   getCalendarBadgeIcon(entityId) {
@@ -10305,19 +10232,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getCalendarBadgePersonEntityId(badgeEntityId) {
-    const mappings = this._config?.calendar_person_entities || {};
-    if (!badgeEntityId) return null;
-
-    if (mappings[badgeEntityId]) {
-      return mappings[badgeEntityId];
-    }
-
-    if (badgeEntityId.startsWith('virtual:')) {
-      const virtualId = badgeEntityId.replace('virtual:', '');
-      return mappings[virtualId] || null;
-    }
-
-    return null;
+    return getCalendarBadgePersonEntityIdHelper(badgeEntityId, this._config?.calendar_person_entities || {});
   }
 
   getCalendarBadgePersonState(badgeEntityId) {


### PR DESCRIPTION
### Motivation
- Continue Phase 12 of the modularization work by extracting pure calendar/entity metadata helpers out of the main card file to a dedicated module without changing runtime or rendering behavior.
- Reduce the responsibility of `src/skylight-calendar-card.js` by moving data-only logic to a new `src/calendars/calendar-entities.js` module while keeping DOM/rendering logic in the main card.

### Description
- Added `src/calendars/calendar-entities.js` with non-rendering helpers: `normalizeVirtualCalendars`, `getVirtualBadgeById`, `getVirtualBadgeForEntity`, `getVirtualBadgeForEvent`, `getCalendarColor`, `getCalendarName`, `getVirtualBadgeItems`, `getWritableCalendars`, and `getCalendarBadgePersonEntityId`.
- Updated `src/skylight-calendar-card.js` to import the new helpers and delegate existing card-level wrapper methods to the new module while keeping original call sites and binding explicit inputs (no whole-card instance passed into helpers).
- Left all rendering- and DOM-related logic in the main card unchanged, specifically preserving `renderCalendarBadges()`, `renderCalendarBadgesInline()`, `renderCalendarBadgeIcon()`, `renderCalendarBadgeLabel()`, badge DOM structure, click handlers, hidden-calendar Set mutation, preference persistence, CSS, translations, custom element names, and `DAYLIGHT_CALENDAR_CARD_VERSION`.
- Added a focused unit test in `skylight-calendar-card.test.js` covering name fallback/override, color fallback, virtual badge item preparation, hidden/visible filtering, writable-calendars detection, and `calendar_person_entities` mapping behavior.

### Testing
- Ran `npm ci --no-audit --fund=false` and `npm run build` successfully and regenerated the root shipped artifact `skylight-calendar-card.js` which was committed with the source change.
- Verified syntax with `node --check src/skylight-calendar-card.js`, `node --check src/calendars/calendar-entities.js`, and `node --check skylight-calendar-card.js` (all passed).
- Ran unit tests with `npm test` (229 tests passed) and visual tests with `npm run test:visual` (39 Playwright snapshots passed).
- Confirmed working tree was clean for `skylight-calendar-card.js` after the Rollup build and commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b5b7dfb6c8331b911ed01298c6f44)