### PR TITLE
Phase 14 modularization checkpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,13 +31,25 @@ The project was formerly named Skylight Calendar Card. The public name is now Da
 
 Current modules are organized around these boundaries. Future modules may be added, but new modules should preserve the same separation principles and keep card-instance orchestration separate from pure/data-only helpers.
 
-* `src/skylight-calendar-card.js`: main custom element, lifecycle, orchestration, rendering, DOM, CSS, Home Assistant integration glue.
+* `src/skylight-calendar-card.js`: main custom element, lifecycle, Home Assistant orchestration, rendering/templates, DOM measurement, scroll restoration, CSS, modal/editor DOM behavior, and event handlers.
 * `src/translations.js`: translation data.
 * `src/constants.js`: shared static constants.
 * `src/defaults.js`: default config values, option lists, aliases, and stub config creation.
-* `src/utils/`: pure utility helpers.
-* `src/events/`: event data normalization and event-related non-rendering helpers.
-* `src/rules/`: rule normalization and condition matching helpers.
+* `src/utils/`: pure utility helpers for dates, normalization, and strings.
+* `src/events/event-normalizer.js`: Home Assistant calendar event normalization and combined-event data shaping.
+* `src/events/event-form.js`: event form validation and create/update data normalization.
+* `src/events/event-service.js`: Home Assistant calendar event service and WebSocket payload helpers.
+* `src/events/event-display.js`: non-rendering event display decisions and display metadata.
+* `src/rules/condition-matcher.js`: condition and value matching helpers.
+* `src/rules/style-rules.js`: style rule normalization and matching helpers.
+* `src/badges/day-badges.js`: day badge normalization, matching, and display data helpers.
+* `src/weather/weather-utils.js`: weather formatting, icon, temperature, and forecast utility helpers.
+* `src/weather/weather-service.js`: weather entity discovery and Home Assistant weather service payload helpers.
+* `src/editor/editor-schema.js`: editor default values, option metadata, and config normalization helpers.
+* `src/views/month-view-model.js`: month-grid date and visible-range view-model helpers.
+* `src/views/week-view-model.js`: week and rolling-days view-model helpers.
+* `src/views/agenda-view-model.js`: agenda visible-range and rolling-days view-model helpers.
+* `src/calendars/calendar-entities.js`: calendar entity metadata, colors, names, virtual calendar badges, writable calendars, and person mappings.
 
 ## Modularization guardrails
 

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -1276,6 +1276,26 @@ test('calendar entity helpers resolve names, colors, visibility, virtual badges,
   assert.equal(getCalendarBadgePersonEntityId('virtual:family_group', { family_group: 'person.family' }), 'person.family');
 });
 
+test('calendar entity helpers resolve virtual badges for combined events', async () => {
+  const {
+    getVirtualBadgeForEvent,
+    normalizeVirtualCalendars
+  } = await import('./src/calendars/calendar-entities.js');
+  const virtualCalendars = normalizeVirtualCalendars([
+    { id: 'family_group', name: 'Family Group', entities: ['calendar.family', 'calendar.school'] },
+    { id: 'work_group', name: 'Work Group', entities: ['calendar.work'] }
+  ], { normalizeSingleColor: (value) => value || null });
+
+  assert.equal(getVirtualBadgeForEvent(virtualCalendars, {
+    isCombinedCalendarEvent: true,
+    sourceEntityIds: ['calendar.school', 'calendar.family']
+  })?.id, 'family_group');
+  assert.equal(getVirtualBadgeForEvent(virtualCalendars, {
+    isCombinedCalendarEvent: true,
+    sourceEntityIds: ['calendar.unknown']
+  }), null);
+});
+
 test('preference_storage_key customizes persisted preference storage key', () => {
   const originalLocation = window.location;
   window.location = { pathname: '/lovelace-family/0', hash: '' };
@@ -4431,6 +4451,41 @@ test('event display helpers preserve title time location and style data decision
     translate: (key, params) => key === 'untitledEvent' ? 'Untitled event' : `${params.title}, ${params.time}`
   });
   assert.equal(scheduleInfo.displayTitle, 'Untitled event, 10:00 PM');
+});
+
+test('event display helper detects combined events inside one visible virtual calendar', async () => {
+  const { isCombinedEventWithinSingleVirtualCalendar } = await import('./src/events/event-display.js');
+  const event = {
+    isCombinedCalendarEvent: true,
+    sourceEvents: [
+      { entityId: 'calendar.family' },
+      { entityId: 'calendar.school' }
+    ]
+  };
+  const getVirtualBadgeForEntity = (entityId) => ['calendar.family', 'calendar.school'].includes(entityId)
+    ? { id: 'family_group' }
+    : null;
+
+  assert.equal(isCombinedEventWithinSingleVirtualCalendar(event, { getVirtualBadgeForEntity }), true);
+  assert.equal(isCombinedEventWithinSingleVirtualCalendar(event, {
+    hiddenCalendars: new Set(['calendar.school']),
+    getVirtualBadgeForEntity
+  }), false);
+  assert.equal(isCombinedEventWithinSingleVirtualCalendar({
+    ...event,
+    sourceEvents: [{ entityId: 'calendar.family' }, { entityId: 'calendar.work' }]
+  }, {
+    getVirtualBadgeForEntity: (entityId) => entityId === 'calendar.family' ? { id: 'family_group' } : { id: 'work_group' }
+  }), false);
+});
+
+test('editor schema normalizes default view aliases for editor controls', async () => {
+  const { normalizeDefaultViewForEditor } = await import('./src/editor/editor-schema.js');
+
+  assert.equal(normalizeDefaultViewForEditor('week'), 'week-compact');
+  assert.equal(normalizeDefaultViewForEditor('schedule'), 'week-standard');
+  assert.equal(normalizeDefaultViewForEditor('agenda'), 'agenda');
+  assert.equal(normalizeDefaultViewForEditor(''), 'month');
 });
 
 test('event form helper preserves validation message keys and normalized data', async () => {

--- a/src/README.md
+++ b/src/README.md
@@ -1,16 +1,48 @@
-# Source map
+# Source module map
 
-`src/skylight-calendar-card.js` is the Rollup entry point and the main custom element source for Daylight Calendar Card. It owns card-instance orchestration, Home Assistant integration glue, lifecycle methods, rendering, DOM updates, CSS, modals, and editor behavior.
+`src/` is the authored source of truth for Daylight Calendar Card. The root `skylight-calendar-card.js` file is the generated Rollup bundle used for HACS and manual installs; it must be committed when build output changes, but it should not be edited as the source of truth. Make source changes in `src/`, then run `npm run build` to regenerate the root artifact.
 
-The root `skylight-calendar-card.js` file is generated from `src/skylight-calendar-card.js` and committed as the HACS/manual-install artifact. Run `npm run build` to regenerate it, then verify it is current with `git diff --exit-code -- skylight-calendar-card.js`.
+## Main custom element
 
-Current source module groups:
+`src/skylight-calendar-card.js` remains the Rollup entry point and main custom element source. It still owns the card-instance responsibilities that have not been extracted:
 
-- `translations.js`: translation data.
-- `constants.js`: shared static constants.
-- `defaults.js`: default config values, option lists, aliases, and stub config creation.
-- `utils/`: pure utility helpers.
-- `events/`: event normalization and event-related non-rendering helpers.
-- `rules/`: rule normalization and condition matching helpers.
+- custom element lifecycle
+- Home Assistant integration and orchestration
+- rendering methods, Lit/HTML templates, and view composition
+- CSS
+- DOM measurement
+- scroll restoration
+- modal and editor DOM behavior
+- event handlers
 
-Future modules may be added as the card evolves. Keep runtime rendering, CSS, DOM structure, lifecycle, modal, editor, and service orchestration in `src/skylight-calendar-card.js` unless a change is explicitly scoped to move that area.
+Do not move renderers, CSS, DOM structure, modal/editor rendering, or service orchestration unless a change is explicitly scoped to do that work.
+
+## Extracted module areas
+
+The current post-Phase 13 module layout keeps pure/data-only helpers outside the main custom element while leaving rendering in `src/skylight-calendar-card.js`:
+
+- `constants.js`: shared static constants used across source modules and the card.
+- `defaults.js`: default config values, option lists, config aliases, and stub config creation.
+- `translations.js`: translation strings and locale data.
+- `utils/`: pure utility helpers for dates, normalization, and strings.
+- `events/event-normalizer.js`: Home Assistant calendar event normalization and combined-event data shaping.
+- `events/event-form.js`: event form validation and create/update data normalization.
+- `events/event-service.js`: Home Assistant calendar event service and WebSocket payload helpers.
+- `events/event-display.js`: non-rendering event display decisions, including time/location visibility, badge data, and schedule visual metadata.
+- `rules/condition-matcher.js`: condition and value matching helpers for rule evaluation.
+- `rules/style-rules.js`: style rule normalization and matching helpers.
+- `badges/day-badges.js`: day badge normalization, matching, and display data helpers.
+- `weather/weather-utils.js`: weather formatting, icon, temperature, and forecast utility helpers.
+- `weather/weather-service.js`: weather entity discovery and Home Assistant weather service payload helpers.
+- `editor/editor-schema.js`: editor default values, option metadata, and config normalization helpers for the editor.
+- `views/month-view-model.js`: month-grid date and visible-range view-model helpers.
+- `views/week-view-model.js`: week and rolling-days view-model helpers.
+- `views/agenda-view-model.js`: agenda visible-range and rolling-days view-model helpers.
+- `calendars/calendar-entities.js`: calendar entity metadata, colors, names, virtual calendar badges, writable calendars, and person mappings.
+
+## Guardrails for future phases
+
+- Prefer direct module tests for extracted pure/data helpers before moving any renderer code.
+- Keep helpers explicit: pass inputs and callbacks instead of importing or depending on the card instance.
+- Preserve public config option names, custom element names, CSS class names, DOM structure, translations, and visual behavior unless a prompt explicitly requests a behavior change.
+- Preserve both `daylight-calendar-card` and legacy `skylight-calendar-card` compatibility.


### PR DESCRIPTION
### Motivation
- Provide a post-extraction checkpoint after Phases 10–13 to document the current module layout and ownership boundaries before renderer extraction begins. 
- Improve test coverage in thin, low-risk areas of the newly extracted modules to reduce future refactoring risk. 
- Make only safe, minimal cleanup and documentation changes without touching renderers, CSS, DOM, or runtime behavior.

### Description
- Added a `src/` module map in `src/README.md` that documents post-Phase 13 modules and clearly states that `src/skylight-calendar-card.js` still owns lifecycle, Home Assistant orchestration, rendering/templates, CSS, DOM measurement, scroll restoration, modal/editor DOM behavior, and event handlers. 
- Updated `AGENTS.md` to align module-boundary guidance with the current extracted modules (event, rules, badges, weather, editor, view-models, calendar metadata, utils, defaults, translations). 
- Added low-risk unit tests in `skylight-calendar-card.test.js` for `getVirtualBadgeForEvent` (virtual badge resolution for combined events), `isCombinedEventWithinSingleVirtualCalendar` (combined-event detection within a single virtual calendar), and `normalizeDefaultViewForEditor` (editor default-view alias normalization). 
- Made no renderer extractions, no CSS/DOM changes, no public API/config renames, and no behavioral changes; no safe-cleanup removals were necessary.

### Testing
- Ran `npm ci --no-audit --fund=false` and `npm run build`; Rollup completed and regenerated `skylight-calendar-card.js` during the build. 
- Verified the generated artifact was current with `git diff --exit-code -- skylight-calendar-card.js` (no artifact changes committed beyond the build check). 
- Verified syntax with `node --check src/skylight-calendar-card.js` and `node --check skylight-calendar-card.js`. 
- Ran unit tests with `npm test` (233 tests, all passed) and visual tests with `npm run test:visual` (39 visual tests, all passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c1fc40e6883318806ea3921eeb683)