### PR TITLE
Extract month view renderer into src/renderers/month-renderer.js

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -2937,6 +2937,108 @@ function renderAgendaView({
     `;
 }
 
+function renderMonthDayHeaders({ weekdayNames, firstDayOfWeek, shouldShowWeekNumbers }) {
+  const orderedDays = [
+    ...weekdayNames.slice(firstDayOfWeek),
+    ...weekdayNames.slice(0, firstDayOfWeek)
+  ];
+
+  const dayHeaders = orderedDays.map(day => `
+      <div class="day-header">${day}</div>
+    `).join('');
+
+  if (!shouldShowWeekNumbers) {
+    return dayHeaders;
+  }
+
+  return `<div class="month-week-number-header"></div>${dayHeaders}`;
+}
+
+function renderMonthGridDays({ currentDate, firstDayOfWeek, shouldShowWeekNumbers, helpers }) {
+  let html = '';
+
+  getMonthGridDates(currentDate, firstDayOfWeek).forEach((dayEntry, dayIndex) => {
+    if (shouldShowWeekNumbers && dayIndex % 7 === 0) {
+      html += helpers.renderMonthWeekNumberCell(dayEntry.date);
+    }
+    html += helpers.renderDay(dayEntry.day, dayEntry.date, dayEntry.isOtherMonth);
+  });
+
+  return html;
+}
+
+function renderRollingWeeks({ currentDate, firstDayOfWeek, rollingWeeks, shouldShowWeekNumbers, helpers }) {
+  let html = '';
+
+  getRollingMonthGridDates(currentDate, firstDayOfWeek, rollingWeeks).forEach((dayEntry, dayIndex) => {
+    if (shouldShowWeekNumbers && dayIndex % 7 === 0) {
+      html += helpers.renderMonthWeekNumberCell(dayEntry.date);
+    }
+
+    html += helpers.renderDay(dayEntry.day, dayEntry.date, dayEntry.isOtherMonth);
+  });
+
+  return html;
+}
+
+function renderMonthDays({ currentDate, config, viewMode, shouldShowWeekNumbers, helpers }) {
+  // If rolling_weeks is set, show current week + N additional weeks
+  if (config.rolling_weeks !== null && viewMode === 'month') {
+    return renderRollingWeeks({
+      currentDate,
+      firstDayOfWeek: config.firstDayOfWeek,
+      rollingWeeks: config.rolling_weeks,
+      shouldShowWeekNumbers,
+      helpers
+    });
+  }
+
+  return renderMonthGridDays({
+    currentDate,
+    firstDayOfWeek: config.firstDayOfWeek,
+    shouldShowWeekNumbers,
+    helpers
+  });
+}
+
+function renderMonthView({
+  compactMaxHeight,
+  config,
+  currentDate,
+  isCompactMonth,
+  monthWeekRows,
+  shouldShowHeaderBadges,
+  shouldShowWeekNumbers,
+  viewMode,
+  weekdayNames,
+  helpers
+}) {
+  const monthStyle = isCompactMonth ? helpers.getCompactMonthGridStyle(monthWeekRows, compactMaxHeight) : '';
+  const monthClass = [
+    'calendar-grid',
+    isCompactMonth ? 'compact-month' : '',
+    shouldShowWeekNumbers ? 'month-week-numbers' : ''
+  ].filter(Boolean).join(' ');
+
+  return `
+        ${shouldShowHeaderBadges ? helpers.renderCalendarBadges() : ''}
+        <div class="${monthClass}" style="${monthStyle}">
+          ${renderMonthDayHeaders({
+            weekdayNames,
+            firstDayOfWeek: config.firstDayOfWeek,
+            shouldShowWeekNumbers
+          })}
+          ${renderMonthDays({
+            currentDate,
+            config,
+            viewMode,
+            shouldShowWeekNumbers,
+            helpers
+          })}
+        </div>
+      `;
+}
+
 function normalizeVirtualCalendars(virtualCalendars, { normalizeSingleColor }) {
   if (!Array.isArray(virtualCalendars)) return [];
 
@@ -8799,20 +8901,23 @@ class SkylightCalendarCard extends HTMLElement {
       const compactMaxHeight = isCompactMonth && !this.hasFixedHeightParentAllocation() ? this.getCompactMaxHeight(this._monthContainerTopInViewport) : null;
       const monthWeekRows = this.getMonthWeekRowCount();
       const showMonthWeekNumbers = this.shouldShowMonthWeekNumbers();
-      const monthStyle = isCompactMonth ? this.getCompactMonthGridStyle(monthWeekRows, compactMaxHeight) : '';
-      const monthClass = [
-        'calendar-grid',
-        isCompactMonth ? 'compact-month' : '',
-        showMonthWeekNumbers ? 'month-week-numbers' : ''
-      ].filter(Boolean).join(' ');
-
-      return `
-        ${shouldShowHeaderBadges ? this.renderCalendarBadges() : ''}
-        <div class="${monthClass}" style="${monthStyle}">
-          ${this.renderDayHeaders()}
-          ${this.renderDays()}
-        </div>
-      `;
+      return renderMonthView({
+        compactMaxHeight,
+        config: this._config,
+        currentDate: this._currentDate,
+        isCompactMonth,
+        monthWeekRows,
+        shouldShowHeaderBadges,
+        shouldShowWeekNumbers: showMonthWeekNumbers,
+        viewMode: this._viewMode,
+        weekdayNames: this.getWeekdayNames(),
+        helpers: {
+          getCompactMonthGridStyle: (weekRows, maxHeight) => this.getCompactMonthGridStyle(weekRows, maxHeight),
+          renderCalendarBadges: () => this.renderCalendarBadges(),
+          renderDay: (day, date, isOtherMonth) => this.renderDay(day, date, isOtherMonth),
+          renderMonthWeekNumberCell: (rowStartDate) => this.renderMonthWeekNumberCell(rowStartDate)
+        }
+      });
     } else if (this._viewMode === 'week-compact') {
       return this.renderWeekCompact();
     } else if (this._viewMode === 'week-standard') {
@@ -8823,20 +8928,11 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   renderDayHeaders() {
-    const days = this.getWeekdayNames();
-    const firstDay = this._config.firstDayOfWeek;
-    const orderedDays = [...days.slice(firstDay), ...days.slice(0, firstDay)];
-    const shouldShowWeekNumbers = this.shouldShowMonthWeekNumbers();
-
-    const dayHeaders = orderedDays.map(day => `
-      <div class="day-header">${day}</div>
-    `).join('');
-
-    if (!shouldShowWeekNumbers) {
-      return dayHeaders;
-    }
-
-    return `<div class="month-week-number-header"></div>${dayHeaders}`;
+    return renderMonthDayHeaders({
+      weekdayNames: this.getWeekdayNames(),
+      firstDayOfWeek: this._config.firstDayOfWeek,
+      shouldShowWeekNumbers: this.shouldShowMonthWeekNumbers()
+    });
   }
 
   renderWeekCompact() {
@@ -9790,37 +9886,16 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   renderDays() {
-    // If rolling_weeks is set, show current week + N additional weeks
-    if (this._config.rolling_weeks !== null && this._viewMode === 'month') {
-      return this.renderRollingWeeks();
-    }
-
-    const shouldShowWeekNumbers = this.shouldShowMonthWeekNumbers();
-    let html = '';
-
-    getMonthGridDates(this._currentDate, this._config.firstDayOfWeek).forEach((dayEntry, dayIndex) => {
-      if (shouldShowWeekNumbers && dayIndex % 7 === 0) {
-        html += this.renderMonthWeekNumberCell(dayEntry.date);
+    return renderMonthDays({
+      currentDate: this._currentDate,
+      config: this._config,
+      viewMode: this._viewMode,
+      shouldShowWeekNumbers: this.shouldShowMonthWeekNumbers(),
+      helpers: {
+        renderDay: (day, date, isOtherMonth) => this.renderDay(day, date, isOtherMonth),
+        renderMonthWeekNumberCell: (rowStartDate) => this.renderMonthWeekNumberCell(rowStartDate)
       }
-      html += this.renderDay(dayEntry.day, dayEntry.date, dayEntry.isOtherMonth);
     });
-
-    return html;
-  }
-
-  renderRollingWeeks() {
-    const shouldShowWeekNumbers = this.shouldShowMonthWeekNumbers();
-    let html = '';
-
-    getRollingMonthGridDates(this._currentDate, this._config.firstDayOfWeek, this._config.rolling_weeks).forEach((dayEntry, dayIndex) => {
-      if (shouldShowWeekNumbers && dayIndex % 7 === 0) {
-        html += this.renderMonthWeekNumberCell(dayEntry.date);
-      }
-
-      html += this.renderDay(dayEntry.day, dayEntry.date, dayEntry.isOtherMonth);
-    });
-
-    return html;
   }
 
   getMaxVisibleEventsForMonthDay() {

--- a/src/renderers/month-renderer.js
+++ b/src/renderers/month-renderer.js
@@ -1,0 +1,106 @@
+import {
+  getMonthGridDates,
+  getRollingMonthGridDates
+} from '../views/month-view-model.js';
+
+export function renderMonthDayHeaders({ weekdayNames, firstDayOfWeek, shouldShowWeekNumbers }) {
+  const orderedDays = [
+    ...weekdayNames.slice(firstDayOfWeek),
+    ...weekdayNames.slice(0, firstDayOfWeek)
+  ];
+
+  const dayHeaders = orderedDays.map(day => `
+      <div class="day-header">${day}</div>
+    `).join('');
+
+  if (!shouldShowWeekNumbers) {
+    return dayHeaders;
+  }
+
+  return `<div class="month-week-number-header"></div>${dayHeaders}`;
+}
+
+function renderMonthGridDays({ currentDate, firstDayOfWeek, shouldShowWeekNumbers, helpers }) {
+  let html = '';
+
+  getMonthGridDates(currentDate, firstDayOfWeek).forEach((dayEntry, dayIndex) => {
+    if (shouldShowWeekNumbers && dayIndex % 7 === 0) {
+      html += helpers.renderMonthWeekNumberCell(dayEntry.date);
+    }
+    html += helpers.renderDay(dayEntry.day, dayEntry.date, dayEntry.isOtherMonth);
+  });
+
+  return html;
+}
+
+function renderRollingWeeks({ currentDate, firstDayOfWeek, rollingWeeks, shouldShowWeekNumbers, helpers }) {
+  let html = '';
+
+  getRollingMonthGridDates(currentDate, firstDayOfWeek, rollingWeeks).forEach((dayEntry, dayIndex) => {
+    if (shouldShowWeekNumbers && dayIndex % 7 === 0) {
+      html += helpers.renderMonthWeekNumberCell(dayEntry.date);
+    }
+
+    html += helpers.renderDay(dayEntry.day, dayEntry.date, dayEntry.isOtherMonth);
+  });
+
+  return html;
+}
+
+export function renderMonthDays({ currentDate, config, viewMode, shouldShowWeekNumbers, helpers }) {
+  // If rolling_weeks is set, show current week + N additional weeks
+  if (config.rolling_weeks !== null && viewMode === 'month') {
+    return renderRollingWeeks({
+      currentDate,
+      firstDayOfWeek: config.firstDayOfWeek,
+      rollingWeeks: config.rolling_weeks,
+      shouldShowWeekNumbers,
+      helpers
+    });
+  }
+
+  return renderMonthGridDays({
+    currentDate,
+    firstDayOfWeek: config.firstDayOfWeek,
+    shouldShowWeekNumbers,
+    helpers
+  });
+}
+
+export function renderMonthView({
+  compactMaxHeight,
+  config,
+  currentDate,
+  isCompactMonth,
+  monthWeekRows,
+  shouldShowHeaderBadges,
+  shouldShowWeekNumbers,
+  viewMode,
+  weekdayNames,
+  helpers
+}) {
+  const monthStyle = isCompactMonth ? helpers.getCompactMonthGridStyle(monthWeekRows, compactMaxHeight) : '';
+  const monthClass = [
+    'calendar-grid',
+    isCompactMonth ? 'compact-month' : '',
+    shouldShowWeekNumbers ? 'month-week-numbers' : ''
+  ].filter(Boolean).join(' ');
+
+  return `
+        ${shouldShowHeaderBadges ? helpers.renderCalendarBadges() : ''}
+        <div class="${monthClass}" style="${monthStyle}">
+          ${renderMonthDayHeaders({
+            weekdayNames,
+            firstDayOfWeek: config.firstDayOfWeek,
+            shouldShowWeekNumbers
+          })}
+          ${renderMonthDays({
+            currentDate,
+            config,
+            viewMode,
+            shouldShowWeekNumbers,
+            helpers
+          })}
+        </div>
+      `;
+}

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -128,11 +128,7 @@ import {
   shouldShowEventLocation as shouldShowEventLocationHelper,
   shouldShowEventTime as shouldShowEventTimeHelper
 } from './events/event-display.js';
-import {
-  getMonthGridDates,
-  getMonthVisibleDateRange,
-  getRollingMonthGridDates
-} from './views/month-view-model.js';
+import { getMonthVisibleDateRange } from './views/month-view-model.js';
 import {
   getRollingDaysForView as getRollingDaysForViewModel,
   getWeekDays as getWeekDaysViewModel,
@@ -147,6 +143,11 @@ import {
   isAgendaRangeWithinWindow
 } from './views/agenda-view-model.js';
 import { renderAgendaView } from './renderers/agenda-renderer.js';
+import {
+  renderMonthDayHeaders,
+  renderMonthDays,
+  renderMonthView
+} from './renderers/month-renderer.js';
 import {
   getCalendarBadgePersonEntityId as getCalendarBadgePersonEntityIdHelper,
   getCalendarColor as getCalendarColorHelper,
@@ -5863,20 +5864,23 @@ class SkylightCalendarCard extends HTMLElement {
       const compactMaxHeight = isCompactMonth && !this.hasFixedHeightParentAllocation() ? this.getCompactMaxHeight(this._monthContainerTopInViewport) : null;
       const monthWeekRows = this.getMonthWeekRowCount();
       const showMonthWeekNumbers = this.shouldShowMonthWeekNumbers();
-      const monthStyle = isCompactMonth ? this.getCompactMonthGridStyle(monthWeekRows, compactMaxHeight) : '';
-      const monthClass = [
-        'calendar-grid',
-        isCompactMonth ? 'compact-month' : '',
-        showMonthWeekNumbers ? 'month-week-numbers' : ''
-      ].filter(Boolean).join(' ');
-
-      return `
-        ${shouldShowHeaderBadges ? this.renderCalendarBadges() : ''}
-        <div class="${monthClass}" style="${monthStyle}">
-          ${this.renderDayHeaders()}
-          ${this.renderDays()}
-        </div>
-      `;
+      return renderMonthView({
+        compactMaxHeight,
+        config: this._config,
+        currentDate: this._currentDate,
+        isCompactMonth,
+        monthWeekRows,
+        shouldShowHeaderBadges,
+        shouldShowWeekNumbers: showMonthWeekNumbers,
+        viewMode: this._viewMode,
+        weekdayNames: this.getWeekdayNames(),
+        helpers: {
+          getCompactMonthGridStyle: (weekRows, maxHeight) => this.getCompactMonthGridStyle(weekRows, maxHeight),
+          renderCalendarBadges: () => this.renderCalendarBadges(),
+          renderDay: (day, date, isOtherMonth) => this.renderDay(day, date, isOtherMonth),
+          renderMonthWeekNumberCell: (rowStartDate) => this.renderMonthWeekNumberCell(rowStartDate)
+        }
+      });
     } else if (this._viewMode === 'week-compact') {
       return this.renderWeekCompact();
     } else if (this._viewMode === 'week-standard') {
@@ -5887,20 +5891,11 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   renderDayHeaders() {
-    const days = this.getWeekdayNames();
-    const firstDay = this._config.firstDayOfWeek;
-    const orderedDays = [...days.slice(firstDay), ...days.slice(0, firstDay)];
-    const shouldShowWeekNumbers = this.shouldShowMonthWeekNumbers();
-
-    const dayHeaders = orderedDays.map(day => `
-      <div class="day-header">${day}</div>
-    `).join('');
-
-    if (!shouldShowWeekNumbers) {
-      return dayHeaders;
-    }
-
-    return `<div class="month-week-number-header"></div>${dayHeaders}`;
+    return renderMonthDayHeaders({
+      weekdayNames: this.getWeekdayNames(),
+      firstDayOfWeek: this._config.firstDayOfWeek,
+      shouldShowWeekNumbers: this.shouldShowMonthWeekNumbers()
+    });
   }
 
   renderWeekCompact() {
@@ -6854,37 +6849,16 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   renderDays() {
-    // If rolling_weeks is set, show current week + N additional weeks
-    if (this._config.rolling_weeks !== null && this._viewMode === 'month') {
-      return this.renderRollingWeeks();
-    }
-
-    const shouldShowWeekNumbers = this.shouldShowMonthWeekNumbers();
-    let html = '';
-
-    getMonthGridDates(this._currentDate, this._config.firstDayOfWeek).forEach((dayEntry, dayIndex) => {
-      if (shouldShowWeekNumbers && dayIndex % 7 === 0) {
-        html += this.renderMonthWeekNumberCell(dayEntry.date);
+    return renderMonthDays({
+      currentDate: this._currentDate,
+      config: this._config,
+      viewMode: this._viewMode,
+      shouldShowWeekNumbers: this.shouldShowMonthWeekNumbers(),
+      helpers: {
+        renderDay: (day, date, isOtherMonth) => this.renderDay(day, date, isOtherMonth),
+        renderMonthWeekNumberCell: (rowStartDate) => this.renderMonthWeekNumberCell(rowStartDate)
       }
-      html += this.renderDay(dayEntry.day, dayEntry.date, dayEntry.isOtherMonth);
     });
-
-    return html;
-  }
-
-  renderRollingWeeks() {
-    const shouldShowWeekNumbers = this.shouldShowMonthWeekNumbers();
-    let html = '';
-
-    getRollingMonthGridDates(this._currentDate, this._config.firstDayOfWeek, this._config.rolling_weeks).forEach((dayEntry, dayIndex) => {
-      if (shouldShowWeekNumbers && dayIndex % 7 === 0) {
-        html += this.renderMonthWeekNumberCell(dayEntry.date);
-      }
-
-      html += this.renderDay(dayEntry.day, dayEntry.date, dayEntry.isOtherMonth);
-    });
-
-    return html;
   }
 
   getMaxVisibleEventsForMonthDay() {


### PR DESCRIPTION
### Motivation
- Reduce size and responsibility of the main card by extracting month-specific HTML rendering into a focused renderer while preserving runtime and visual behavior.
- Make month rendering composable and testable by passing explicit inputs and narrow helper callbacks instead of card instance state.
- Keep month view-model/date helpers in `src/views/month-view-model.js` and avoid moving week renderers or DOM/runtime-sensitive logic.

### Description
- Added `src/renderers/month-renderer.js` which implements `renderMonthView`, `renderMonthDayHeaders`, and `renderMonthDays` (including standard month grid and `rolling_weeks` composition) and uses `getMonthGridDates` / `getRollingMonthGridDates` from `src/views/month-view-model.js`.
- Updated `src/skylight-calendar-card.js` to import `renderMonthView`, `renderMonthDayHeaders`, and `renderMonthDays` and delegate month composition to the renderer via explicit inputs and a narrow `helpers` callback object (e.g. `renderDay`, `renderMonthWeekNumberCell`, `getCompactMonthGridStyle`, `renderCalendarBadges`).
- Left shared rendering helpers and runtime-sensitive behavior in the main card (including `renderDay`, day badge/weather/event rendering, modal/click handlers, DOM measurement, compact-height behavior, CSS, lifecycle, and Home Assistant orchestration) to preserve DOM structure, CSS classes, data attributes, and event handlers.
- Did not move week renderers and did not change any class names, data attributes, public config option names, translations, custom element names, or `DAYLIGHT_CALENDAR_CARD_VERSION`.

### Testing
- Ran `npm ci --no-audit --fund=false` and `npm run build`, and Rollup regenerated the root `skylight-calendar-card.js` artifact which was committed with the source changes.
- Ran `node --check src/skylight-calendar-card.js`, `node --check src/renderers/month-renderer.js`, and `node --check skylight-calendar-card.js` with no syntax errors.
- Ran `npm test` (unit tests) with all tests passing (`233` tests passing).
- Ran `npm run test:visual` (Playwright visual tests) with all visual tests passing (39 snapshots) and no snapshot updates required.
- Verified `git diff --exit-code -- skylight-calendar-card.js` during the build process and included the regenerated artifact in the commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c34031eb88331a70abfcf5faf7aee)