### PR TITLE
Extract week-compact renderer (Phase 17)

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -2937,6 +2937,52 @@ function renderAgendaView({
     `;
 }
 
+function renderWeekCompactView({
+  config,
+  weekDays,
+  today,
+  dayNames,
+  headerHeight,
+  helpers
+}) {
+  const headerHeightStyle = headerHeight ? `--week-compact-header-height: ${headerHeight}px;` : '';
+  const containerStyle = `${headerHeightStyle}${helpers.getCompactContainerStyle()}`;
+
+  return `
+      ${!config.compact_header && !config.hide_calendars ? helpers.renderCalendarBadges() : ''}
+      <div class="week-compact-container day-badge-layout-${config.day_badge_layout_week}" style="${containerStyle}">
+        ${weekDays.map(date => {
+          const isToday = date.toDateString() === today.toDateString();
+          const dayEventsForMatching = helpers.getEventsForDay(date, { includeHiddenStyledEvents: true });
+          const events = helpers.sortEventsForDate(dayEventsForMatching.filter((event) => !helpers.isEventHiddenByStyle(event)), date);
+          const dayStyle = helpers.getDayStyleAttributes(date, dayEventsForMatching, isToday);
+          const dayStyleAttr = dayStyle.style ? ` style="${dayStyle.style}"` : '';
+
+          return `
+            <div class="week-day-column ${isToday ? 'today' : ''} ${dayStyle.className}" data-date="${date.toISOString()}" data-click-target="day-header"${dayStyleAttr}>
+              <div class="week-day-header">
+                <div class="week-day-header-main">
+                  <div class="week-day-name">${dayNames[date.getDay()]}</div>
+                  <div class="week-day-meta-row">
+                    <div class="week-day-date">${date.getDate()}</div>
+                    ${helpers.renderDayBadges(date, dayEventsForMatching)}
+                    ${helpers.renderDayForecast(date, 'week-compact')}
+                  </div>
+                </div>
+              </div>
+              <div class="week-day-events">
+                ${events.map(event => {
+                  return helpers.renderWeekCompactEvent(event, date);
+                }).join('')}
+                ${events.length === 0 ? `<div style="color: #9ca3af; font-size: 13px; text-align: center; margin-top: 20px;">${helpers.t('noEvents')}</div>` : ''}
+              </div>
+            </div>
+          `;
+        }).join('')}
+      </div>
+    `;
+}
+
 function renderMonthDayHeaders({ weekdayNames, firstDayOfWeek, shouldShowWeekNumbers }) {
   const orderedDays = [
     ...weekdayNames.slice(firstDayOfWeek),
@@ -8936,46 +8982,28 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   renderWeekCompact() {
-    const weekDays = this.getWeekDays();
     const today = new Date();
     today.setHours(0, 0, 0, 0);
-    const dayNames = this.getWeekdayNames();
-    const headerHeightStyle = this._weekCompactHeaderHeight ? `--week-compact-header-height: ${this._weekCompactHeaderHeight}px;` : '';
-    const containerStyle = `${headerHeightStyle}${this.getCompactContainerStyle()}`;
 
-    return `
-      ${!this._config.compact_header && !this._config.hide_calendars ? this.renderCalendarBadges() : ''}
-      <div class="week-compact-container day-badge-layout-${this._config.day_badge_layout_week}" style="${containerStyle}">
-        ${weekDays.map(date => {
-          const isToday = date.toDateString() === today.toDateString();
-          const dayEventsForMatching = this.getEventsForDay(date, { includeHiddenStyledEvents: true });
-          const events = this.sortEventsForDate(dayEventsForMatching.filter((event) => !this.isEventHiddenByStyle(event)), date);
-          const dayStyle = this.getDayStyleAttributes(date, dayEventsForMatching, isToday);
-          const dayStyleAttr = dayStyle.style ? ` style="${dayStyle.style}"` : '';
-
-          return `
-            <div class="week-day-column ${isToday ? 'today' : ''} ${dayStyle.className}" data-date="${date.toISOString()}" data-click-target="day-header"${dayStyleAttr}>
-              <div class="week-day-header">
-                <div class="week-day-header-main">
-                  <div class="week-day-name">${dayNames[date.getDay()]}</div>
-                  <div class="week-day-meta-row">
-                    <div class="week-day-date">${date.getDate()}</div>
-                    ${this.renderDayBadges(date, dayEventsForMatching)}
-                    ${this.renderDayForecast(date, 'week-compact')}
-                  </div>
-                </div>
-              </div>
-              <div class="week-day-events">
-                ${events.map(event => {
-                  return this.renderWeekCompactEvent(event, date);
-                }).join('')}
-                ${events.length === 0 ? `<div style="color: #9ca3af; font-size: 13px; text-align: center; margin-top: 20px;">${this.t('noEvents')}</div>` : ''}
-              </div>
-            </div>
-          `;
-        }).join('')}
-      </div>
-    `;
+    return renderWeekCompactView({
+      config: this._config,
+      weekDays: this.getWeekDays(),
+      today,
+      dayNames: this.getWeekdayNames(),
+      headerHeight: this._weekCompactHeaderHeight,
+      helpers: {
+        getCompactContainerStyle: () => this.getCompactContainerStyle(),
+        renderCalendarBadges: () => this.renderCalendarBadges(),
+        getEventsForDay: (date, options) => this.getEventsForDay(date, options),
+        isEventHiddenByStyle: (event) => this.isEventHiddenByStyle(event),
+        sortEventsForDate: (events, date) => this.sortEventsForDate(events, date),
+        getDayStyleAttributes: (date, events, isToday) => this.getDayStyleAttributes(date, events, isToday),
+        renderDayBadges: (date, events) => this.renderDayBadges(date, events),
+        renderDayForecast: (date, viewMode) => this.renderDayForecast(date, viewMode),
+        renderWeekCompactEvent: (event, date) => this.renderWeekCompactEvent(event, date),
+        t: (key, params) => this.t(key, params)
+      }
+    });
   }
 
   renderWeekStandard() {

--- a/src/renderers/week-compact-renderer.js
+++ b/src/renderers/week-compact-renderer.js
@@ -1,0 +1,45 @@
+export function renderWeekCompactView({
+  config,
+  weekDays,
+  today,
+  dayNames,
+  headerHeight,
+  helpers
+}) {
+  const headerHeightStyle = headerHeight ? `--week-compact-header-height: ${headerHeight}px;` : '';
+  const containerStyle = `${headerHeightStyle}${helpers.getCompactContainerStyle()}`;
+
+  return `
+      ${!config.compact_header && !config.hide_calendars ? helpers.renderCalendarBadges() : ''}
+      <div class="week-compact-container day-badge-layout-${config.day_badge_layout_week}" style="${containerStyle}">
+        ${weekDays.map(date => {
+          const isToday = date.toDateString() === today.toDateString();
+          const dayEventsForMatching = helpers.getEventsForDay(date, { includeHiddenStyledEvents: true });
+          const events = helpers.sortEventsForDate(dayEventsForMatching.filter((event) => !helpers.isEventHiddenByStyle(event)), date);
+          const dayStyle = helpers.getDayStyleAttributes(date, dayEventsForMatching, isToday);
+          const dayStyleAttr = dayStyle.style ? ` style="${dayStyle.style}"` : '';
+
+          return `
+            <div class="week-day-column ${isToday ? 'today' : ''} ${dayStyle.className}" data-date="${date.toISOString()}" data-click-target="day-header"${dayStyleAttr}>
+              <div class="week-day-header">
+                <div class="week-day-header-main">
+                  <div class="week-day-name">${dayNames[date.getDay()]}</div>
+                  <div class="week-day-meta-row">
+                    <div class="week-day-date">${date.getDate()}</div>
+                    ${helpers.renderDayBadges(date, dayEventsForMatching)}
+                    ${helpers.renderDayForecast(date, 'week-compact')}
+                  </div>
+                </div>
+              </div>
+              <div class="week-day-events">
+                ${events.map(event => {
+                  return helpers.renderWeekCompactEvent(event, date);
+                }).join('')}
+                ${events.length === 0 ? `<div style="color: #9ca3af; font-size: 13px; text-align: center; margin-top: 20px;">${helpers.t('noEvents')}</div>` : ''}
+              </div>
+            </div>
+          `;
+        }).join('')}
+      </div>
+    `;
+}

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -143,6 +143,7 @@ import {
   isAgendaRangeWithinWindow
 } from './views/agenda-view-model.js';
 import { renderAgendaView } from './renderers/agenda-renderer.js';
+import { renderWeekCompactView } from './renderers/week-compact-renderer.js';
 import {
   renderMonthDayHeaders,
   renderMonthDays,
@@ -5899,46 +5900,28 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   renderWeekCompact() {
-    const weekDays = this.getWeekDays();
     const today = new Date();
     today.setHours(0, 0, 0, 0);
-    const dayNames = this.getWeekdayNames();
-    const headerHeightStyle = this._weekCompactHeaderHeight ? `--week-compact-header-height: ${this._weekCompactHeaderHeight}px;` : '';
-    const containerStyle = `${headerHeightStyle}${this.getCompactContainerStyle()}`;
 
-    return `
-      ${!this._config.compact_header && !this._config.hide_calendars ? this.renderCalendarBadges() : ''}
-      <div class="week-compact-container day-badge-layout-${this._config.day_badge_layout_week}" style="${containerStyle}">
-        ${weekDays.map(date => {
-          const isToday = date.toDateString() === today.toDateString();
-          const dayEventsForMatching = this.getEventsForDay(date, { includeHiddenStyledEvents: true });
-          const events = this.sortEventsForDate(dayEventsForMatching.filter((event) => !this.isEventHiddenByStyle(event)), date);
-          const dayStyle = this.getDayStyleAttributes(date, dayEventsForMatching, isToday);
-          const dayStyleAttr = dayStyle.style ? ` style="${dayStyle.style}"` : '';
-
-          return `
-            <div class="week-day-column ${isToday ? 'today' : ''} ${dayStyle.className}" data-date="${date.toISOString()}" data-click-target="day-header"${dayStyleAttr}>
-              <div class="week-day-header">
-                <div class="week-day-header-main">
-                  <div class="week-day-name">${dayNames[date.getDay()]}</div>
-                  <div class="week-day-meta-row">
-                    <div class="week-day-date">${date.getDate()}</div>
-                    ${this.renderDayBadges(date, dayEventsForMatching)}
-                    ${this.renderDayForecast(date, 'week-compact')}
-                  </div>
-                </div>
-              </div>
-              <div class="week-day-events">
-                ${events.map(event => {
-                  return this.renderWeekCompactEvent(event, date);
-                }).join('')}
-                ${events.length === 0 ? `<div style="color: #9ca3af; font-size: 13px; text-align: center; margin-top: 20px;">${this.t('noEvents')}</div>` : ''}
-              </div>
-            </div>
-          `;
-        }).join('')}
-      </div>
-    `;
+    return renderWeekCompactView({
+      config: this._config,
+      weekDays: this.getWeekDays(),
+      today,
+      dayNames: this.getWeekdayNames(),
+      headerHeight: this._weekCompactHeaderHeight,
+      helpers: {
+        getCompactContainerStyle: () => this.getCompactContainerStyle(),
+        renderCalendarBadges: () => this.renderCalendarBadges(),
+        getEventsForDay: (date, options) => this.getEventsForDay(date, options),
+        isEventHiddenByStyle: (event) => this.isEventHiddenByStyle(event),
+        sortEventsForDate: (events, date) => this.sortEventsForDate(events, date),
+        getDayStyleAttributes: (date, events, isToday) => this.getDayStyleAttributes(date, events, isToday),
+        renderDayBadges: (date, events) => this.renderDayBadges(date, events),
+        renderDayForecast: (date, viewMode) => this.renderDayForecast(date, viewMode),
+        renderWeekCompactEvent: (event, date) => this.renderWeekCompactEvent(event, date),
+        t: (key, params) => this.t(key, params)
+      }
+    });
   }
 
   renderWeekStandard() {


### PR DESCRIPTION
### Motivation
- Continue modularization by extracting week-compact-specific HTML composition into its own renderer module to keep `src/skylight-calendar-card.js` focused on orchestration and state while preserving runtime and visual behavior.

### Description
- Added `src/renderers/week-compact-renderer.js` exporting `renderWeekCompactView` which composes the week-compact container, per-day columns/headers/meta, event lists, and the empty-state markup.
- Replaced the inlined `renderWeekCompact()` HTML in `src/skylight-calendar-card.js` with a thin composer that calls `renderWeekCompactView` and passes explicit inputs and narrow helper callbacks (e.g. `renderWeekCompactEvent`, `renderDayBadges`, `renderDayForecast`, `getEventsForDay`, `sortEventsForDate`, `isEventHiddenByStyle`, `getDayStyleAttributes`, `getCompactContainerStyle`, `renderCalendarBadges`, `t`).
- Preserved all shared/stateful logic in `src/skylight-calendar-card.js` (event rendering, badges, weather, modal/click behavior, layout/measurement, week-standard renderer) and did not move the week-standard renderer.
- No intentional changes to CSS, DOM structure, class names, data attributes, public config names, translations, click/modal behavior, `week_days`, `rolling_days_week_compact`, `hide_times_for_calendars`, or visual output; the regenerated root `skylight-calendar-card.js` artifact is included alongside the source change.

### Testing
- Ran dependency/install and build steps: `npm ci --no-audit --fund=false` and `npm run build`, both completed successfully.
- Performed syntax checks with `node --check src/skylight-calendar-card.js`, `node --check src/renderers/week-compact-renderer.js`, and `node --check skylight-calendar-card.js`, all succeeded.
- Executed unit tests with `npm test`, with all tests passing (`233` tests passed); executed visual tests with `npm run test:visual`, with all visual checks passing (`39` tests passed).
- No visual snapshot differences were observed during `npm run test:visual`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c431e2a5c8331945234c065476489)