### PR TITLE
Extract event details modal renderer (Phase 19)

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -2937,6 +2937,115 @@ function renderAgendaView({
     `;
 }
 
+function renderEventDetailsModal({
+  event,
+  startDate,
+  endDate,
+  isAllDay,
+  calendarName,
+  visibleBadges,
+  capabilities,
+  hasUID,
+  canEdit,
+  canDelete,
+  canForward,
+  canModify,
+  helpers
+}) {
+  const {
+    escapeHtml,
+    formatDate,
+    formatEventTime,
+    formatDuration,
+    renderEventDescription,
+    t
+  } = helpers;
+
+  const combinedBadgeHtml = event.isCombinedCalendarEvent
+    ? `<div style="display:flex; gap:6px; flex-wrap:wrap; margin-top:8px;">${visibleBadges.map(calendar => `<span class="modal-calendar-badge" style="background: ${calendar.color}; color: white; display: inline-block; padding: 4px 10px; border-radius: 12px; font-size: 12px;">${escapeHtml(calendar.name)}</span>`).join('')}</div>`
+    : `<div class="modal-calendar-badge" style="background: ${event.color}; color: white; display: inline-block; padding: 4px 12px; border-radius: 12px; font-size: 12px; margin-top: 8px;">${escapeHtml(calendarName)}</div>`;
+
+  return `
+      <div class="modal-header">
+        <div>
+          <h3 class="modal-title">${escapeHtml(event.summary || t('untitledEvent'))}</h3>
+          ${combinedBadgeHtml}
+        </div>
+        <button class="modal-close" id="close-modal">×</button>
+      </div>
+      <div class="modal-body">
+        <div class="modal-row">
+          <div class="modal-label">📅 ${t('start')}</div>
+          <div class="modal-value">
+            ${formatDate(startDate)}${!isAllDay ? ` ${t('at')} ${formatEventTime(startDate)}` : ` (${t('allDay')})`}
+          </div>
+        </div>
+        <div class="modal-row">
+          <div class="modal-label">🏁 ${t('end')}</div>
+          <div class="modal-value">
+            ${formatDate(endDate)}${!isAllDay ? ` ${t('at')} ${formatEventTime(endDate)}` : ` (${t('allDay')})`}
+          </div>
+        </div>
+        ${!isAllDay ? `
+          <div class="modal-row">
+            <div class="modal-label">⏱️ ${t('duration')}</div>
+            <div class="modal-value">${formatDuration(startDate, endDate)}</div>
+          </div>
+        ` : ''}
+        ${event.location ? `
+          <div class="modal-row">
+            <div class="modal-label">📍 ${t('location')}</div>
+            <div class="modal-value">${escapeHtml(event.location)}</div>
+          </div>
+        ` : ''}
+        ${event.description ? `
+          <div class="modal-row modal-row-description">
+            <div class="modal-label">📝 ${t('description')}</div>
+            <div class="modal-value event-description-content">${renderEventDescription(event.description)}</div>
+          </div>
+        ` : ''}
+        ${event.attendees && event.attendees.length > 0 ? `
+          <div class="modal-row">
+            <div class="modal-label">👥 ${t('attendees')}</div>
+            <div class="modal-value">
+              ${event.attendees.map(a => escapeHtml(a.email || a.displayName || t('unknownAttendee'))).join(', ')}
+            </div>
+          </div>
+        ` : ''}
+        ${event.rrule ? `
+          <div class="modal-row">
+            <div class="modal-label">🔁 ${t('recurrence')}</div>
+            <div class="modal-value">${t('recurringEvent')}</div>
+          </div>
+        ` : ''}
+
+        ${!canModify && !capabilities.isReadonly && capabilities.isGoogleCalendar ? `
+          <div class="info-banner warning">
+            <strong>${t('googleCalendarLimitationTitle')}</strong> ${t('googleCalendarLimitationBody')}
+          </div>
+        ` : ''}
+
+        ${!canModify && !hasUID && !capabilities.isGoogleCalendar ? `
+          <div class="info-banner warning">
+            <strong>${t('cannotModifyTitle')}</strong> ${t('cannotModifyBody')}
+          </div>
+        ` : ''}
+
+        ${(canEdit || canDelete || canForward) ? `
+          <div class="modal-actions">
+            <div class="modal-actions-left">
+              ${canDelete ? `<button class="btn btn-danger" id="delete-event-btn">${t('delete')}</button>` : ''}
+            </div>
+            <div class="modal-actions-right">
+              ${canForward ? `<button class="btn btn-secondary" id="forward-event-btn">${t('forwardEvent')}</button>` : ''}
+              ${canEdit ? `<button class="btn btn-primary" id="edit-event-btn">${t('editEvent')}</button>` : ''}
+            </div>
+          </div>
+        ` : ''}
+      </div>
+    `;
+}
+
 function renderWeekCompactView({
   config,
   weekDays,
@@ -12682,10 +12791,11 @@ class SkylightCalendarCard extends HTMLElement {
     // Get calendar info and capabilities
     const calendarName = this.getCalendarName(event.entityId);
     const capabilities = this._calendarCapabilities[event.entityId] || {};
-    const visibleBadges = this.getModalCalendarBadgesForEvent(event);
-    const combinedBadgeHtml = event.isCombinedCalendarEvent
-      ? `<div style="display:flex; gap:6px; flex-wrap:wrap; margin-top:8px;">${visibleBadges.map(calendar => `<span class="modal-calendar-badge" style="background: ${calendar.color}; color: white; display: inline-block; padding: 4px 10px; border-radius: 12px; font-size: 12px;">${this.escapeHtml(this.getCalendarName(calendar.entityId))}</span>`).join('')}</div>`
-      : `<div class="modal-calendar-badge" style="background: ${event.color}; color: white; display: inline-block; padding: 4px 12px; border-radius: 12px; font-size: 12px; margin-top: 8px;">${this.escapeHtml(calendarName)}</div>`;
+    const visibleBadges = this.getModalCalendarBadgesForEvent(event)
+      .map((calendar) => ({
+        ...calendar,
+        name: this.getCalendarName(calendar.entityId)
+      }));
 
     // For edit/delete to work, we need:
     // 1. Event management enabled
@@ -12701,85 +12811,28 @@ class SkylightCalendarCard extends HTMLElement {
     const canDelete = canModify; // WebSocket delete works for all calendars including Google
     const canForward = !!this._config.enable_event_management && this.getWritableCalendars().length > 0;
 
-    content.innerHTML = `
-      <div class="modal-header">
-        <div>
-          <h3 class="modal-title">${this.escapeHtml(event.summary || this.t('untitledEvent'))}</h3>
-          ${combinedBadgeHtml}
-        </div>
-        <button class="modal-close" id="close-modal">×</button>
-      </div>
-      <div class="modal-body">
-        <div class="modal-row">
-          <div class="modal-label">📅 ${this.t('start')}</div>
-          <div class="modal-value">
-            ${this.formatDate(startDate)}${!isAllDay ? ` ${this.t('at')} ${this.formatEventTime(startDate)}` : ` (${this.t('allDay')})`}
-          </div>
-        </div>
-        <div class="modal-row">
-          <div class="modal-label">🏁 ${this.t('end')}</div>
-          <div class="modal-value">
-            ${this.formatDate(endDate)}${!isAllDay ? ` ${this.t('at')} ${this.formatEventTime(endDate)}` : ` (${this.t('allDay')})`}
-          </div>
-        </div>
-        ${!isAllDay ? `
-          <div class="modal-row">
-            <div class="modal-label">⏱️ ${this.t('duration')}</div>
-            <div class="modal-value">${this.formatDuration(startDate, endDate)}</div>
-          </div>
-        ` : ''}
-        ${event.location ? `
-          <div class="modal-row">
-            <div class="modal-label">📍 ${this.t('location')}</div>
-            <div class="modal-value">${this.escapeHtml(event.location)}</div>
-          </div>
-        ` : ''}
-        ${event.description ? `
-          <div class="modal-row modal-row-description">
-            <div class="modal-label">📝 ${this.t('description')}</div>
-            <div class="modal-value event-description-content">${this.renderEventDescription(event.description)}</div>
-          </div>
-        ` : ''}
-        ${event.attendees && event.attendees.length > 0 ? `
-          <div class="modal-row">
-            <div class="modal-label">👥 ${this.t('attendees')}</div>
-            <div class="modal-value">
-              ${event.attendees.map(a => this.escapeHtml(a.email || a.displayName || this.t('unknownAttendee'))).join(', ')}
-            </div>
-          </div>
-        ` : ''}
-        ${event.rrule ? `
-          <div class="modal-row">
-            <div class="modal-label">🔁 ${this.t('recurrence')}</div>
-            <div class="modal-value">${this.t('recurringEvent')}</div>
-          </div>
-        ` : ''}
-
-        ${!canModify && !capabilities.isReadonly && capabilities.isGoogleCalendar ? `
-          <div class="info-banner warning">
-            <strong>${this.t('googleCalendarLimitationTitle')}</strong> ${this.t('googleCalendarLimitationBody')}
-          </div>
-        ` : ''}
-
-        ${!canModify && !hasUID && !capabilities.isGoogleCalendar ? `
-          <div class="info-banner warning">
-            <strong>${this.t('cannotModifyTitle')}</strong> ${this.t('cannotModifyBody')}
-          </div>
-        ` : ''}
-
-        ${(canEdit || canDelete || canForward) ? `
-          <div class="modal-actions">
-            <div class="modal-actions-left">
-              ${canDelete ? `<button class="btn btn-danger" id="delete-event-btn">${this.t('delete')}</button>` : ''}
-            </div>
-            <div class="modal-actions-right">
-              ${canForward ? `<button class="btn btn-secondary" id="forward-event-btn">${this.t('forwardEvent')}</button>` : ''}
-              ${canEdit ? `<button class="btn btn-primary" id="edit-event-btn">${this.t('editEvent')}</button>` : ''}
-            </div>
-          </div>
-        ` : ''}
-      </div>
-    `;
+    content.innerHTML = renderEventDetailsModal({
+      event,
+      startDate,
+      endDate,
+      isAllDay,
+      calendarName,
+      visibleBadges,
+      capabilities,
+      hasUID,
+      canEdit,
+      canDelete,
+      canForward,
+      canModify,
+      helpers: {
+        escapeHtml: this.escapeHtml.bind(this),
+        formatDate: this.formatDate.bind(this),
+        formatEventTime: this.formatEventTime.bind(this),
+        formatDuration: this.formatDuration.bind(this),
+        renderEventDescription: this.renderEventDescription.bind(this),
+        t: this.t.bind(this)
+      }
+    });
 
     modal.classList.add('show');
     this.setModalBackHandler(onCloseBack);

--- a/src/renderers/event-modal-renderer.js
+++ b/src/renderers/event-modal-renderer.js
@@ -1,0 +1,108 @@
+export function renderEventDetailsModal({
+  event,
+  startDate,
+  endDate,
+  isAllDay,
+  calendarName,
+  visibleBadges,
+  capabilities,
+  hasUID,
+  canEdit,
+  canDelete,
+  canForward,
+  canModify,
+  helpers
+}) {
+  const {
+    escapeHtml,
+    formatDate,
+    formatEventTime,
+    formatDuration,
+    renderEventDescription,
+    t
+  } = helpers;
+
+  const combinedBadgeHtml = event.isCombinedCalendarEvent
+    ? `<div style="display:flex; gap:6px; flex-wrap:wrap; margin-top:8px;">${visibleBadges.map(calendar => `<span class="modal-calendar-badge" style="background: ${calendar.color}; color: white; display: inline-block; padding: 4px 10px; border-radius: 12px; font-size: 12px;">${escapeHtml(calendar.name)}</span>`).join('')}</div>`
+    : `<div class="modal-calendar-badge" style="background: ${event.color}; color: white; display: inline-block; padding: 4px 12px; border-radius: 12px; font-size: 12px; margin-top: 8px;">${escapeHtml(calendarName)}</div>`;
+
+  return `
+      <div class="modal-header">
+        <div>
+          <h3 class="modal-title">${escapeHtml(event.summary || t('untitledEvent'))}</h3>
+          ${combinedBadgeHtml}
+        </div>
+        <button class="modal-close" id="close-modal">×</button>
+      </div>
+      <div class="modal-body">
+        <div class="modal-row">
+          <div class="modal-label">📅 ${t('start')}</div>
+          <div class="modal-value">
+            ${formatDate(startDate)}${!isAllDay ? ` ${t('at')} ${formatEventTime(startDate)}` : ` (${t('allDay')})`}
+          </div>
+        </div>
+        <div class="modal-row">
+          <div class="modal-label">🏁 ${t('end')}</div>
+          <div class="modal-value">
+            ${formatDate(endDate)}${!isAllDay ? ` ${t('at')} ${formatEventTime(endDate)}` : ` (${t('allDay')})`}
+          </div>
+        </div>
+        ${!isAllDay ? `
+          <div class="modal-row">
+            <div class="modal-label">⏱️ ${t('duration')}</div>
+            <div class="modal-value">${formatDuration(startDate, endDate)}</div>
+          </div>
+        ` : ''}
+        ${event.location ? `
+          <div class="modal-row">
+            <div class="modal-label">📍 ${t('location')}</div>
+            <div class="modal-value">${escapeHtml(event.location)}</div>
+          </div>
+        ` : ''}
+        ${event.description ? `
+          <div class="modal-row modal-row-description">
+            <div class="modal-label">📝 ${t('description')}</div>
+            <div class="modal-value event-description-content">${renderEventDescription(event.description)}</div>
+          </div>
+        ` : ''}
+        ${event.attendees && event.attendees.length > 0 ? `
+          <div class="modal-row">
+            <div class="modal-label">👥 ${t('attendees')}</div>
+            <div class="modal-value">
+              ${event.attendees.map(a => escapeHtml(a.email || a.displayName || t('unknownAttendee'))).join(', ')}
+            </div>
+          </div>
+        ` : ''}
+        ${event.rrule ? `
+          <div class="modal-row">
+            <div class="modal-label">🔁 ${t('recurrence')}</div>
+            <div class="modal-value">${t('recurringEvent')}</div>
+          </div>
+        ` : ''}
+
+        ${!canModify && !capabilities.isReadonly && capabilities.isGoogleCalendar ? `
+          <div class="info-banner warning">
+            <strong>${t('googleCalendarLimitationTitle')}</strong> ${t('googleCalendarLimitationBody')}
+          </div>
+        ` : ''}
+
+        ${!canModify && !hasUID && !capabilities.isGoogleCalendar ? `
+          <div class="info-banner warning">
+            <strong>${t('cannotModifyTitle')}</strong> ${t('cannotModifyBody')}
+          </div>
+        ` : ''}
+
+        ${(canEdit || canDelete || canForward) ? `
+          <div class="modal-actions">
+            <div class="modal-actions-left">
+              ${canDelete ? `<button class="btn btn-danger" id="delete-event-btn">${t('delete')}</button>` : ''}
+            </div>
+            <div class="modal-actions-right">
+              ${canForward ? `<button class="btn btn-secondary" id="forward-event-btn">${t('forwardEvent')}</button>` : ''}
+              ${canEdit ? `<button class="btn btn-primary" id="edit-event-btn">${t('editEvent')}</button>` : ''}
+            </div>
+          </div>
+        ` : ''}
+      </div>
+    `;
+}

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -143,6 +143,7 @@ import {
   isAgendaRangeWithinWindow
 } from './views/agenda-view-model.js';
 import { renderAgendaView } from './renderers/agenda-renderer.js';
+import { renderEventDetailsModal } from './renderers/event-modal-renderer.js';
 import { renderWeekCompactView } from './renderers/week-compact-renderer.js';
 import { renderWeekStandardView } from './renderers/week-standard-renderer.js';
 import {
@@ -9532,10 +9533,11 @@ class SkylightCalendarCard extends HTMLElement {
     // Get calendar info and capabilities
     const calendarName = this.getCalendarName(event.entityId);
     const capabilities = this._calendarCapabilities[event.entityId] || {};
-    const visibleBadges = this.getModalCalendarBadgesForEvent(event);
-    const combinedBadgeHtml = event.isCombinedCalendarEvent
-      ? `<div style="display:flex; gap:6px; flex-wrap:wrap; margin-top:8px;">${visibleBadges.map(calendar => `<span class="modal-calendar-badge" style="background: ${calendar.color}; color: white; display: inline-block; padding: 4px 10px; border-radius: 12px; font-size: 12px;">${this.escapeHtml(this.getCalendarName(calendar.entityId))}</span>`).join('')}</div>`
-      : `<div class="modal-calendar-badge" style="background: ${event.color}; color: white; display: inline-block; padding: 4px 12px; border-radius: 12px; font-size: 12px; margin-top: 8px;">${this.escapeHtml(calendarName)}</div>`;
+    const visibleBadges = this.getModalCalendarBadgesForEvent(event)
+      .map((calendar) => ({
+        ...calendar,
+        name: this.getCalendarName(calendar.entityId)
+      }));
 
     // For edit/delete to work, we need:
     // 1. Event management enabled
@@ -9551,85 +9553,28 @@ class SkylightCalendarCard extends HTMLElement {
     const canDelete = canModify; // WebSocket delete works for all calendars including Google
     const canForward = !!this._config.enable_event_management && this.getWritableCalendars().length > 0;
 
-    content.innerHTML = `
-      <div class="modal-header">
-        <div>
-          <h3 class="modal-title">${this.escapeHtml(event.summary || this.t('untitledEvent'))}</h3>
-          ${combinedBadgeHtml}
-        </div>
-        <button class="modal-close" id="close-modal">×</button>
-      </div>
-      <div class="modal-body">
-        <div class="modal-row">
-          <div class="modal-label">📅 ${this.t('start')}</div>
-          <div class="modal-value">
-            ${this.formatDate(startDate)}${!isAllDay ? ` ${this.t('at')} ${this.formatEventTime(startDate)}` : ` (${this.t('allDay')})`}
-          </div>
-        </div>
-        <div class="modal-row">
-          <div class="modal-label">🏁 ${this.t('end')}</div>
-          <div class="modal-value">
-            ${this.formatDate(endDate)}${!isAllDay ? ` ${this.t('at')} ${this.formatEventTime(endDate)}` : ` (${this.t('allDay')})`}
-          </div>
-        </div>
-        ${!isAllDay ? `
-          <div class="modal-row">
-            <div class="modal-label">⏱️ ${this.t('duration')}</div>
-            <div class="modal-value">${this.formatDuration(startDate, endDate)}</div>
-          </div>
-        ` : ''}
-        ${event.location ? `
-          <div class="modal-row">
-            <div class="modal-label">📍 ${this.t('location')}</div>
-            <div class="modal-value">${this.escapeHtml(event.location)}</div>
-          </div>
-        ` : ''}
-        ${event.description ? `
-          <div class="modal-row modal-row-description">
-            <div class="modal-label">📝 ${this.t('description')}</div>
-            <div class="modal-value event-description-content">${this.renderEventDescription(event.description)}</div>
-          </div>
-        ` : ''}
-        ${event.attendees && event.attendees.length > 0 ? `
-          <div class="modal-row">
-            <div class="modal-label">👥 ${this.t('attendees')}</div>
-            <div class="modal-value">
-              ${event.attendees.map(a => this.escapeHtml(a.email || a.displayName || this.t('unknownAttendee'))).join(', ')}
-            </div>
-          </div>
-        ` : ''}
-        ${event.rrule ? `
-          <div class="modal-row">
-            <div class="modal-label">🔁 ${this.t('recurrence')}</div>
-            <div class="modal-value">${this.t('recurringEvent')}</div>
-          </div>
-        ` : ''}
-
-        ${!canModify && !capabilities.isReadonly && capabilities.isGoogleCalendar ? `
-          <div class="info-banner warning">
-            <strong>${this.t('googleCalendarLimitationTitle')}</strong> ${this.t('googleCalendarLimitationBody')}
-          </div>
-        ` : ''}
-
-        ${!canModify && !hasUID && !capabilities.isGoogleCalendar ? `
-          <div class="info-banner warning">
-            <strong>${this.t('cannotModifyTitle')}</strong> ${this.t('cannotModifyBody')}
-          </div>
-        ` : ''}
-
-        ${(canEdit || canDelete || canForward) ? `
-          <div class="modal-actions">
-            <div class="modal-actions-left">
-              ${canDelete ? `<button class="btn btn-danger" id="delete-event-btn">${this.t('delete')}</button>` : ''}
-            </div>
-            <div class="modal-actions-right">
-              ${canForward ? `<button class="btn btn-secondary" id="forward-event-btn">${this.t('forwardEvent')}</button>` : ''}
-              ${canEdit ? `<button class="btn btn-primary" id="edit-event-btn">${this.t('editEvent')}</button>` : ''}
-            </div>
-          </div>
-        ` : ''}
-      </div>
-    `;
+    content.innerHTML = renderEventDetailsModal({
+      event,
+      startDate,
+      endDate,
+      isAllDay,
+      calendarName,
+      visibleBadges,
+      capabilities,
+      hasUID,
+      canEdit,
+      canDelete,
+      canForward,
+      canModify,
+      helpers: {
+        escapeHtml: this.escapeHtml.bind(this),
+        formatDate: this.formatDate.bind(this),
+        formatEventTime: this.formatEventTime.bind(this),
+        formatDuration: this.formatDuration.bind(this),
+        renderEventDescription: this.renderEventDescription.bind(this),
+        t: this.t.bind(this)
+      }
+    });
 
     modal.classList.add('show');
     this.setModalBackHandler(onCloseBack);


### PR DESCRIPTION
### Motivation
- Reduce the size of `src/skylight-calendar-card.js` by extracting event detail modal HTML composition into a dedicated renderer while preserving runtime behavior and DOM output.

### Description
- Added `src/renderers/event-modal-renderer.js` exporting `renderEventDetailsModal` which composes event detail modal header, body rows, calendar badge markup, warning banners, and edit/forward/delete action markup.
- Updated `src/skylight-calendar-card.js` to import and call `renderEventDetailsModal(...)` with explicit inputs and narrow helper callbacks (`escapeHtml`, `formatDate`, `formatEventTime`, `formatDuration`, `renderEventDescription`, `t`) and to map `visibleBadges` to include resolved calendar names before handing them to the renderer.
- Kept modal lifecycle, focus/back-handler, keyboard/click listeners, event listener attachment/removal, form submission handlers, validation state mutation, DOM reads/writes, recurrence orchestration, and Home Assistant create/update/delete service orchestration in `src/skylight-calendar-card.js` (only pure HTML/string composition moved).
- Did not move the editor renderer, create/edit modal form rendering, CSS, IDs/classes/data-attributes, translations, public config names, or change `DAYLIGHT_CALENDAR_CARD_VERSION`.

### Testing
- Ran `npm ci --no-audit --fund=false` and `npm run build` and confirmed Rollup regenerated the root `skylight-calendar-card.js` artifact which was committed with the source change.
- Verified syntax with `node --check src/skylight-calendar-card.js`, `node --check src/renderers/event-modal-renderer.js`, and `node --check skylight-calendar-card.js` with no errors.
- Ran `npm test` (unit tests) which passed (233 tests, 0 failures).
- Ran `npm run test:visual` (Playwright visual tests) which passed (39 visual tests) and produced no unintended snapshot differences.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c51db666c8331b06d52a94f70fbc9)