### PR TITLE
Extract editor rendering helpers into src/renderers/editor-renderer.js

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1238,6 +1238,54 @@ function getEventCalendarBubbleMode(config = {}) {
   return 'icon';
 }
 
+function renderEditorSection({ title, content, disclosureKey, open = false }) {
+  const openAttr = open ? 'open' : '';
+  return `
+      <details class="config-section" data-disclosure-key="${disclosureKey}" ${openAttr}>
+        <summary>${title}</summary>
+        <div class="section-content">${content}</div>
+      </details>
+    `;
+}
+
+function renderEditorSubSection({ title, content, disclosureKey, open = false }) {
+  const openAttr = open ? 'open' : '';
+  return `
+      <details class="config-subsection" data-disclosure-key="${disclosureKey}" ${openAttr}>
+        <summary>${title}</summary>
+        <div class="subsection-content">${content}</div>
+      </details>
+    `;
+}
+
+function renderEditorColorInputControl({ id, field, mapKey = null, value, toColorInputValue }) {
+  const colorValue = toColorInputValue(value);
+  const triggerAttributes = mapKey
+    ? `data-color-trigger="true" data-color-field="${field}" data-color-map-key="${mapKey}"`
+    : `data-color-trigger="true" data-color-field="${field}"`;
+
+  return `
+      <div class="color-picker-wrap">
+        <button id="${id}" class="selected-color-swatch" data-color-field="${field}" ${mapKey ? `data-color-map-key="${mapKey}"` : ''} ${triggerAttributes} style="--selected-color: ${colorValue};" title="Choose color" type="button"></button>
+      </div>
+    `;
+}
+
+function renderEditorWeekdayCheckboxes({ selectedWeekdays }) {
+  const days = EDITOR_WEEKDAY_OPTIONS;
+
+  return `
+      <div class="weekday-grid" role="group" aria-label="Week days">
+        ${days.map((day) => `<span class="weekday-label">${day}</span>`).join('')}
+        ${days.map((_, index) => `
+          <label class="weekday-checkbox-wrap" aria-label="${days[index]}">
+            <input type="checkbox" data-weekday="${index}" ${selectedWeekdays.has(index) ? 'checked' : ''}>
+          </label>
+        `).join('')}
+      </div>
+    `;
+}
+
 function normalizeDayBadgeBlock(rule = {}, {
   normalizeEventTextValue,
   normalizeDayBadgeDisplayColor,
@@ -14087,16 +14135,13 @@ class SkylightCalendarCardEditor extends HTMLElement {
   }
 
   renderColorInputControl({ id, field, mapKey = null, value }) {
-    const colorValue = this.toColorInputValue(value);
-    const triggerAttributes = mapKey
-      ? `data-color-trigger="true" data-color-field="${field}" data-color-map-key="${mapKey}"`
-      : `data-color-trigger="true" data-color-field="${field}"`;
-
-    return `
-      <div class="color-picker-wrap">
-        <button id="${id}" class="selected-color-swatch" data-color-field="${field}" ${mapKey ? `data-color-map-key="${mapKey}"` : ''} ${triggerAttributes} style="--selected-color: ${colorValue};" title="Choose color" type="button"></button>
-      </div>
-    `;
+    return renderEditorColorInputControl({
+      id,
+      field,
+      mapKey,
+      value,
+      toColorInputValue: (colorValue) => this.toColorInputValue(colorValue)
+    });
   }
 
   renderMapRowInputs(mapKey, { label, inputType = 'text', placeholder = '' } = {}) {
@@ -14167,24 +14212,22 @@ class SkylightCalendarCardEditor extends HTMLElement {
 
   renderSection(title, content) {
     const disclosureKey = this.buildDisclosureKey('section', title);
-    const openAttr = this._openDisclosureKeys.has(disclosureKey) ? 'open' : '';
-    return `
-      <details class="config-section" data-disclosure-key="${disclosureKey}" ${openAttr}>
-        <summary>${title}</summary>
-        <div class="section-content">${content}</div>
-      </details>
-    `;
+    return renderEditorSection({
+      title,
+      content,
+      disclosureKey,
+      open: this._openDisclosureKeys.has(disclosureKey)
+    });
   }
 
   renderSubSection(title, content) {
     const disclosureKey = this.buildDisclosureKey('subsection', title);
-    const openAttr = this._openDisclosureKeys.has(disclosureKey) ? 'open' : '';
-    return `
-      <details class="config-subsection" data-disclosure-key="${disclosureKey}" ${openAttr}>
-        <summary>${title}</summary>
-        <div class="subsection-content">${content}</div>
-      </details>
-    `;
+    return renderEditorSubSection({
+      title,
+      content,
+      disclosureKey,
+      open: this._openDisclosureKeys.has(disclosureKey)
+    });
   }
 
   renderVirtualCalendarsEditor() {
@@ -14381,19 +14424,9 @@ class SkylightCalendarCardEditor extends HTMLElement {
   }
 
   renderWeekdayCheckboxes() {
-    const selectedWeekdays = new Set(this.getListFieldValue('week_days'));
-    const days = EDITOR_WEEKDAY_OPTIONS;
-
-    return `
-      <div class="weekday-grid" role="group" aria-label="Week days">
-        ${days.map((day) => `<span class="weekday-label">${day}</span>`).join('')}
-        ${days.map((_, index) => `
-          <label class="weekday-checkbox-wrap" aria-label="${days[index]}">
-            <input type="checkbox" data-weekday="${index}" ${selectedWeekdays.has(index) ? 'checked' : ''}>
-          </label>
-        `).join('')}
-      </div>
-    `;
+    return renderEditorWeekdayCheckboxes({
+      selectedWeekdays: new Set(this.getListFieldValue('week_days'))
+    });
   }
 
   render() {

--- a/src/renderers/editor-renderer.js
+++ b/src/renderers/editor-renderer.js
@@ -1,0 +1,49 @@
+import { EDITOR_WEEKDAY_OPTIONS } from '../editor/editor-schema.js';
+
+export function renderEditorSection({ title, content, disclosureKey, open = false }) {
+  const openAttr = open ? 'open' : '';
+  return `
+      <details class="config-section" data-disclosure-key="${disclosureKey}" ${openAttr}>
+        <summary>${title}</summary>
+        <div class="section-content">${content}</div>
+      </details>
+    `;
+}
+
+export function renderEditorSubSection({ title, content, disclosureKey, open = false }) {
+  const openAttr = open ? 'open' : '';
+  return `
+      <details class="config-subsection" data-disclosure-key="${disclosureKey}" ${openAttr}>
+        <summary>${title}</summary>
+        <div class="subsection-content">${content}</div>
+      </details>
+    `;
+}
+
+export function renderEditorColorInputControl({ id, field, mapKey = null, value, toColorInputValue }) {
+  const colorValue = toColorInputValue(value);
+  const triggerAttributes = mapKey
+    ? `data-color-trigger="true" data-color-field="${field}" data-color-map-key="${mapKey}"`
+    : `data-color-trigger="true" data-color-field="${field}"`;
+
+  return `
+      <div class="color-picker-wrap">
+        <button id="${id}" class="selected-color-swatch" data-color-field="${field}" ${mapKey ? `data-color-map-key="${mapKey}"` : ''} ${triggerAttributes} style="--selected-color: ${colorValue};" title="Choose color" type="button"></button>
+      </div>
+    `;
+}
+
+export function renderEditorWeekdayCheckboxes({ selectedWeekdays }) {
+  const days = EDITOR_WEEKDAY_OPTIONS;
+
+  return `
+      <div class="weekday-grid" role="group" aria-label="Week days">
+        ${days.map((day) => `<span class="weekday-label">${day}</span>`).join('')}
+        ${days.map((_, index) => `
+          <label class="weekday-checkbox-wrap" aria-label="${days[index]}">
+            <input type="checkbox" data-weekday="${index}" ${selectedWeekdays.has(index) ? 'checked' : ''}>
+          </label>
+        `).join('')}
+      </div>
+    `;
+}

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -32,12 +32,17 @@ import {
 } from './defaults.js';
 import { TRANSLATIONS } from './translations.js';
 import {
-  EDITOR_WEEKDAY_OPTIONS,
   createConfigNormalizationSchema,
   getEditorDefaultValue as getEditorDefaultValueFromSchema,
   getEventCalendarBubbleMode as getEventCalendarBubbleModeFromConfig,
   normalizeDefaultViewForEditor as normalizeDefaultViewForEditorValue
 } from './editor/editor-schema.js';
+import {
+  renderEditorColorInputControl,
+  renderEditorSection,
+  renderEditorSubSection,
+  renderEditorWeekdayCheckboxes
+} from './renderers/editor-renderer.js';
 import {
   normalizeDayBadgeBlock as normalizeDayBadgeBlockHelper,
   normalizeDayBadgeConditions as normalizeDayBadgeConditionsHelper,
@@ -10829,16 +10834,13 @@ class SkylightCalendarCardEditor extends HTMLElement {
   }
 
   renderColorInputControl({ id, field, mapKey = null, value }) {
-    const colorValue = this.toColorInputValue(value);
-    const triggerAttributes = mapKey
-      ? `data-color-trigger="true" data-color-field="${field}" data-color-map-key="${mapKey}"`
-      : `data-color-trigger="true" data-color-field="${field}"`;
-
-    return `
-      <div class="color-picker-wrap">
-        <button id="${id}" class="selected-color-swatch" data-color-field="${field}" ${mapKey ? `data-color-map-key="${mapKey}"` : ''} ${triggerAttributes} style="--selected-color: ${colorValue};" title="Choose color" type="button"></button>
-      </div>
-    `;
+    return renderEditorColorInputControl({
+      id,
+      field,
+      mapKey,
+      value,
+      toColorInputValue: (colorValue) => this.toColorInputValue(colorValue)
+    });
   }
 
   renderMapRowInputs(mapKey, { label, inputType = 'text', placeholder = '' } = {}) {
@@ -10909,24 +10911,22 @@ class SkylightCalendarCardEditor extends HTMLElement {
 
   renderSection(title, content) {
     const disclosureKey = this.buildDisclosureKey('section', title);
-    const openAttr = this._openDisclosureKeys.has(disclosureKey) ? 'open' : '';
-    return `
-      <details class="config-section" data-disclosure-key="${disclosureKey}" ${openAttr}>
-        <summary>${title}</summary>
-        <div class="section-content">${content}</div>
-      </details>
-    `;
+    return renderEditorSection({
+      title,
+      content,
+      disclosureKey,
+      open: this._openDisclosureKeys.has(disclosureKey)
+    });
   }
 
   renderSubSection(title, content) {
     const disclosureKey = this.buildDisclosureKey('subsection', title);
-    const openAttr = this._openDisclosureKeys.has(disclosureKey) ? 'open' : '';
-    return `
-      <details class="config-subsection" data-disclosure-key="${disclosureKey}" ${openAttr}>
-        <summary>${title}</summary>
-        <div class="subsection-content">${content}</div>
-      </details>
-    `;
+    return renderEditorSubSection({
+      title,
+      content,
+      disclosureKey,
+      open: this._openDisclosureKeys.has(disclosureKey)
+    });
   }
 
   renderVirtualCalendarsEditor() {
@@ -11123,19 +11123,9 @@ class SkylightCalendarCardEditor extends HTMLElement {
   }
 
   renderWeekdayCheckboxes() {
-    const selectedWeekdays = new Set(this.getListFieldValue('week_days'));
-    const days = EDITOR_WEEKDAY_OPTIONS;
-
-    return `
-      <div class="weekday-grid" role="group" aria-label="Week days">
-        ${days.map((day) => `<span class="weekday-label">${day}</span>`).join('')}
-        ${days.map((_, index) => `
-          <label class="weekday-checkbox-wrap" aria-label="${days[index]}">
-            <input type="checkbox" data-weekday="${index}" ${selectedWeekdays.has(index) ? 'checked' : ''}>
-          </label>
-        `).join('')}
-      </div>
-    `;
+    return renderEditorWeekdayCheckboxes({
+      selectedWeekdays: new Set(this.getListFieldValue('week_days'))
+    });
   }
 
   render() {


### PR DESCRIPTION
### Motivation
- Continue Phase 20 modularization by moving output-only configuration-editor HTML composition into a dedicated renderer module to reduce size/complexity in the main editor element while preserving runtime behavior.
- Limit the extraction to pure rendering helpers so interactive/editor lifecycle, DOM state mutation, event handling, validation, and config persistence remain in the main card where they depend on live element state.

### Description
- Added `src/renderers/editor-renderer.js` exporting `renderEditorSection`, `renderEditorSubSection`, `renderEditorColorInputControl`, and `renderEditorWeekdayCheckboxes` that produce the editor HTML fragments (section/subsection wrappers, color swatches, and weekday checkbox grid).
- Updated `src/skylight-calendar-card.js` to import and delegate those output-only rendering fragments while keeping the editor custom element (`SkylightCalendarCardEditor`) as the composer and owner of lifecycle, DOM reads/writes, event listeners, validation orchestration, color-picker state, virtual-calendar management, and config persistence.
- Did not move or change non-editor renderers, translations, CSS, DOM structure, input IDs/names/types/defaults, data attributes, class names, custom element names, or public config option names.
- Regenerated the shipped artifact `skylight-calendar-card.js` with Rollup to reflect the source changes.

### Testing
- Ran `npm ci --no-audit --fund=false`; install succeeded.
- Ran `npm run build`; Rollup rebuilt the root `skylight-calendar-card.js` artifact and it was regenerated as part of the change.
- Ran `node --check src/skylight-calendar-card.js`, `node --check src/renderers/editor-renderer.js`, and `node --check skylight-calendar-card.js`; all checks passed.
- Ran unit tests with `npm test` (233 tests) and Playwright visual tests with `npm run test:visual` (39 visual tests); all tests passed and no visual snapshot differences were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c57b5c15c8331a8d776f4bf3ebdca)