### PR TITLE
Extract event form rendering into renderer module

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3094,6 +3094,330 @@ function renderEventDetailsModal({
     `;
 }
 
+function formatDateTimeLocal(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
+
+function formatDate(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function renderRecurrenceControls({
+  recurrenceData,
+  recurrenceEndMode,
+  recurrenceWeekdayOptions,
+  showRecurringFields,
+  showWeekdays,
+  helpers
+}) {
+  const { escapeHtmlAttribute, t } = helpers;
+
+  return `
+          <div id="recurring-event-fields" style="display: ${showRecurringFields ? 'block' : 'none'};">
+            <div class="form-row">
+              <div class="form-group form-group-inline">
+                <div class="form-inline-row">
+                  <label class="form-label">${t('recurrenceFrequency')}</label>
+                  <select class="form-select" id="event-recurrence-frequency">
+                  <option value="DAILY" ${recurrenceData.frequency === 'DAILY' ? 'selected' : ''}>${t('recurrenceDaily')}</option>
+                  <option value="WEEKLY" ${recurrenceData.frequency === 'WEEKLY' ? 'selected' : ''}>${t('recurrenceWeekly')}</option>
+                  <option value="MONTHLY" ${recurrenceData.frequency === 'MONTHLY' ? 'selected' : ''}>${t('recurrenceMonthly')}</option>
+                  <option value="YEARLY" ${recurrenceData.frequency === 'YEARLY' ? 'selected' : ''}>${t('recurrenceYearly')}</option>
+                  </select>
+                </div>
+              </div>
+              <div class="form-group form-group-inline">
+                <div class="form-inline-row">
+                  <label class="form-label">${t('recurrenceEvery')}</label>
+                  <input type="number" class="form-input" id="event-recurrence-interval" min="1" value="${escapeHtmlAttribute(recurrenceData.interval || '1')}" />
+                </div>
+              </div>
+            </div>
+            <div class="form-group" id="event-recurrence-weekdays-group" style="display: ${showWeekdays ? 'block' : 'none'};">
+              <label class="form-label">${t('recurrenceWeekdays')}</label>
+              <div class="form-checkbox-group" style="flex-wrap: wrap; gap: 10px;">
+                ${recurrenceWeekdayOptions.map(day => `
+                  <label class="form-checkbox-label" style="display:flex;align-items:center;gap:6px;">
+                    <input type="checkbox" class="form-checkbox event-recurrence-weekday" value="${day.key}" ${recurrenceData.byDay.includes(day.key) ? 'checked' : ''} />
+                    <span>${day.label}</span>
+                  </label>
+                `).join('')}
+              </div>
+            </div>
+            <div class="form-group">
+              <label class="form-label recurrence-ends-label">${t('recurrenceEndsOn')}</label>
+              <div class="recurrence-end-row">
+                <label class="recurrence-end-option" for="event-recurrence-end-never">
+                  <input type="radio" name="event-recurrence-end-mode" id="event-recurrence-end-never" value="never" ${recurrenceEndMode === 'never' ? 'checked' : ''} />
+                  <span>${t('recurrenceNever')}</span>
+                </label>
+                <div></div>
+              </div>
+              <div class="recurrence-end-row">
+                <label class="recurrence-end-option" for="event-recurrence-end-on">
+                  <input type="radio" name="event-recurrence-end-mode" id="event-recurrence-end-on" value="on" ${recurrenceEndMode === 'on' ? 'checked' : ''} />
+                  <span>${t('recurrenceOn')}</span>
+                </label>
+                <input type="date" class="form-input" id="event-recurrence-until" value="${escapeHtmlAttribute(recurrenceData.untilDate || '')}" ${recurrenceEndMode === 'on' ? '' : 'disabled'} />
+              </div>
+              <div class="recurrence-end-row">
+                <label class="recurrence-end-option" for="event-recurrence-end-after">
+                  <input type="radio" name="event-recurrence-end-mode" id="event-recurrence-end-after" value="after" ${recurrenceEndMode === 'after' ? 'checked' : ''} />
+                  <span>${t('recurrenceAfter')}</span>
+                </label>
+                <div class="recurrence-after-input">
+                  <input type="number" class="form-input" id="event-recurrence-count" min="1" placeholder="13" value="${escapeHtmlAttribute(recurrenceData.count || '')}" ${recurrenceEndMode === 'after' ? '' : 'disabled'} />
+                  <span>${t('recurrenceOccurrences')}</span>
+                </div>
+              </div>
+            </div>
+          </div>`;
+}
+
+function renderEventFields({
+  title,
+  location,
+  description,
+  startDate,
+  startTime,
+  endDate,
+  endTime,
+  isAllDay,
+  isRecurring,
+  recurrenceData,
+  recurrenceEndMode,
+  recurrenceWeekdayOptions,
+  helpers
+}) {
+  const { escapeHtml, escapeHtmlAttribute, t } = helpers;
+
+  return `
+          <div class="form-group form-group-inline">
+            <div class="form-inline-row">
+              <label class="form-label">
+                ${t('eventTitle')}<span class="form-required">*</span>
+              </label>
+              <input type="text" class="form-input" id="event-title" placeholder="${escapeHtmlAttribute(t('eventTitlePlaceholder'))}" value="${escapeHtmlAttribute(title || '')}" required />
+            </div>
+          </div>
+
+          <div class="form-group form-group-inline">
+            <div class="form-inline-row form-inline-row-top">
+              <label class="form-label">${t('eventOptions')}</label>
+              <div class="form-checkbox-row">
+                <div class="form-group">
+                  <div class="form-checkbox-group">
+                    <input type="checkbox" class="form-checkbox" id="event-all-day" ${isAllDay ? 'checked' : ''} />
+                    <label class="form-checkbox-label" for="event-all-day">${t('allDayEvent')}</label>
+                  </div>
+                </div>
+
+                <div class="form-group">
+                  <div class="form-checkbox-group">
+                    <input type="checkbox" class="form-checkbox" id="event-recurring" ${isRecurring ? 'checked' : ''} />
+                    <label class="form-checkbox-label" for="event-recurring">${t('recurring')}</label>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+${renderRecurrenceControls({
+    recurrenceData,
+    recurrenceEndMode,
+    recurrenceWeekdayOptions,
+    showRecurringFields: isRecurring,
+    showWeekdays: isRecurring && recurrenceData.frequency === 'WEEKLY',
+    helpers
+  })}
+
+          <div id="timed-event-fields" style="display: ${isAllDay ? 'none' : 'block'};">
+            <div class="form-group form-group-inline">
+              <div class="form-inline-row">
+                <label class="form-label">${t('start')}</label>
+                <input type="datetime-local" class="form-input" id="event-start"
+                       value="${formatDateTimeLocal(startTime)}" required />
+              </div>
+            </div>
+
+            <div class="form-group form-group-inline">
+              <div class="form-inline-row">
+                <label class="form-label">${t('end')}</label>
+                <input type="datetime-local" class="form-input" id="event-end"
+                       value="${formatDateTimeLocal(endTime)}" />
+              </div>
+            </div>
+          </div>
+
+          <div id="all-day-event-fields" style="display: ${isAllDay ? 'block' : 'none'};">
+            <div class="form-row">
+              <div class="form-group">
+                <label class="form-label">${t('startDate')}</label>
+                <input type="date" class="form-input" id="event-start-date"
+                       value="${formatDate(startDate)}" />
+              </div>
+
+              <div class="form-group">
+                <label class="form-label">${t('endDate')}</label>
+                <input type="date" class="form-input" id="event-end-date"
+                       value="${formatDate(endDate)}" />
+              </div>
+            </div>
+          </div>
+
+          <div class="form-group form-group-inline">
+            <div class="form-inline-row">
+              <label class="form-label">${t('location')}</label>
+              <input type="text" class="form-input" id="event-location" placeholder="${escapeHtmlAttribute(t('locationPlaceholder'))}" value="${escapeHtmlAttribute(location || '')}" />
+            </div>
+          </div>
+
+          <div class="form-group">
+            <label class="form-label">${t('description')}</label>
+            <textarea class="form-textarea" id="event-description" placeholder="${escapeHtmlAttribute(t('descriptionPlaceholder'))}">${escapeHtml(description || '')}</textarea>
+          </div>
+
+          <div id="form-error" class="error-message" style="display: none;"></div>`;
+}
+
+function renderCreateEventForm({
+  writableCalendars,
+  selectedCalendarIds,
+  prefill,
+  startDate,
+  startTime,
+  endDate,
+  endTime,
+  recurrenceData,
+  isPrefilledRecurring,
+  isPrefilledAllDay,
+  recurrenceEndMode,
+  recurrenceWeekdayOptions,
+  helpers
+}) {
+  const { escapeHtml, getCalendarName, t } = helpers;
+
+  return `
+      <div class="modal-header">
+        <h3 class="modal-title">${t('createEvent')}</h3>
+        <button class="modal-close" id="close-modal">×</button>
+      </div>
+      <div class="modal-body">
+        <form id="create-event-form">
+          <div class="form-group form-group-inline">
+            <div class="form-inline-row">
+              <label class="form-label">
+                ${t('calendars')}<span class="form-required">*</span>
+              </label>
+              <div class="form-checkbox-grid">
+                ${writableCalendars.map((entityId, index) => `
+                  <label class="form-checkbox-group" style="margin: 0;">
+                    <input
+                      type="checkbox"
+                      class="form-checkbox create-event-calendar"
+                      value="${entityId}"
+                      ${(selectedCalendarIds.length > 0 ? selectedCalendarIds.includes(entityId) : index === 0) ? 'checked' : ''}
+                    />
+                    <span class="form-checkbox-label">${escapeHtml(getCalendarName(entityId))}</span>
+                  </label>
+                `).join('')}
+              </div>
+            </div>
+          </div>
+
+${renderEventFields({
+    title: prefill?.summary || '',
+    location: prefill?.location || '',
+    description: prefill?.description || '',
+    startDate,
+    startTime,
+    endDate,
+    endTime,
+    isAllDay: isPrefilledAllDay,
+    isRecurring: isPrefilledRecurring,
+    recurrenceData,
+    recurrenceEndMode,
+    recurrenceWeekdayOptions,
+    helpers
+  })}
+
+          <div class="form-actions">
+            <button type="button" class="btn btn-secondary" id="cancel-btn">${t('cancel')}</button>
+            <button type="submit" class="btn btn-primary" id="submit-btn">${t('createEvent')}</button>
+          </div>
+        </form>
+      </div>
+    `;
+}
+
+function renderEditEventForm({
+  event,
+  startDate,
+  endDate,
+  isAllDay,
+  visibleCalendarOptions,
+  selectedCombinedCalendarIds,
+  recurrenceData,
+  recurringSelectedByDefault,
+  recurrenceEndMode,
+  recurrenceWeekdayOptions,
+  helpers
+}) {
+  const { escapeHtml, getCalendarName, t } = helpers;
+
+  return `
+      <div class="modal-header">
+        <h3 class="modal-title">${t('editEvent')}</h3>
+        <button class="modal-close" id="close-modal">×</button>
+      </div>
+      <div class="modal-body">
+        <form id="edit-event-form">
+          <div class="form-group">
+            <label class="form-label">
+              ${t('calendar')}<span class="form-required">*</span>
+            </label>
+            <select class="form-select" id="event-calendar" required ${selectedCombinedCalendarIds.length > 1 ? 'disabled' : ''}>
+              ${visibleCalendarOptions.map((entityId) => `
+                <option value="${entityId}" ${entityId === event.entityId ? 'selected' : ''}>
+                  ${escapeHtml(getCalendarName(entityId))}
+                </option>
+              `).join('')}
+            </select>
+          </div>
+
+${renderEventFields({
+    title: event.summary || '',
+    location: event.location || '',
+    description: event.description || '',
+    startDate,
+    startTime: startDate,
+    endDate,
+    endTime: endDate,
+    isAllDay,
+    isRecurring: recurringSelectedByDefault,
+    recurrenceData,
+    recurrenceEndMode,
+    recurrenceWeekdayOptions,
+    helpers
+  })}
+
+          <div class="form-actions">
+            <button type="button" class="btn btn-secondary" id="cancel-btn">${t('cancel')}</button>
+            <button type="submit" class="btn btn-primary" id="submit-btn">${t('saveChanges')}</button>
+          </div>
+        </form>
+      </div>
+    `;
+}
+
 function renderWeekCompactView({
   config,
   weekDays,
@@ -11502,196 +11826,26 @@ class SkylightCalendarCard extends HTMLElement {
     const isPrefilledRecurring = !!prefill?.rrule;
     const isPrefilledAllDay = !!prefill?.isAllDay;
 
-    // Format for datetime-local input
-    const formatDateTimeLocal = (date) => {
-      const year = date.getFullYear();
-      const month = String(date.getMonth() + 1).padStart(2, '0');
-      const day = String(date.getDate()).padStart(2, '0');
-      const hours = String(date.getHours()).padStart(2, '0');
-      const minutes = String(date.getMinutes()).padStart(2, '0');
-      return `${year}-${month}-${day}T${hours}:${minutes}`;
-    };
-
-    const formatDate = (date) => {
-      const year = date.getFullYear();
-      const month = String(date.getMonth() + 1).padStart(2, '0');
-      const day = String(date.getDate()).padStart(2, '0');
-      return `${year}-${month}-${day}`;
-    };
-
-    content.innerHTML = `
-      <div class="modal-header">
-        <h3 class="modal-title">${this.t('createEvent')}</h3>
-        <button class="modal-close" id="close-modal">×</button>
-      </div>
-      <div class="modal-body">
-        <form id="create-event-form">
-          <div class="form-group form-group-inline">
-            <div class="form-inline-row">
-              <label class="form-label">
-                ${this.t('calendars')}<span class="form-required">*</span>
-              </label>
-              <div class="form-checkbox-grid">
-                ${writableCalendars.map((entityId, index) => `
-                  <label class="form-checkbox-group" style="margin: 0;">
-                    <input
-                      type="checkbox"
-                      class="form-checkbox create-event-calendar"
-                      value="${entityId}"
-                      ${(selectedCalendarIds.length > 0 ? selectedCalendarIds.includes(entityId) : index === 0) ? 'checked' : ''}
-                    />
-                    <span class="form-checkbox-label">${this.escapeHtml(this.getCalendarName(entityId))}</span>
-                  </label>
-                `).join('')}
-              </div>
-            </div>
-          </div>
-
-          <div class="form-group form-group-inline">
-            <div class="form-inline-row">
-              <label class="form-label">
-                ${this.t('eventTitle')}<span class="form-required">*</span>
-              </label>
-              <input type="text" class="form-input" id="event-title" placeholder="${this.escapeHtmlAttribute(this.t('eventTitlePlaceholder'))}" value="${this.escapeHtmlAttribute(prefill?.summary || '')}" required />
-            </div>
-          </div>
-
-          <div class="form-group form-group-inline">
-            <div class="form-inline-row form-inline-row-top">
-              <label class="form-label">${this.t('eventOptions')}</label>
-              <div class="form-checkbox-row">
-                <div class="form-group">
-                  <div class="form-checkbox-group">
-                    <input type="checkbox" class="form-checkbox" id="event-all-day" ${isPrefilledAllDay ? 'checked' : ''} />
-                    <label class="form-checkbox-label" for="event-all-day">${this.t('allDayEvent')}</label>
-                  </div>
-                </div>
-
-                <div class="form-group">
-                  <div class="form-checkbox-group">
-                    <input type="checkbox" class="form-checkbox" id="event-recurring" ${isPrefilledRecurring ? 'checked' : ''} />
-                    <label class="form-checkbox-label" for="event-recurring">${this.t('recurring')}</label>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div id="recurring-event-fields" style="display: ${isPrefilledRecurring ? 'block' : 'none'};">
-            <div class="form-row">
-              <div class="form-group form-group-inline">
-                <div class="form-inline-row">
-                  <label class="form-label">${this.t('recurrenceFrequency')}</label>
-                  <select class="form-select" id="event-recurrence-frequency">
-                  <option value="DAILY" ${recurrenceData.frequency === 'DAILY' ? 'selected' : ''}>${this.t('recurrenceDaily')}</option>
-                  <option value="WEEKLY" ${recurrenceData.frequency === 'WEEKLY' ? 'selected' : ''}>${this.t('recurrenceWeekly')}</option>
-                  <option value="MONTHLY" ${recurrenceData.frequency === 'MONTHLY' ? 'selected' : ''}>${this.t('recurrenceMonthly')}</option>
-                  <option value="YEARLY" ${recurrenceData.frequency === 'YEARLY' ? 'selected' : ''}>${this.t('recurrenceYearly')}</option>
-                  </select>
-                </div>
-              </div>
-              <div class="form-group form-group-inline">
-                <div class="form-inline-row">
-                  <label class="form-label">${this.t('recurrenceEvery')}</label>
-                  <input type="number" class="form-input" id="event-recurrence-interval" min="1" value="${this.escapeHtmlAttribute(recurrenceData.interval || '1')}" />
-                </div>
-              </div>
-            </div>
-            <div class="form-group" id="event-recurrence-weekdays-group" style="display: ${isPrefilledRecurring && recurrenceData.frequency === 'WEEKLY' ? 'block' : 'none'};">
-              <label class="form-label">${this.t('recurrenceWeekdays')}</label>
-              <div class="form-checkbox-group" style="flex-wrap: wrap; gap: 10px;">
-                ${this.getRecurrenceWeekdayOptions().map(day => `
-                  <label class="form-checkbox-label" style="display:flex;align-items:center;gap:6px;">
-                    <input type="checkbox" class="form-checkbox event-recurrence-weekday" value="${day.key}" ${recurrenceData.byDay.includes(day.key) ? 'checked' : ''} />
-                    <span>${day.label}</span>
-                  </label>
-                `).join('')}
-              </div>
-            </div>
-            <div class="form-group">
-              <label class="form-label recurrence-ends-label">${this.t('recurrenceEndsOn')}</label>
-              <div class="recurrence-end-row">
-                <label class="recurrence-end-option" for="event-recurrence-end-never">
-                  <input type="radio" name="event-recurrence-end-mode" id="event-recurrence-end-never" value="never" ${this.getRecurrenceEndMode(recurrenceData) === 'never' ? 'checked' : ''} />
-                  <span>${this.t('recurrenceNever')}</span>
-                </label>
-                <div></div>
-              </div>
-              <div class="recurrence-end-row">
-                <label class="recurrence-end-option" for="event-recurrence-end-on">
-                  <input type="radio" name="event-recurrence-end-mode" id="event-recurrence-end-on" value="on" ${this.getRecurrenceEndMode(recurrenceData) === 'on' ? 'checked' : ''} />
-                  <span>${this.t('recurrenceOn')}</span>
-                </label>
-                <input type="date" class="form-input" id="event-recurrence-until" value="${this.escapeHtmlAttribute(recurrenceData.untilDate || '')}" ${this.getRecurrenceEndMode(recurrenceData) === 'on' ? '' : 'disabled'} />
-              </div>
-              <div class="recurrence-end-row">
-                <label class="recurrence-end-option" for="event-recurrence-end-after">
-                  <input type="radio" name="event-recurrence-end-mode" id="event-recurrence-end-after" value="after" ${this.getRecurrenceEndMode(recurrenceData) === 'after' ? 'checked' : ''} />
-                  <span>${this.t('recurrenceAfter')}</span>
-                </label>
-                <div class="recurrence-after-input">
-                  <input type="number" class="form-input" id="event-recurrence-count" min="1" placeholder="13" value="${this.escapeHtmlAttribute(recurrenceData.count || '')}" ${this.getRecurrenceEndMode(recurrenceData) === 'after' ? '' : 'disabled'} />
-                  <span>${this.t('recurrenceOccurrences')}</span>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div id="timed-event-fields" style="display: ${isPrefilledAllDay ? 'none' : 'block'};">
-            <div class="form-group form-group-inline">
-              <div class="form-inline-row">
-                <label class="form-label">${this.t('start')}</label>
-                <input type="datetime-local" class="form-input" id="event-start"
-                       value="${formatDateTimeLocal(startTime)}" required />
-              </div>
-            </div>
-
-            <div class="form-group form-group-inline">
-              <div class="form-inline-row">
-                <label class="form-label">${this.t('end')}</label>
-                <input type="datetime-local" class="form-input" id="event-end"
-                       value="${formatDateTimeLocal(endTime)}" />
-              </div>
-            </div>
-          </div>
-
-          <div id="all-day-event-fields" style="display: ${isPrefilledAllDay ? 'block' : 'none'};">
-            <div class="form-row">
-              <div class="form-group">
-                <label class="form-label">${this.t('startDate')}</label>
-                <input type="date" class="form-input" id="event-start-date"
-                       value="${formatDate(startDate)}" />
-              </div>
-
-              <div class="form-group">
-                <label class="form-label">${this.t('endDate')}</label>
-                <input type="date" class="form-input" id="event-end-date"
-                       value="${formatDate(endDate)}" />
-              </div>
-            </div>
-          </div>
-
-          <div class="form-group form-group-inline">
-            <div class="form-inline-row">
-              <label class="form-label">${this.t('location')}</label>
-              <input type="text" class="form-input" id="event-location" placeholder="${this.escapeHtmlAttribute(this.t('locationPlaceholder'))}" value="${this.escapeHtmlAttribute(prefill?.location || '')}" />
-            </div>
-          </div>
-
-          <div class="form-group">
-            <label class="form-label">${this.t('description')}</label>
-            <textarea class="form-textarea" id="event-description" placeholder="${this.escapeHtmlAttribute(this.t('descriptionPlaceholder'))}">${this.escapeHtml(prefill?.description || '')}</textarea>
-          </div>
-
-          <div id="form-error" class="error-message" style="display: none;"></div>
-
-          <div class="form-actions">
-            <button type="button" class="btn btn-secondary" id="cancel-btn">${this.t('cancel')}</button>
-            <button type="submit" class="btn btn-primary" id="submit-btn">${this.t('createEvent')}</button>
-          </div>
-        </form>
-      </div>
-    `;
+    content.innerHTML = renderCreateEventForm({
+      writableCalendars,
+      selectedCalendarIds,
+      prefill,
+      startDate,
+      startTime,
+      endDate,
+      endTime,
+      recurrenceData,
+      isPrefilledRecurring,
+      isPrefilledAllDay,
+      recurrenceEndMode: this.getRecurrenceEndMode(recurrenceData),
+      recurrenceWeekdayOptions: this.getRecurrenceWeekdayOptions(),
+      helpers: {
+        escapeHtml: (value) => this.escapeHtml(value),
+        escapeHtmlAttribute: (value) => this.escapeHtmlAttribute(value),
+        getCalendarName: (entityId) => this.getCalendarName(entityId),
+        t: (key) => this.t(key)
+      }
+    });
 
     modal.classList.add('show');
 
@@ -11865,197 +12019,29 @@ class SkylightCalendarCard extends HTMLElement {
       : [];
     const visibleCalendarOptions = selectedCombinedCalendarIds.length > 0 ? selectedCombinedCalendarIds : writableCalendars;
 
-    // Format for datetime-local input
-    const formatDateTimeLocal = (date) => {
-      const year = date.getFullYear();
-      const month = String(date.getMonth() + 1).padStart(2, '0');
-      const day = String(date.getDate()).padStart(2, '0');
-      const hours = String(date.getHours()).padStart(2, '0');
-      const minutes = String(date.getMinutes()).padStart(2, '0');
-      return `${year}-${month}-${day}T${hours}:${minutes}`;
-    };
-
-    const formatDate = (date) => {
-      const year = date.getFullYear();
-      const month = String(date.getMonth() + 1).padStart(2, '0');
-      const day = String(date.getDate()).padStart(2, '0');
-      return `${year}-${month}-${day}`;
-    };
-
     const recurrenceData = this.parseRRule(event.rrule || '');
     const isRecurring = !!event.rrule;
     const isSingleOccurrenceEdit = editScope === 'this' && isRecurring;
     const recurringSelectedByDefault = isRecurring && !isSingleOccurrenceEdit;
 
-    content.innerHTML = `
-      <div class="modal-header">
-        <h3 class="modal-title">${this.t('editEvent')}</h3>
-        <button class="modal-close" id="close-modal">×</button>
-      </div>
-      <div class="modal-body">
-        <form id="edit-event-form">
-          <div class="form-group">
-            <label class="form-label">
-              ${this.t('calendar')}<span class="form-required">*</span>
-            </label>
-            <select class="form-select" id="event-calendar" required ${selectedCombinedCalendarIds.length > 1 ? 'disabled' : ''}>
-              ${visibleCalendarOptions.map((entityId) => `
-                <option value="${entityId}" ${entityId === event.entityId ? 'selected' : ''}>
-                  ${this.escapeHtml(this.getCalendarName(entityId))}
-                </option>
-              `).join('')}
-            </select>
-          </div>
-
-          <div class="form-group form-group-inline">
-            <div class="form-inline-row">
-              <label class="form-label">
-                ${this.t('eventTitle')}<span class="form-required">*</span>
-              </label>
-              <input type="text" class="form-input" id="event-title"
-                     placeholder="${this.escapeHtmlAttribute(this.t('eventTitlePlaceholder'))}"
-                     value="${this.escapeHtmlAttribute(event.summary || '')}" required />
-            </div>
-          </div>
-
-          <div class="form-group form-group-inline">
-            <div class="form-inline-row form-inline-row-top">
-              <label class="form-label">${this.t('eventOptions')}</label>
-              <div class="form-checkbox-row">
-                <div class="form-group">
-                  <div class="form-checkbox-group">
-                    <input type="checkbox" class="form-checkbox" id="event-all-day" ${isAllDay ? 'checked' : ''} />
-                    <label class="form-checkbox-label" for="event-all-day">${this.t('allDayEvent')}</label>
-                  </div>
-                </div>
-
-                <div class="form-group">
-                  <div class="form-checkbox-group">
-                    <input type="checkbox" class="form-checkbox" id="event-recurring" ${recurringSelectedByDefault ? 'checked' : ''} />
-                    <label class="form-checkbox-label" for="event-recurring">${this.t('recurring')}</label>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div id="recurring-event-fields" style="display: ${recurringSelectedByDefault ? 'block' : 'none'};">
-            <div class="form-row">
-              <div class="form-group form-group-inline">
-                <div class="form-inline-row">
-                  <label class="form-label">${this.t('recurrenceFrequency')}</label>
-                  <select class="form-select" id="event-recurrence-frequency">
-                  <option value="DAILY" ${recurrenceData.frequency === 'DAILY' ? 'selected' : ''}>${this.t('recurrenceDaily')}</option>
-                  <option value="WEEKLY" ${recurrenceData.frequency === 'WEEKLY' ? 'selected' : ''}>${this.t('recurrenceWeekly')}</option>
-                  <option value="MONTHLY" ${recurrenceData.frequency === 'MONTHLY' ? 'selected' : ''}>${this.t('recurrenceMonthly')}</option>
-                  <option value="YEARLY" ${recurrenceData.frequency === 'YEARLY' ? 'selected' : ''}>${this.t('recurrenceYearly')}</option>
-                </select>
-                </div>
-              </div>
-              <div class="form-group form-group-inline">
-                <div class="form-inline-row">
-                  <label class="form-label">${this.t('recurrenceEvery')}</label>
-                  <input type="number" class="form-input" id="event-recurrence-interval" min="1" value="${this.escapeHtmlAttribute(recurrenceData.interval || '1')}" />
-                </div>
-              </div>
-            </div>
-            <div class="form-group" id="event-recurrence-weekdays-group" style="display: ${recurringSelectedByDefault && recurrenceData.frequency === 'WEEKLY' ? 'block' : 'none'};">
-              <label class="form-label">${this.t('recurrenceWeekdays')}</label>
-              <div class="form-checkbox-group" style="flex-wrap: wrap; gap: 10px;">
-                ${this.getRecurrenceWeekdayOptions().map(day => `
-                  <label class="form-checkbox-label" style="display:flex;align-items:center;gap:6px;">
-                    <input type="checkbox" class="form-checkbox event-recurrence-weekday" value="${day.key}" ${recurrenceData.byDay.includes(day.key) ? 'checked' : ''} />
-                    <span>${day.label}</span>
-                  </label>
-                `).join('')}
-              </div>
-            </div>
-            <div class="form-group">
-              <label class="form-label recurrence-ends-label">${this.t('recurrenceEndsOn')}</label>
-              <div class="recurrence-end-row">
-                <label class="recurrence-end-option" for="event-recurrence-end-never">
-                  <input type="radio" name="event-recurrence-end-mode" id="event-recurrence-end-never" value="never" ${this.getRecurrenceEndMode(recurrenceData) === 'never' ? 'checked' : ''} />
-                  <span>${this.t('recurrenceNever')}</span>
-                </label>
-                <div></div>
-              </div>
-              <div class="recurrence-end-row">
-                <label class="recurrence-end-option" for="event-recurrence-end-on">
-                  <input type="radio" name="event-recurrence-end-mode" id="event-recurrence-end-on" value="on" ${this.getRecurrenceEndMode(recurrenceData) === 'on' ? 'checked' : ''} />
-                  <span>${this.t('recurrenceOn')}</span>
-                </label>
-                <input type="date" class="form-input" id="event-recurrence-until" value="${this.escapeHtmlAttribute(recurrenceData.untilDate || '')}" ${this.getRecurrenceEndMode(recurrenceData) === 'on' ? '' : 'disabled'} />
-              </div>
-              <div class="recurrence-end-row">
-                <label class="recurrence-end-option" for="event-recurrence-end-after">
-                  <input type="radio" name="event-recurrence-end-mode" id="event-recurrence-end-after" value="after" ${this.getRecurrenceEndMode(recurrenceData) === 'after' ? 'checked' : ''} />
-                  <span>${this.t('recurrenceAfter')}</span>
-                </label>
-                <div class="recurrence-after-input">
-                  <input type="number" class="form-input" id="event-recurrence-count" min="1" placeholder="13" value="${this.escapeHtmlAttribute(recurrenceData.count || '')}" ${this.getRecurrenceEndMode(recurrenceData) === 'after' ? '' : 'disabled'} />
-                  <span>${this.t('recurrenceOccurrences')}</span>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div id="timed-event-fields" style="display: ${isAllDay ? 'none' : 'block'};">
-            <div class="form-group form-group-inline">
-              <div class="form-inline-row">
-                <label class="form-label">${this.t('start')}</label>
-                <input type="datetime-local" class="form-input" id="event-start"
-                       value="${formatDateTimeLocal(startDate)}" required />
-              </div>
-            </div>
-
-            <div class="form-group form-group-inline">
-              <div class="form-inline-row">
-                <label class="form-label">${this.t('end')}</label>
-                <input type="datetime-local" class="form-input" id="event-end"
-                       value="${formatDateTimeLocal(endDate)}" />
-              </div>
-            </div>
-          </div>
-
-          <div id="all-day-event-fields" style="display: ${isAllDay ? 'block' : 'none'};">
-            <div class="form-row">
-              <div class="form-group">
-                <label class="form-label">${this.t('startDate')}</label>
-                <input type="date" class="form-input" id="event-start-date"
-                       value="${formatDate(startDate)}" />
-              </div>
-
-              <div class="form-group">
-                <label class="form-label">${this.t('endDate')}</label>
-                <input type="date" class="form-input" id="event-end-date"
-                       value="${formatDate(endDate)}" />
-              </div>
-            </div>
-          </div>
-
-          <div class="form-group form-group-inline">
-            <div class="form-inline-row">
-              <label class="form-label">${this.t('location')}</label>
-              <input type="text" class="form-input" id="event-location"
-                     placeholder="${this.escapeHtmlAttribute(this.t('locationPlaceholder'))}"
-                     value="${this.escapeHtmlAttribute(event.location || '')}" />
-            </div>
-          </div>
-
-          <div class="form-group">
-            <label class="form-label">${this.t('description')}</label>
-            <textarea class="form-textarea" id="event-description" placeholder="${this.escapeHtmlAttribute(this.t('descriptionPlaceholder'))}">${this.escapeHtml(event.description || '')}</textarea>
-          </div>
-
-          <div id="form-error" class="error-message" style="display: none;"></div>
-
-          <div class="form-actions">
-            <button type="button" class="btn btn-secondary" id="cancel-btn">${this.t('cancel')}</button>
-            <button type="submit" class="btn btn-primary" id="submit-btn">${this.t('saveChanges')}</button>
-          </div>
-        </form>
-      </div>
-    `;
+    content.innerHTML = renderEditEventForm({
+      event,
+      startDate,
+      endDate,
+      isAllDay,
+      visibleCalendarOptions,
+      selectedCombinedCalendarIds,
+      recurrenceData,
+      recurringSelectedByDefault,
+      recurrenceEndMode: this.getRecurrenceEndMode(recurrenceData),
+      recurrenceWeekdayOptions: this.getRecurrenceWeekdayOptions(),
+      helpers: {
+        escapeHtml: (value) => this.escapeHtml(value),
+        escapeHtmlAttribute: (value) => this.escapeHtmlAttribute(value),
+        getCalendarName: (entityId) => this.getCalendarName(entityId),
+        t: (key) => this.t(key)
+      }
+    });
 
     modal.classList.add('show');
 

--- a/src/renderers/event-form-renderer.js
+++ b/src/renderers/event-form-renderer.js
@@ -1,0 +1,323 @@
+function formatDateTimeLocal(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
+
+function formatDate(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function renderRecurrenceControls({
+  recurrenceData,
+  recurrenceEndMode,
+  recurrenceWeekdayOptions,
+  showRecurringFields,
+  showWeekdays,
+  helpers
+}) {
+  const { escapeHtmlAttribute, t } = helpers;
+
+  return `
+          <div id="recurring-event-fields" style="display: ${showRecurringFields ? 'block' : 'none'};">
+            <div class="form-row">
+              <div class="form-group form-group-inline">
+                <div class="form-inline-row">
+                  <label class="form-label">${t('recurrenceFrequency')}</label>
+                  <select class="form-select" id="event-recurrence-frequency">
+                  <option value="DAILY" ${recurrenceData.frequency === 'DAILY' ? 'selected' : ''}>${t('recurrenceDaily')}</option>
+                  <option value="WEEKLY" ${recurrenceData.frequency === 'WEEKLY' ? 'selected' : ''}>${t('recurrenceWeekly')}</option>
+                  <option value="MONTHLY" ${recurrenceData.frequency === 'MONTHLY' ? 'selected' : ''}>${t('recurrenceMonthly')}</option>
+                  <option value="YEARLY" ${recurrenceData.frequency === 'YEARLY' ? 'selected' : ''}>${t('recurrenceYearly')}</option>
+                  </select>
+                </div>
+              </div>
+              <div class="form-group form-group-inline">
+                <div class="form-inline-row">
+                  <label class="form-label">${t('recurrenceEvery')}</label>
+                  <input type="number" class="form-input" id="event-recurrence-interval" min="1" value="${escapeHtmlAttribute(recurrenceData.interval || '1')}" />
+                </div>
+              </div>
+            </div>
+            <div class="form-group" id="event-recurrence-weekdays-group" style="display: ${showWeekdays ? 'block' : 'none'};">
+              <label class="form-label">${t('recurrenceWeekdays')}</label>
+              <div class="form-checkbox-group" style="flex-wrap: wrap; gap: 10px;">
+                ${recurrenceWeekdayOptions.map(day => `
+                  <label class="form-checkbox-label" style="display:flex;align-items:center;gap:6px;">
+                    <input type="checkbox" class="form-checkbox event-recurrence-weekday" value="${day.key}" ${recurrenceData.byDay.includes(day.key) ? 'checked' : ''} />
+                    <span>${day.label}</span>
+                  </label>
+                `).join('')}
+              </div>
+            </div>
+            <div class="form-group">
+              <label class="form-label recurrence-ends-label">${t('recurrenceEndsOn')}</label>
+              <div class="recurrence-end-row">
+                <label class="recurrence-end-option" for="event-recurrence-end-never">
+                  <input type="radio" name="event-recurrence-end-mode" id="event-recurrence-end-never" value="never" ${recurrenceEndMode === 'never' ? 'checked' : ''} />
+                  <span>${t('recurrenceNever')}</span>
+                </label>
+                <div></div>
+              </div>
+              <div class="recurrence-end-row">
+                <label class="recurrence-end-option" for="event-recurrence-end-on">
+                  <input type="radio" name="event-recurrence-end-mode" id="event-recurrence-end-on" value="on" ${recurrenceEndMode === 'on' ? 'checked' : ''} />
+                  <span>${t('recurrenceOn')}</span>
+                </label>
+                <input type="date" class="form-input" id="event-recurrence-until" value="${escapeHtmlAttribute(recurrenceData.untilDate || '')}" ${recurrenceEndMode === 'on' ? '' : 'disabled'} />
+              </div>
+              <div class="recurrence-end-row">
+                <label class="recurrence-end-option" for="event-recurrence-end-after">
+                  <input type="radio" name="event-recurrence-end-mode" id="event-recurrence-end-after" value="after" ${recurrenceEndMode === 'after' ? 'checked' : ''} />
+                  <span>${t('recurrenceAfter')}</span>
+                </label>
+                <div class="recurrence-after-input">
+                  <input type="number" class="form-input" id="event-recurrence-count" min="1" placeholder="13" value="${escapeHtmlAttribute(recurrenceData.count || '')}" ${recurrenceEndMode === 'after' ? '' : 'disabled'} />
+                  <span>${t('recurrenceOccurrences')}</span>
+                </div>
+              </div>
+            </div>
+          </div>`;
+}
+
+function renderEventFields({
+  title,
+  location,
+  description,
+  startDate,
+  startTime,
+  endDate,
+  endTime,
+  isAllDay,
+  isRecurring,
+  recurrenceData,
+  recurrenceEndMode,
+  recurrenceWeekdayOptions,
+  helpers
+}) {
+  const { escapeHtml, escapeHtmlAttribute, t } = helpers;
+
+  return `
+          <div class="form-group form-group-inline">
+            <div class="form-inline-row">
+              <label class="form-label">
+                ${t('eventTitle')}<span class="form-required">*</span>
+              </label>
+              <input type="text" class="form-input" id="event-title" placeholder="${escapeHtmlAttribute(t('eventTitlePlaceholder'))}" value="${escapeHtmlAttribute(title || '')}" required />
+            </div>
+          </div>
+
+          <div class="form-group form-group-inline">
+            <div class="form-inline-row form-inline-row-top">
+              <label class="form-label">${t('eventOptions')}</label>
+              <div class="form-checkbox-row">
+                <div class="form-group">
+                  <div class="form-checkbox-group">
+                    <input type="checkbox" class="form-checkbox" id="event-all-day" ${isAllDay ? 'checked' : ''} />
+                    <label class="form-checkbox-label" for="event-all-day">${t('allDayEvent')}</label>
+                  </div>
+                </div>
+
+                <div class="form-group">
+                  <div class="form-checkbox-group">
+                    <input type="checkbox" class="form-checkbox" id="event-recurring" ${isRecurring ? 'checked' : ''} />
+                    <label class="form-checkbox-label" for="event-recurring">${t('recurring')}</label>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+${renderRecurrenceControls({
+    recurrenceData,
+    recurrenceEndMode,
+    recurrenceWeekdayOptions,
+    showRecurringFields: isRecurring,
+    showWeekdays: isRecurring && recurrenceData.frequency === 'WEEKLY',
+    helpers
+  })}
+
+          <div id="timed-event-fields" style="display: ${isAllDay ? 'none' : 'block'};">
+            <div class="form-group form-group-inline">
+              <div class="form-inline-row">
+                <label class="form-label">${t('start')}</label>
+                <input type="datetime-local" class="form-input" id="event-start"
+                       value="${formatDateTimeLocal(startTime)}" required />
+              </div>
+            </div>
+
+            <div class="form-group form-group-inline">
+              <div class="form-inline-row">
+                <label class="form-label">${t('end')}</label>
+                <input type="datetime-local" class="form-input" id="event-end"
+                       value="${formatDateTimeLocal(endTime)}" />
+              </div>
+            </div>
+          </div>
+
+          <div id="all-day-event-fields" style="display: ${isAllDay ? 'block' : 'none'};">
+            <div class="form-row">
+              <div class="form-group">
+                <label class="form-label">${t('startDate')}</label>
+                <input type="date" class="form-input" id="event-start-date"
+                       value="${formatDate(startDate)}" />
+              </div>
+
+              <div class="form-group">
+                <label class="form-label">${t('endDate')}</label>
+                <input type="date" class="form-input" id="event-end-date"
+                       value="${formatDate(endDate)}" />
+              </div>
+            </div>
+          </div>
+
+          <div class="form-group form-group-inline">
+            <div class="form-inline-row">
+              <label class="form-label">${t('location')}</label>
+              <input type="text" class="form-input" id="event-location" placeholder="${escapeHtmlAttribute(t('locationPlaceholder'))}" value="${escapeHtmlAttribute(location || '')}" />
+            </div>
+          </div>
+
+          <div class="form-group">
+            <label class="form-label">${t('description')}</label>
+            <textarea class="form-textarea" id="event-description" placeholder="${escapeHtmlAttribute(t('descriptionPlaceholder'))}">${escapeHtml(description || '')}</textarea>
+          </div>
+
+          <div id="form-error" class="error-message" style="display: none;"></div>`;
+}
+
+export function renderCreateEventForm({
+  writableCalendars,
+  selectedCalendarIds,
+  prefill,
+  startDate,
+  startTime,
+  endDate,
+  endTime,
+  recurrenceData,
+  isPrefilledRecurring,
+  isPrefilledAllDay,
+  recurrenceEndMode,
+  recurrenceWeekdayOptions,
+  helpers
+}) {
+  const { escapeHtml, getCalendarName, t } = helpers;
+
+  return `
+      <div class="modal-header">
+        <h3 class="modal-title">${t('createEvent')}</h3>
+        <button class="modal-close" id="close-modal">×</button>
+      </div>
+      <div class="modal-body">
+        <form id="create-event-form">
+          <div class="form-group form-group-inline">
+            <div class="form-inline-row">
+              <label class="form-label">
+                ${t('calendars')}<span class="form-required">*</span>
+              </label>
+              <div class="form-checkbox-grid">
+                ${writableCalendars.map((entityId, index) => `
+                  <label class="form-checkbox-group" style="margin: 0;">
+                    <input
+                      type="checkbox"
+                      class="form-checkbox create-event-calendar"
+                      value="${entityId}"
+                      ${(selectedCalendarIds.length > 0 ? selectedCalendarIds.includes(entityId) : index === 0) ? 'checked' : ''}
+                    />
+                    <span class="form-checkbox-label">${escapeHtml(getCalendarName(entityId))}</span>
+                  </label>
+                `).join('')}
+              </div>
+            </div>
+          </div>
+
+${renderEventFields({
+    title: prefill?.summary || '',
+    location: prefill?.location || '',
+    description: prefill?.description || '',
+    startDate,
+    startTime,
+    endDate,
+    endTime,
+    isAllDay: isPrefilledAllDay,
+    isRecurring: isPrefilledRecurring,
+    recurrenceData,
+    recurrenceEndMode,
+    recurrenceWeekdayOptions,
+    helpers
+  })}
+
+          <div class="form-actions">
+            <button type="button" class="btn btn-secondary" id="cancel-btn">${t('cancel')}</button>
+            <button type="submit" class="btn btn-primary" id="submit-btn">${t('createEvent')}</button>
+          </div>
+        </form>
+      </div>
+    `;
+}
+
+export function renderEditEventForm({
+  event,
+  startDate,
+  endDate,
+  isAllDay,
+  visibleCalendarOptions,
+  selectedCombinedCalendarIds,
+  recurrenceData,
+  recurringSelectedByDefault,
+  recurrenceEndMode,
+  recurrenceWeekdayOptions,
+  helpers
+}) {
+  const { escapeHtml, getCalendarName, t } = helpers;
+
+  return `
+      <div class="modal-header">
+        <h3 class="modal-title">${t('editEvent')}</h3>
+        <button class="modal-close" id="close-modal">×</button>
+      </div>
+      <div class="modal-body">
+        <form id="edit-event-form">
+          <div class="form-group">
+            <label class="form-label">
+              ${t('calendar')}<span class="form-required">*</span>
+            </label>
+            <select class="form-select" id="event-calendar" required ${selectedCombinedCalendarIds.length > 1 ? 'disabled' : ''}>
+              ${visibleCalendarOptions.map((entityId) => `
+                <option value="${entityId}" ${entityId === event.entityId ? 'selected' : ''}>
+                  ${escapeHtml(getCalendarName(entityId))}
+                </option>
+              `).join('')}
+            </select>
+          </div>
+
+${renderEventFields({
+    title: event.summary || '',
+    location: event.location || '',
+    description: event.description || '',
+    startDate,
+    startTime: startDate,
+    endDate,
+    endTime: endDate,
+    isAllDay,
+    isRecurring: recurringSelectedByDefault,
+    recurrenceData,
+    recurrenceEndMode,
+    recurrenceWeekdayOptions,
+    helpers
+  })}
+
+          <div class="form-actions">
+            <button type="button" class="btn btn-secondary" id="cancel-btn">${t('cancel')}</button>
+            <button type="submit" class="btn btn-primary" id="submit-btn">${t('saveChanges')}</button>
+          </div>
+        </form>
+      </div>
+    `;
+}

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -149,6 +149,7 @@ import {
 } from './views/agenda-view-model.js';
 import { renderAgendaView } from './renderers/agenda-renderer.js';
 import { renderEventDetailsModal } from './renderers/event-modal-renderer.js';
+import { renderCreateEventForm, renderEditEventForm } from './renderers/event-form-renderer.js';
 import { renderWeekCompactView } from './renderers/week-compact-renderer.js';
 import { renderWeekStandardView } from './renderers/week-standard-renderer.js';
 import {
@@ -8201,196 +8202,26 @@ class SkylightCalendarCard extends HTMLElement {
     const isPrefilledRecurring = !!prefill?.rrule;
     const isPrefilledAllDay = !!prefill?.isAllDay;
 
-    // Format for datetime-local input
-    const formatDateTimeLocal = (date) => {
-      const year = date.getFullYear();
-      const month = String(date.getMonth() + 1).padStart(2, '0');
-      const day = String(date.getDate()).padStart(2, '0');
-      const hours = String(date.getHours()).padStart(2, '0');
-      const minutes = String(date.getMinutes()).padStart(2, '0');
-      return `${year}-${month}-${day}T${hours}:${minutes}`;
-    };
-
-    const formatDate = (date) => {
-      const year = date.getFullYear();
-      const month = String(date.getMonth() + 1).padStart(2, '0');
-      const day = String(date.getDate()).padStart(2, '0');
-      return `${year}-${month}-${day}`;
-    };
-
-    content.innerHTML = `
-      <div class="modal-header">
-        <h3 class="modal-title">${this.t('createEvent')}</h3>
-        <button class="modal-close" id="close-modal">×</button>
-      </div>
-      <div class="modal-body">
-        <form id="create-event-form">
-          <div class="form-group form-group-inline">
-            <div class="form-inline-row">
-              <label class="form-label">
-                ${this.t('calendars')}<span class="form-required">*</span>
-              </label>
-              <div class="form-checkbox-grid">
-                ${writableCalendars.map((entityId, index) => `
-                  <label class="form-checkbox-group" style="margin: 0;">
-                    <input
-                      type="checkbox"
-                      class="form-checkbox create-event-calendar"
-                      value="${entityId}"
-                      ${(selectedCalendarIds.length > 0 ? selectedCalendarIds.includes(entityId) : index === 0) ? 'checked' : ''}
-                    />
-                    <span class="form-checkbox-label">${this.escapeHtml(this.getCalendarName(entityId))}</span>
-                  </label>
-                `).join('')}
-              </div>
-            </div>
-          </div>
-
-          <div class="form-group form-group-inline">
-            <div class="form-inline-row">
-              <label class="form-label">
-                ${this.t('eventTitle')}<span class="form-required">*</span>
-              </label>
-              <input type="text" class="form-input" id="event-title" placeholder="${this.escapeHtmlAttribute(this.t('eventTitlePlaceholder'))}" value="${this.escapeHtmlAttribute(prefill?.summary || '')}" required />
-            </div>
-          </div>
-
-          <div class="form-group form-group-inline">
-            <div class="form-inline-row form-inline-row-top">
-              <label class="form-label">${this.t('eventOptions')}</label>
-              <div class="form-checkbox-row">
-                <div class="form-group">
-                  <div class="form-checkbox-group">
-                    <input type="checkbox" class="form-checkbox" id="event-all-day" ${isPrefilledAllDay ? 'checked' : ''} />
-                    <label class="form-checkbox-label" for="event-all-day">${this.t('allDayEvent')}</label>
-                  </div>
-                </div>
-
-                <div class="form-group">
-                  <div class="form-checkbox-group">
-                    <input type="checkbox" class="form-checkbox" id="event-recurring" ${isPrefilledRecurring ? 'checked' : ''} />
-                    <label class="form-checkbox-label" for="event-recurring">${this.t('recurring')}</label>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div id="recurring-event-fields" style="display: ${isPrefilledRecurring ? 'block' : 'none'};">
-            <div class="form-row">
-              <div class="form-group form-group-inline">
-                <div class="form-inline-row">
-                  <label class="form-label">${this.t('recurrenceFrequency')}</label>
-                  <select class="form-select" id="event-recurrence-frequency">
-                  <option value="DAILY" ${recurrenceData.frequency === 'DAILY' ? 'selected' : ''}>${this.t('recurrenceDaily')}</option>
-                  <option value="WEEKLY" ${recurrenceData.frequency === 'WEEKLY' ? 'selected' : ''}>${this.t('recurrenceWeekly')}</option>
-                  <option value="MONTHLY" ${recurrenceData.frequency === 'MONTHLY' ? 'selected' : ''}>${this.t('recurrenceMonthly')}</option>
-                  <option value="YEARLY" ${recurrenceData.frequency === 'YEARLY' ? 'selected' : ''}>${this.t('recurrenceYearly')}</option>
-                  </select>
-                </div>
-              </div>
-              <div class="form-group form-group-inline">
-                <div class="form-inline-row">
-                  <label class="form-label">${this.t('recurrenceEvery')}</label>
-                  <input type="number" class="form-input" id="event-recurrence-interval" min="1" value="${this.escapeHtmlAttribute(recurrenceData.interval || '1')}" />
-                </div>
-              </div>
-            </div>
-            <div class="form-group" id="event-recurrence-weekdays-group" style="display: ${isPrefilledRecurring && recurrenceData.frequency === 'WEEKLY' ? 'block' : 'none'};">
-              <label class="form-label">${this.t('recurrenceWeekdays')}</label>
-              <div class="form-checkbox-group" style="flex-wrap: wrap; gap: 10px;">
-                ${this.getRecurrenceWeekdayOptions().map(day => `
-                  <label class="form-checkbox-label" style="display:flex;align-items:center;gap:6px;">
-                    <input type="checkbox" class="form-checkbox event-recurrence-weekday" value="${day.key}" ${recurrenceData.byDay.includes(day.key) ? 'checked' : ''} />
-                    <span>${day.label}</span>
-                  </label>
-                `).join('')}
-              </div>
-            </div>
-            <div class="form-group">
-              <label class="form-label recurrence-ends-label">${this.t('recurrenceEndsOn')}</label>
-              <div class="recurrence-end-row">
-                <label class="recurrence-end-option" for="event-recurrence-end-never">
-                  <input type="radio" name="event-recurrence-end-mode" id="event-recurrence-end-never" value="never" ${this.getRecurrenceEndMode(recurrenceData) === 'never' ? 'checked' : ''} />
-                  <span>${this.t('recurrenceNever')}</span>
-                </label>
-                <div></div>
-              </div>
-              <div class="recurrence-end-row">
-                <label class="recurrence-end-option" for="event-recurrence-end-on">
-                  <input type="radio" name="event-recurrence-end-mode" id="event-recurrence-end-on" value="on" ${this.getRecurrenceEndMode(recurrenceData) === 'on' ? 'checked' : ''} />
-                  <span>${this.t('recurrenceOn')}</span>
-                </label>
-                <input type="date" class="form-input" id="event-recurrence-until" value="${this.escapeHtmlAttribute(recurrenceData.untilDate || '')}" ${this.getRecurrenceEndMode(recurrenceData) === 'on' ? '' : 'disabled'} />
-              </div>
-              <div class="recurrence-end-row">
-                <label class="recurrence-end-option" for="event-recurrence-end-after">
-                  <input type="radio" name="event-recurrence-end-mode" id="event-recurrence-end-after" value="after" ${this.getRecurrenceEndMode(recurrenceData) === 'after' ? 'checked' : ''} />
-                  <span>${this.t('recurrenceAfter')}</span>
-                </label>
-                <div class="recurrence-after-input">
-                  <input type="number" class="form-input" id="event-recurrence-count" min="1" placeholder="13" value="${this.escapeHtmlAttribute(recurrenceData.count || '')}" ${this.getRecurrenceEndMode(recurrenceData) === 'after' ? '' : 'disabled'} />
-                  <span>${this.t('recurrenceOccurrences')}</span>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div id="timed-event-fields" style="display: ${isPrefilledAllDay ? 'none' : 'block'};">
-            <div class="form-group form-group-inline">
-              <div class="form-inline-row">
-                <label class="form-label">${this.t('start')}</label>
-                <input type="datetime-local" class="form-input" id="event-start"
-                       value="${formatDateTimeLocal(startTime)}" required />
-              </div>
-            </div>
-
-            <div class="form-group form-group-inline">
-              <div class="form-inline-row">
-                <label class="form-label">${this.t('end')}</label>
-                <input type="datetime-local" class="form-input" id="event-end"
-                       value="${formatDateTimeLocal(endTime)}" />
-              </div>
-            </div>
-          </div>
-
-          <div id="all-day-event-fields" style="display: ${isPrefilledAllDay ? 'block' : 'none'};">
-            <div class="form-row">
-              <div class="form-group">
-                <label class="form-label">${this.t('startDate')}</label>
-                <input type="date" class="form-input" id="event-start-date"
-                       value="${formatDate(startDate)}" />
-              </div>
-
-              <div class="form-group">
-                <label class="form-label">${this.t('endDate')}</label>
-                <input type="date" class="form-input" id="event-end-date"
-                       value="${formatDate(endDate)}" />
-              </div>
-            </div>
-          </div>
-
-          <div class="form-group form-group-inline">
-            <div class="form-inline-row">
-              <label class="form-label">${this.t('location')}</label>
-              <input type="text" class="form-input" id="event-location" placeholder="${this.escapeHtmlAttribute(this.t('locationPlaceholder'))}" value="${this.escapeHtmlAttribute(prefill?.location || '')}" />
-            </div>
-          </div>
-
-          <div class="form-group">
-            <label class="form-label">${this.t('description')}</label>
-            <textarea class="form-textarea" id="event-description" placeholder="${this.escapeHtmlAttribute(this.t('descriptionPlaceholder'))}">${this.escapeHtml(prefill?.description || '')}</textarea>
-          </div>
-
-          <div id="form-error" class="error-message" style="display: none;"></div>
-
-          <div class="form-actions">
-            <button type="button" class="btn btn-secondary" id="cancel-btn">${this.t('cancel')}</button>
-            <button type="submit" class="btn btn-primary" id="submit-btn">${this.t('createEvent')}</button>
-          </div>
-        </form>
-      </div>
-    `;
+    content.innerHTML = renderCreateEventForm({
+      writableCalendars,
+      selectedCalendarIds,
+      prefill,
+      startDate,
+      startTime,
+      endDate,
+      endTime,
+      recurrenceData,
+      isPrefilledRecurring,
+      isPrefilledAllDay,
+      recurrenceEndMode: this.getRecurrenceEndMode(recurrenceData),
+      recurrenceWeekdayOptions: this.getRecurrenceWeekdayOptions(),
+      helpers: {
+        escapeHtml: (value) => this.escapeHtml(value),
+        escapeHtmlAttribute: (value) => this.escapeHtmlAttribute(value),
+        getCalendarName: (entityId) => this.getCalendarName(entityId),
+        t: (key) => this.t(key)
+      }
+    });
 
     modal.classList.add('show');
 
@@ -8564,197 +8395,29 @@ class SkylightCalendarCard extends HTMLElement {
       : [];
     const visibleCalendarOptions = selectedCombinedCalendarIds.length > 0 ? selectedCombinedCalendarIds : writableCalendars;
 
-    // Format for datetime-local input
-    const formatDateTimeLocal = (date) => {
-      const year = date.getFullYear();
-      const month = String(date.getMonth() + 1).padStart(2, '0');
-      const day = String(date.getDate()).padStart(2, '0');
-      const hours = String(date.getHours()).padStart(2, '0');
-      const minutes = String(date.getMinutes()).padStart(2, '0');
-      return `${year}-${month}-${day}T${hours}:${minutes}`;
-    };
-
-    const formatDate = (date) => {
-      const year = date.getFullYear();
-      const month = String(date.getMonth() + 1).padStart(2, '0');
-      const day = String(date.getDate()).padStart(2, '0');
-      return `${year}-${month}-${day}`;
-    };
-
     const recurrenceData = this.parseRRule(event.rrule || '');
     const isRecurring = !!event.rrule;
     const isSingleOccurrenceEdit = editScope === 'this' && isRecurring;
     const recurringSelectedByDefault = isRecurring && !isSingleOccurrenceEdit;
 
-    content.innerHTML = `
-      <div class="modal-header">
-        <h3 class="modal-title">${this.t('editEvent')}</h3>
-        <button class="modal-close" id="close-modal">×</button>
-      </div>
-      <div class="modal-body">
-        <form id="edit-event-form">
-          <div class="form-group">
-            <label class="form-label">
-              ${this.t('calendar')}<span class="form-required">*</span>
-            </label>
-            <select class="form-select" id="event-calendar" required ${selectedCombinedCalendarIds.length > 1 ? 'disabled' : ''}>
-              ${visibleCalendarOptions.map((entityId) => `
-                <option value="${entityId}" ${entityId === event.entityId ? 'selected' : ''}>
-                  ${this.escapeHtml(this.getCalendarName(entityId))}
-                </option>
-              `).join('')}
-            </select>
-          </div>
-
-          <div class="form-group form-group-inline">
-            <div class="form-inline-row">
-              <label class="form-label">
-                ${this.t('eventTitle')}<span class="form-required">*</span>
-              </label>
-              <input type="text" class="form-input" id="event-title"
-                     placeholder="${this.escapeHtmlAttribute(this.t('eventTitlePlaceholder'))}"
-                     value="${this.escapeHtmlAttribute(event.summary || '')}" required />
-            </div>
-          </div>
-
-          <div class="form-group form-group-inline">
-            <div class="form-inline-row form-inline-row-top">
-              <label class="form-label">${this.t('eventOptions')}</label>
-              <div class="form-checkbox-row">
-                <div class="form-group">
-                  <div class="form-checkbox-group">
-                    <input type="checkbox" class="form-checkbox" id="event-all-day" ${isAllDay ? 'checked' : ''} />
-                    <label class="form-checkbox-label" for="event-all-day">${this.t('allDayEvent')}</label>
-                  </div>
-                </div>
-
-                <div class="form-group">
-                  <div class="form-checkbox-group">
-                    <input type="checkbox" class="form-checkbox" id="event-recurring" ${recurringSelectedByDefault ? 'checked' : ''} />
-                    <label class="form-checkbox-label" for="event-recurring">${this.t('recurring')}</label>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div id="recurring-event-fields" style="display: ${recurringSelectedByDefault ? 'block' : 'none'};">
-            <div class="form-row">
-              <div class="form-group form-group-inline">
-                <div class="form-inline-row">
-                  <label class="form-label">${this.t('recurrenceFrequency')}</label>
-                  <select class="form-select" id="event-recurrence-frequency">
-                  <option value="DAILY" ${recurrenceData.frequency === 'DAILY' ? 'selected' : ''}>${this.t('recurrenceDaily')}</option>
-                  <option value="WEEKLY" ${recurrenceData.frequency === 'WEEKLY' ? 'selected' : ''}>${this.t('recurrenceWeekly')}</option>
-                  <option value="MONTHLY" ${recurrenceData.frequency === 'MONTHLY' ? 'selected' : ''}>${this.t('recurrenceMonthly')}</option>
-                  <option value="YEARLY" ${recurrenceData.frequency === 'YEARLY' ? 'selected' : ''}>${this.t('recurrenceYearly')}</option>
-                </select>
-                </div>
-              </div>
-              <div class="form-group form-group-inline">
-                <div class="form-inline-row">
-                  <label class="form-label">${this.t('recurrenceEvery')}</label>
-                  <input type="number" class="form-input" id="event-recurrence-interval" min="1" value="${this.escapeHtmlAttribute(recurrenceData.interval || '1')}" />
-                </div>
-              </div>
-            </div>
-            <div class="form-group" id="event-recurrence-weekdays-group" style="display: ${recurringSelectedByDefault && recurrenceData.frequency === 'WEEKLY' ? 'block' : 'none'};">
-              <label class="form-label">${this.t('recurrenceWeekdays')}</label>
-              <div class="form-checkbox-group" style="flex-wrap: wrap; gap: 10px;">
-                ${this.getRecurrenceWeekdayOptions().map(day => `
-                  <label class="form-checkbox-label" style="display:flex;align-items:center;gap:6px;">
-                    <input type="checkbox" class="form-checkbox event-recurrence-weekday" value="${day.key}" ${recurrenceData.byDay.includes(day.key) ? 'checked' : ''} />
-                    <span>${day.label}</span>
-                  </label>
-                `).join('')}
-              </div>
-            </div>
-            <div class="form-group">
-              <label class="form-label recurrence-ends-label">${this.t('recurrenceEndsOn')}</label>
-              <div class="recurrence-end-row">
-                <label class="recurrence-end-option" for="event-recurrence-end-never">
-                  <input type="radio" name="event-recurrence-end-mode" id="event-recurrence-end-never" value="never" ${this.getRecurrenceEndMode(recurrenceData) === 'never' ? 'checked' : ''} />
-                  <span>${this.t('recurrenceNever')}</span>
-                </label>
-                <div></div>
-              </div>
-              <div class="recurrence-end-row">
-                <label class="recurrence-end-option" for="event-recurrence-end-on">
-                  <input type="radio" name="event-recurrence-end-mode" id="event-recurrence-end-on" value="on" ${this.getRecurrenceEndMode(recurrenceData) === 'on' ? 'checked' : ''} />
-                  <span>${this.t('recurrenceOn')}</span>
-                </label>
-                <input type="date" class="form-input" id="event-recurrence-until" value="${this.escapeHtmlAttribute(recurrenceData.untilDate || '')}" ${this.getRecurrenceEndMode(recurrenceData) === 'on' ? '' : 'disabled'} />
-              </div>
-              <div class="recurrence-end-row">
-                <label class="recurrence-end-option" for="event-recurrence-end-after">
-                  <input type="radio" name="event-recurrence-end-mode" id="event-recurrence-end-after" value="after" ${this.getRecurrenceEndMode(recurrenceData) === 'after' ? 'checked' : ''} />
-                  <span>${this.t('recurrenceAfter')}</span>
-                </label>
-                <div class="recurrence-after-input">
-                  <input type="number" class="form-input" id="event-recurrence-count" min="1" placeholder="13" value="${this.escapeHtmlAttribute(recurrenceData.count || '')}" ${this.getRecurrenceEndMode(recurrenceData) === 'after' ? '' : 'disabled'} />
-                  <span>${this.t('recurrenceOccurrences')}</span>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div id="timed-event-fields" style="display: ${isAllDay ? 'none' : 'block'};">
-            <div class="form-group form-group-inline">
-              <div class="form-inline-row">
-                <label class="form-label">${this.t('start')}</label>
-                <input type="datetime-local" class="form-input" id="event-start"
-                       value="${formatDateTimeLocal(startDate)}" required />
-              </div>
-            </div>
-
-            <div class="form-group form-group-inline">
-              <div class="form-inline-row">
-                <label class="form-label">${this.t('end')}</label>
-                <input type="datetime-local" class="form-input" id="event-end"
-                       value="${formatDateTimeLocal(endDate)}" />
-              </div>
-            </div>
-          </div>
-
-          <div id="all-day-event-fields" style="display: ${isAllDay ? 'block' : 'none'};">
-            <div class="form-row">
-              <div class="form-group">
-                <label class="form-label">${this.t('startDate')}</label>
-                <input type="date" class="form-input" id="event-start-date"
-                       value="${formatDate(startDate)}" />
-              </div>
-
-              <div class="form-group">
-                <label class="form-label">${this.t('endDate')}</label>
-                <input type="date" class="form-input" id="event-end-date"
-                       value="${formatDate(endDate)}" />
-              </div>
-            </div>
-          </div>
-
-          <div class="form-group form-group-inline">
-            <div class="form-inline-row">
-              <label class="form-label">${this.t('location')}</label>
-              <input type="text" class="form-input" id="event-location"
-                     placeholder="${this.escapeHtmlAttribute(this.t('locationPlaceholder'))}"
-                     value="${this.escapeHtmlAttribute(event.location || '')}" />
-            </div>
-          </div>
-
-          <div class="form-group">
-            <label class="form-label">${this.t('description')}</label>
-            <textarea class="form-textarea" id="event-description" placeholder="${this.escapeHtmlAttribute(this.t('descriptionPlaceholder'))}">${this.escapeHtml(event.description || '')}</textarea>
-          </div>
-
-          <div id="form-error" class="error-message" style="display: none;"></div>
-
-          <div class="form-actions">
-            <button type="button" class="btn btn-secondary" id="cancel-btn">${this.t('cancel')}</button>
-            <button type="submit" class="btn btn-primary" id="submit-btn">${this.t('saveChanges')}</button>
-          </div>
-        </form>
-      </div>
-    `;
+    content.innerHTML = renderEditEventForm({
+      event,
+      startDate,
+      endDate,
+      isAllDay,
+      visibleCalendarOptions,
+      selectedCombinedCalendarIds,
+      recurrenceData,
+      recurringSelectedByDefault,
+      recurrenceEndMode: this.getRecurrenceEndMode(recurrenceData),
+      recurrenceWeekdayOptions: this.getRecurrenceWeekdayOptions(),
+      helpers: {
+        escapeHtml: (value) => this.escapeHtml(value),
+        escapeHtmlAttribute: (value) => this.escapeHtmlAttribute(value),
+        getCalendarName: (entityId) => this.getCalendarName(entityId),
+        t: (key) => this.t(key)
+      }
+    });
 
     modal.classList.add('show');
 


### PR DESCRIPTION
### Motivation
- Move the create/edit event modal form HTML composition out of the main card into a dedicated renderer to continue Phase 21 modularization while preserving runtime behavior and DOM output.
- Keep behavioral logic (modal lifecycle, focus, event listeners, validation, submission, recurrence/service orchestration) in the main card because those pieces query/mutate live DOM and own runtime state.

### Description
- Added `src/renderers/event-form-renderer.js` which exports `renderCreateEventForm` and `renderEditEventForm` and smaller helpers (`renderRecurrenceControls`, shared field rendering and date formatting) that produce the exact form HTML/IDs/classes/inputs used today.
- Updated `src/skylight-calendar-card.js` to import and call `renderCreateEventForm` / `renderEditEventForm` with explicit inputs and narrow helper callbacks (`escapeHtml`, `escapeHtmlAttribute`, `getCalendarName`, `t`) instead of passing the card instance; kept all DOM IDs, class names, data attributes, input names/types, and ordering unchanged.
- Intentionally left in `src/skylight-calendar-card.js` the modal lifecycle, focus management, keyboard/click handlers, event listener attachment, validation execution and error display, form submit handlers, recurrence orchestration, and Home Assistant create/update/delete service behavior.

### Testing
- Ran `npm ci --no-audit --fund=false`, `npm run build`, `node --check` on changed files, `npm test`, and `npm run test:visual`; all steps completed and the test suites passed.
- Rollup regenerated the root `skylight-calendar-card.js` artifact as part of the build and the generated artifact was updated to match the source changes.
- Visual tests produced no snapshot differences and the visual test suite passed without updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c65176cec8331a23f898d1af2178e)