### PR TITLE
Extract calendar badge renderer

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3094,6 +3094,93 @@ function renderEventDetailsModal({
     `;
 }
 
+function renderCalendarBadges({ badgeItems, hideCalendarNames = false, helpers }) {
+  if (badgeItems.length === 0) return '';
+
+  return `
+      <div class="calendar-badges-container">
+        <div class="calendar-badges">
+          ${badgeItems.map((badgeItem) => renderCalendarBadge({
+            badgeItem,
+            hideCalendarNames,
+            inline: false,
+            helpers
+          })).join('')}
+        </div>
+      </div>
+    `;
+}
+
+function renderCalendarBadgesInline({ badgeItems, hideCalendarNames = false, helpers }) {
+  if (badgeItems.length === 0) return '';
+
+  return `
+      <div class="calendar-badges-inline">
+        ${badgeItems.map((badgeItem) => renderCalendarBadge({
+          badgeItem,
+          hideCalendarNames,
+          inline: true,
+          helpers
+        })).join('')}
+      </div>
+    `;
+}
+
+function renderCalendarBadge({ badgeItem, hideCalendarNames, inline, helpers }) {
+  const badgeBackground = badgeItem.isHidden ? '#f3f4f6' : helpers.lightenColor(badgeItem.color, 0.85);
+  const badgeTextColor = badgeItem.isHidden ? '#9ca3af' : helpers.getContractColor(badgeBackground);
+  const inlineClass = inline ? ' calendar-badge-inline' : '';
+  const cursorStyle = inline ? '' : '\n                          cursor: pointer;';
+
+  return `
+            <div class="calendar-badge${inlineClass} ${badgeItem.isHidden ? 'calendar-badge-hidden' : ''} ${hideCalendarNames ? 'hide-calendar-name' : ''}"
+                 data-entity="${badgeItem.entityId}"
+                 style="background: ${badgeBackground};
+                        border-color: ${badgeItem.isHidden ? '#d1d5db' : badgeItem.color};${cursorStyle}">
+              ${renderCalendarBadgeIcon({
+                entityId: badgeItem.entityId,
+                name: badgeItem.name,
+                color: badgeItem.color,
+                isHidden: badgeItem.isHidden,
+                iconOverride: badgeItem.icon,
+                helpers
+              })}
+              ${hideCalendarNames ? '' : renderCalendarBadgeLabel({ badgeItem, badgeTextColor, helpers })}
+            </div>
+          `;
+}
+
+function renderCalendarBadgeLabel({ badgeItem, badgeTextColor, helpers }) {
+  const personStateLabel = helpers.formatPersonStateLabel(helpers.getCalendarBadgePersonState(badgeItem.entityId));
+  return `
+      <span class="calendar-badge-label" style="color: ${badgeTextColor}">
+        <span class="calendar-badge-name">${helpers.escapeHtml(badgeItem.name)}</span>
+        ${personStateLabel ? `<span class="calendar-badge-person-state">${helpers.escapeHtml(personStateLabel)}</span>` : ''}
+      </span>
+    `;
+}
+
+function renderCalendarBadgeIcon({ entityId, name, color, isHidden, iconOverride = null, helpers }) {
+  const configuredBadgeIcon = iconOverride || helpers.getCalendarBadgeIcon(entityId);
+  const hasPersonEntity = !!helpers.getCalendarBadgePersonEntityId(entityId);
+  const personPictureUrl = configuredBadgeIcon ? null : helpers.getPersonEntityPictureUrl(helpers.getCalendarBadgePersonState(entityId));
+  const iconBackground = isHidden ? '#9ca3af' : helpers.normalizeSingleColor(color);
+  const personIconClass = hasPersonEntity ? ' calendar-badge-person-icon' : '';
+
+  if (configuredBadgeIcon && configuredBadgeIcon.startsWith('mdi:')) {
+    return `<div class="calendar-badge-icon${personIconClass}" style="background: ${iconBackground}"><ha-icon icon="${helpers.escapeHtml(configuredBadgeIcon)}"></ha-icon></div>`;
+  }
+
+  if (configuredBadgeIcon || personPictureUrl) {
+    const imageUrl = configuredBadgeIcon || personPictureUrl;
+    const normalizedUrl = helpers.normalizeBackgroundImageUrl(imageUrl) || imageUrl;
+    return `<div class="calendar-badge-icon calendar-badge-photo${personIconClass}" style="background: ${iconBackground}"><img src="${helpers.escapeHtml(normalizedUrl)}" alt="${helpers.escapeHtml(name)}" loading="lazy"></div>`;
+  }
+
+  const initial = name.charAt(0).toUpperCase();
+  return `<div class="calendar-badge-icon${personIconClass}" style="background: ${iconBackground}">${helpers.escapeHtml(initial)}</div>`;
+}
+
 function formatDateTimeLocal(date) {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0');
@@ -9336,29 +9423,27 @@ class SkylightCalendarCard extends HTMLElement {
     `;
   }
 
+  getCalendarBadgeRenderHelpers() {
+    return {
+      escapeHtml: (value) => this.escapeHtml(value),
+      formatPersonStateLabel: (state) => this.formatPersonStateLabel(state),
+      getCalendarBadgeIcon: (entityId) => this.getCalendarBadgeIcon(entityId),
+      getCalendarBadgePersonEntityId: (entityId) => this.getCalendarBadgePersonEntityId(entityId),
+      getCalendarBadgePersonState: (entityId) => this.getCalendarBadgePersonState(entityId),
+      getContractColor: (color) => this.getContractColor(color),
+      getPersonEntityPictureUrl: (state) => this.getPersonEntityPictureUrl(state),
+      lightenColor: (color, amount) => this.lightenColor(color, amount),
+      normalizeBackgroundImageUrl: (url) => this.normalizeBackgroundImageUrl(url),
+      normalizeSingleColor: (color) => this.normalizeSingleColor(color)
+    };
+  }
+
   renderCalendarBadgesInline() {
-    const badgeItems = this.getVirtualBadgeItems();
-    if (badgeItems.length === 0) return '';
-    const hideCalendarNames = !!this._config.hide_calendar_names;
-
-    return `
-      <div class="calendar-badges-inline">
-        ${badgeItems.map((badgeItem) => {
-          const badgeBackground = badgeItem.isHidden ? '#f3f4f6' : this.lightenColor(badgeItem.color, 0.85);
-          const badgeTextColor = badgeItem.isHidden ? '#9ca3af' : this.getContractColor(badgeBackground);
-
-          return `
-            <div class="calendar-badge calendar-badge-inline ${badgeItem.isHidden ? 'calendar-badge-hidden' : ''} ${hideCalendarNames ? 'hide-calendar-name' : ''}"
-                 data-entity="${badgeItem.entityId}"
-                 style="background: ${badgeBackground};
-                        border-color: ${badgeItem.isHidden ? '#d1d5db' : badgeItem.color};">
-              ${this.renderCalendarBadgeIcon(badgeItem.entityId, badgeItem.name, badgeItem.color, badgeItem.isHidden, badgeItem.icon)}
-              ${hideCalendarNames ? '' : this.renderCalendarBadgeLabel(badgeItem, badgeTextColor)}
-            </div>
-          `;
-        }).join('')}
-      </div>
-    `;
+    return renderCalendarBadgesInline({
+      badgeItems: this.getVirtualBadgeItems(),
+      hideCalendarNames: !!this._config.hide_calendar_names,
+      helpers: this.getCalendarBadgeRenderHelpers()
+    });
   }
 
   renderHeaderTitle() {
@@ -9832,31 +9917,11 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   renderCalendarBadges() {
-    const badgeItems = this.getVirtualBadgeItems();
-    if (badgeItems.length === 0) return '';
-    const hideCalendarNames = !!this._config.hide_calendar_names;
-
-    return `
-      <div class="calendar-badges-container">
-        <div class="calendar-badges">
-          ${badgeItems.map((badgeItem) => {
-            const badgeBackground = badgeItem.isHidden ? '#f3f4f6' : this.lightenColor(badgeItem.color, 0.85);
-            const badgeTextColor = badgeItem.isHidden ? '#9ca3af' : this.getContractColor(badgeBackground);
-
-            return `
-              <div class="calendar-badge ${badgeItem.isHidden ? 'calendar-badge-hidden' : ''} ${hideCalendarNames ? 'hide-calendar-name' : ''}"
-                   data-entity="${badgeItem.entityId}"
-                   style="background: ${badgeBackground};
-                          border-color: ${badgeItem.isHidden ? '#d1d5db' : badgeItem.color};
-                          cursor: pointer;">
-                ${this.renderCalendarBadgeIcon(badgeItem.entityId, badgeItem.name, badgeItem.color, badgeItem.isHidden, badgeItem.icon)}
-                ${hideCalendarNames ? '' : this.renderCalendarBadgeLabel(badgeItem, badgeTextColor)}
-              </div>
-            `;
-          }).join('')}
-        </div>
-      </div>
-    `;
+    return renderCalendarBadges({
+      badgeItems: this.getVirtualBadgeItems(),
+      hideCalendarNames: !!this._config.hide_calendar_names,
+      helpers: this.getCalendarBadgeRenderHelpers()
+    });
   }
 
   renderAllDayEventsForDay(allDayLanes, allDayHeight) {
@@ -13336,34 +13401,22 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   renderCalendarBadgeLabel(badgeItem, badgeTextColor) {
-    const personStateLabel = this.formatPersonStateLabel(this.getCalendarBadgePersonState(badgeItem.entityId));
-    return `
-      <span class="calendar-badge-label" style="color: ${badgeTextColor}">
-        <span class="calendar-badge-name">${this.escapeHtml(badgeItem.name)}</span>
-        ${personStateLabel ? `<span class="calendar-badge-person-state">${this.escapeHtml(personStateLabel)}</span>` : ''}
-      </span>
-    `;
+    return renderCalendarBadgeLabel({
+      badgeItem,
+      badgeTextColor,
+      helpers: this.getCalendarBadgeRenderHelpers()
+    });
   }
 
   renderCalendarBadgeIcon(entityId, name, color, isHidden, iconOverride = null) {
-    const configuredBadgeIcon = iconOverride || this.getCalendarBadgeIcon(entityId);
-    const hasPersonEntity = !!this.getCalendarBadgePersonEntityId(entityId);
-    const personPictureUrl = configuredBadgeIcon ? null : this.getPersonEntityPictureUrl(this.getCalendarBadgePersonState(entityId));
-    const iconBackground = isHidden ? '#9ca3af' : this.normalizeSingleColor(color);
-    const personIconClass = hasPersonEntity ? ' calendar-badge-person-icon' : '';
-
-    if (configuredBadgeIcon && configuredBadgeIcon.startsWith('mdi:')) {
-      return `<div class="calendar-badge-icon${personIconClass}" style="background: ${iconBackground}"><ha-icon icon="${this.escapeHtml(configuredBadgeIcon)}"></ha-icon></div>`;
-    }
-
-    if (configuredBadgeIcon || personPictureUrl) {
-      const imageUrl = configuredBadgeIcon || personPictureUrl;
-      const normalizedUrl = this.normalizeBackgroundImageUrl(imageUrl) || imageUrl;
-      return `<div class="calendar-badge-icon calendar-badge-photo${personIconClass}" style="background: ${iconBackground}"><img src="${this.escapeHtml(normalizedUrl)}" alt="${this.escapeHtml(name)}" loading="lazy"></div>`;
-    }
-
-    const initial = name.charAt(0).toUpperCase();
-    return `<div class="calendar-badge-icon${personIconClass}" style="background: ${iconBackground}">${this.escapeHtml(initial)}</div>`;
+    return renderCalendarBadgeIcon({
+      entityId,
+      name,
+      color,
+      isHidden,
+      iconOverride,
+      helpers: this.getCalendarBadgeRenderHelpers()
+    });
   }
 
   renderEventDescription(description) {

--- a/src/renderers/calendar-badge-renderer.js
+++ b/src/renderers/calendar-badge-renderer.js
@@ -1,0 +1,86 @@
+export function renderCalendarBadges({ badgeItems, hideCalendarNames = false, helpers }) {
+  if (badgeItems.length === 0) return '';
+
+  return `
+      <div class="calendar-badges-container">
+        <div class="calendar-badges">
+          ${badgeItems.map((badgeItem) => renderCalendarBadge({
+            badgeItem,
+            hideCalendarNames,
+            inline: false,
+            helpers
+          })).join('')}
+        </div>
+      </div>
+    `;
+}
+
+export function renderCalendarBadgesInline({ badgeItems, hideCalendarNames = false, helpers }) {
+  if (badgeItems.length === 0) return '';
+
+  return `
+      <div class="calendar-badges-inline">
+        ${badgeItems.map((badgeItem) => renderCalendarBadge({
+          badgeItem,
+          hideCalendarNames,
+          inline: true,
+          helpers
+        })).join('')}
+      </div>
+    `;
+}
+
+function renderCalendarBadge({ badgeItem, hideCalendarNames, inline, helpers }) {
+  const badgeBackground = badgeItem.isHidden ? '#f3f4f6' : helpers.lightenColor(badgeItem.color, 0.85);
+  const badgeTextColor = badgeItem.isHidden ? '#9ca3af' : helpers.getContractColor(badgeBackground);
+  const inlineClass = inline ? ' calendar-badge-inline' : '';
+  const cursorStyle = inline ? '' : '\n                          cursor: pointer;';
+
+  return `
+            <div class="calendar-badge${inlineClass} ${badgeItem.isHidden ? 'calendar-badge-hidden' : ''} ${hideCalendarNames ? 'hide-calendar-name' : ''}"
+                 data-entity="${badgeItem.entityId}"
+                 style="background: ${badgeBackground};
+                        border-color: ${badgeItem.isHidden ? '#d1d5db' : badgeItem.color};${cursorStyle}">
+              ${renderCalendarBadgeIcon({
+                entityId: badgeItem.entityId,
+                name: badgeItem.name,
+                color: badgeItem.color,
+                isHidden: badgeItem.isHidden,
+                iconOverride: badgeItem.icon,
+                helpers
+              })}
+              ${hideCalendarNames ? '' : renderCalendarBadgeLabel({ badgeItem, badgeTextColor, helpers })}
+            </div>
+          `;
+}
+
+export function renderCalendarBadgeLabel({ badgeItem, badgeTextColor, helpers }) {
+  const personStateLabel = helpers.formatPersonStateLabel(helpers.getCalendarBadgePersonState(badgeItem.entityId));
+  return `
+      <span class="calendar-badge-label" style="color: ${badgeTextColor}">
+        <span class="calendar-badge-name">${helpers.escapeHtml(badgeItem.name)}</span>
+        ${personStateLabel ? `<span class="calendar-badge-person-state">${helpers.escapeHtml(personStateLabel)}</span>` : ''}
+      </span>
+    `;
+}
+
+export function renderCalendarBadgeIcon({ entityId, name, color, isHidden, iconOverride = null, helpers }) {
+  const configuredBadgeIcon = iconOverride || helpers.getCalendarBadgeIcon(entityId);
+  const hasPersonEntity = !!helpers.getCalendarBadgePersonEntityId(entityId);
+  const personPictureUrl = configuredBadgeIcon ? null : helpers.getPersonEntityPictureUrl(helpers.getCalendarBadgePersonState(entityId));
+  const iconBackground = isHidden ? '#9ca3af' : helpers.normalizeSingleColor(color);
+  const personIconClass = hasPersonEntity ? ' calendar-badge-person-icon' : '';
+
+  if (configuredBadgeIcon && configuredBadgeIcon.startsWith('mdi:')) {
+    return `<div class="calendar-badge-icon${personIconClass}" style="background: ${iconBackground}"><ha-icon icon="${helpers.escapeHtml(configuredBadgeIcon)}"></ha-icon></div>`;
+  }
+
+  if (configuredBadgeIcon || personPictureUrl) {
+    const imageUrl = configuredBadgeIcon || personPictureUrl;
+    const normalizedUrl = helpers.normalizeBackgroundImageUrl(imageUrl) || imageUrl;
+    return `<div class="calendar-badge-icon calendar-badge-photo${personIconClass}" style="background: ${iconBackground}"><img src="${helpers.escapeHtml(normalizedUrl)}" alt="${helpers.escapeHtml(name)}" loading="lazy"></div>`;
+  }
+
+  const initial = name.charAt(0).toUpperCase();
+  return `<div class="calendar-badge-icon${personIconClass}" style="background: ${iconBackground}">${helpers.escapeHtml(initial)}</div>`;
+}

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -149,6 +149,12 @@ import {
 } from './views/agenda-view-model.js';
 import { renderAgendaView } from './renderers/agenda-renderer.js';
 import { renderEventDetailsModal } from './renderers/event-modal-renderer.js';
+import {
+  renderCalendarBadgeIcon as renderCalendarBadgeIconMarkup,
+  renderCalendarBadgeLabel as renderCalendarBadgeLabelMarkup,
+  renderCalendarBadges as renderCalendarBadgesMarkup,
+  renderCalendarBadgesInline as renderCalendarBadgesInlineMarkup
+} from './renderers/calendar-badge-renderer.js';
 import { renderCreateEventForm, renderEditEventForm } from './renderers/event-form-renderer.js';
 import { renderWeekCompactView } from './renderers/week-compact-renderer.js';
 import { renderWeekStandardView } from './renderers/week-standard-renderer.js';
@@ -5712,29 +5718,27 @@ class SkylightCalendarCard extends HTMLElement {
     `;
   }
 
+  getCalendarBadgeRenderHelpers() {
+    return {
+      escapeHtml: (value) => this.escapeHtml(value),
+      formatPersonStateLabel: (state) => this.formatPersonStateLabel(state),
+      getCalendarBadgeIcon: (entityId) => this.getCalendarBadgeIcon(entityId),
+      getCalendarBadgePersonEntityId: (entityId) => this.getCalendarBadgePersonEntityId(entityId),
+      getCalendarBadgePersonState: (entityId) => this.getCalendarBadgePersonState(entityId),
+      getContractColor: (color) => this.getContractColor(color),
+      getPersonEntityPictureUrl: (state) => this.getPersonEntityPictureUrl(state),
+      lightenColor: (color, amount) => this.lightenColor(color, amount),
+      normalizeBackgroundImageUrl: (url) => this.normalizeBackgroundImageUrl(url),
+      normalizeSingleColor: (color) => this.normalizeSingleColor(color)
+    };
+  }
+
   renderCalendarBadgesInline() {
-    const badgeItems = this.getVirtualBadgeItems();
-    if (badgeItems.length === 0) return '';
-    const hideCalendarNames = !!this._config.hide_calendar_names;
-
-    return `
-      <div class="calendar-badges-inline">
-        ${badgeItems.map((badgeItem) => {
-          const badgeBackground = badgeItem.isHidden ? '#f3f4f6' : this.lightenColor(badgeItem.color, 0.85);
-          const badgeTextColor = badgeItem.isHidden ? '#9ca3af' : this.getContractColor(badgeBackground);
-
-          return `
-            <div class="calendar-badge calendar-badge-inline ${badgeItem.isHidden ? 'calendar-badge-hidden' : ''} ${hideCalendarNames ? 'hide-calendar-name' : ''}"
-                 data-entity="${badgeItem.entityId}"
-                 style="background: ${badgeBackground};
-                        border-color: ${badgeItem.isHidden ? '#d1d5db' : badgeItem.color};">
-              ${this.renderCalendarBadgeIcon(badgeItem.entityId, badgeItem.name, badgeItem.color, badgeItem.isHidden, badgeItem.icon)}
-              ${hideCalendarNames ? '' : this.renderCalendarBadgeLabel(badgeItem, badgeTextColor)}
-            </div>
-          `;
-        }).join('')}
-      </div>
-    `;
+    return renderCalendarBadgesInlineMarkup({
+      badgeItems: this.getVirtualBadgeItems(),
+      hideCalendarNames: !!this._config.hide_calendar_names,
+      helpers: this.getCalendarBadgeRenderHelpers()
+    });
   }
 
   renderHeaderTitle() {
@@ -6208,31 +6212,11 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   renderCalendarBadges() {
-    const badgeItems = this.getVirtualBadgeItems();
-    if (badgeItems.length === 0) return '';
-    const hideCalendarNames = !!this._config.hide_calendar_names;
-
-    return `
-      <div class="calendar-badges-container">
-        <div class="calendar-badges">
-          ${badgeItems.map((badgeItem) => {
-            const badgeBackground = badgeItem.isHidden ? '#f3f4f6' : this.lightenColor(badgeItem.color, 0.85);
-            const badgeTextColor = badgeItem.isHidden ? '#9ca3af' : this.getContractColor(badgeBackground);
-
-            return `
-              <div class="calendar-badge ${badgeItem.isHidden ? 'calendar-badge-hidden' : ''} ${hideCalendarNames ? 'hide-calendar-name' : ''}"
-                   data-entity="${badgeItem.entityId}"
-                   style="background: ${badgeBackground};
-                          border-color: ${badgeItem.isHidden ? '#d1d5db' : badgeItem.color};
-                          cursor: pointer;">
-                ${this.renderCalendarBadgeIcon(badgeItem.entityId, badgeItem.name, badgeItem.color, badgeItem.isHidden, badgeItem.icon)}
-                ${hideCalendarNames ? '' : this.renderCalendarBadgeLabel(badgeItem, badgeTextColor)}
-              </div>
-            `;
-          }).join('')}
-        </div>
-      </div>
-    `;
+    return renderCalendarBadgesMarkup({
+      badgeItems: this.getVirtualBadgeItems(),
+      hideCalendarNames: !!this._config.hide_calendar_names,
+      helpers: this.getCalendarBadgeRenderHelpers()
+    });
   }
 
   renderAllDayEventsForDay(allDayLanes, allDayHeight) {
@@ -9712,34 +9696,22 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   renderCalendarBadgeLabel(badgeItem, badgeTextColor) {
-    const personStateLabel = this.formatPersonStateLabel(this.getCalendarBadgePersonState(badgeItem.entityId));
-    return `
-      <span class="calendar-badge-label" style="color: ${badgeTextColor}">
-        <span class="calendar-badge-name">${this.escapeHtml(badgeItem.name)}</span>
-        ${personStateLabel ? `<span class="calendar-badge-person-state">${this.escapeHtml(personStateLabel)}</span>` : ''}
-      </span>
-    `;
+    return renderCalendarBadgeLabelMarkup({
+      badgeItem,
+      badgeTextColor,
+      helpers: this.getCalendarBadgeRenderHelpers()
+    });
   }
 
   renderCalendarBadgeIcon(entityId, name, color, isHidden, iconOverride = null) {
-    const configuredBadgeIcon = iconOverride || this.getCalendarBadgeIcon(entityId);
-    const hasPersonEntity = !!this.getCalendarBadgePersonEntityId(entityId);
-    const personPictureUrl = configuredBadgeIcon ? null : this.getPersonEntityPictureUrl(this.getCalendarBadgePersonState(entityId));
-    const iconBackground = isHidden ? '#9ca3af' : this.normalizeSingleColor(color);
-    const personIconClass = hasPersonEntity ? ' calendar-badge-person-icon' : '';
-
-    if (configuredBadgeIcon && configuredBadgeIcon.startsWith('mdi:')) {
-      return `<div class="calendar-badge-icon${personIconClass}" style="background: ${iconBackground}"><ha-icon icon="${this.escapeHtml(configuredBadgeIcon)}"></ha-icon></div>`;
-    }
-
-    if (configuredBadgeIcon || personPictureUrl) {
-      const imageUrl = configuredBadgeIcon || personPictureUrl;
-      const normalizedUrl = this.normalizeBackgroundImageUrl(imageUrl) || imageUrl;
-      return `<div class="calendar-badge-icon calendar-badge-photo${personIconClass}" style="background: ${iconBackground}"><img src="${this.escapeHtml(normalizedUrl)}" alt="${this.escapeHtml(name)}" loading="lazy"></div>`;
-    }
-
-    const initial = name.charAt(0).toUpperCase();
-    return `<div class="calendar-badge-icon${personIconClass}" style="background: ${iconBackground}">${this.escapeHtml(initial)}</div>`;
+    return renderCalendarBadgeIconMarkup({
+      entityId,
+      name,
+      color,
+      isHidden,
+      iconOverride,
+      helpers: this.getCalendarBadgeRenderHelpers()
+    });
   }
 
   renderEventDescription(description) {


### PR DESCRIPTION
### Motivation
- Separate calendar badge HTML/string composition into its own renderer to continue the ongoing modularization while preserving runtime and visual behavior.

### Description
- Added `src/renderers/calendar-badge-renderer.js` which exports `renderCalendarBadges`, `renderCalendarBadgesInline`, `renderCalendarBadgeIcon`, and `renderCalendarBadgeLabel` and contains the exact badge/inline/virtual/label/icon markup previously in the main card.
- Updated `src/skylight-calendar-card.js` to import the new renderer and call it with explicit badge inputs and a small `getCalendarBadgeRenderHelpers()` helper object so no card instance is passed into the renderer.
- Intentionally left stateful and interaction responsibilities in the main card, including hidden-calendar `Set` mutation, badge click handlers and event listeners, preference persistence/localStorage behavior, Home Assistant orchestration, CSS and lifecycle logic.
- Did not move unrelated renderers or change CSS, DOM structure, IDs/classes, data attributes, public config option names, translations, click behavior, hidden-calendar behavior, virtual calendar behavior, or readonly/writable behavior.

### Testing
- Ran `npm ci --no-audit --fund=false` and `npm run build` successfully and the root `skylight-calendar-card.js` artifact was regenerated.
- Ran `node --check` on `src/skylight-calendar-card.js`, `src/renderers/calendar-badge-renderer.js`, and `skylight-calendar-card.js` with no errors.
- Ran `npm test` and all unit tests passed (233/233).
- Ran `npm run test:visual` and visual test suite passed (39/39), and the generated artifact was verified fresh after the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c68914fc48331968e6813c198e1d7)