### PR TITLE
Extract day badge and day forecast renderer

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -1286,6 +1286,66 @@ function renderEditorWeekdayCheckboxes({ selectedWeekdays }) {
     `;
 }
 
+function renderDayBadge(badge, { escapeHtml }) {
+  const style = [
+    badge.background_color ? `--dcc-day-badge-background: ${badge.background_color};` : '',
+    badge.color ? `--dcc-day-badge-color: ${badge.color};` : '',
+    badge.size ? `--dcc-day-badge-size: ${badge.size};` : '',
+    badge.font_size ? `--dcc-day-badge-font-size: ${badge.font_size};` : ''
+  ].join(' ');
+  const hasIcon = Boolean(badge.icon);
+  const hasText = Boolean(badge.text);
+  const content = [
+    hasIcon ? `<ha-icon icon="${escapeHtml(badge.icon)}"></ha-icon>` : '',
+    hasText ? `<span class="day-badge-text">${escapeHtml(badge.text)}</span>` : ''
+  ].join('');
+  const classes = ['day-badge', hasIcon ? 'has-icon' : '', hasText ? 'has-text' : ''].filter(Boolean).join(' ');
+  return `<span class="${classes}" style="${style}">${content}</span>`;
+}
+
+function renderDayBadges(date, dayEvents, { escapeHtml, getDayBadges }) {
+  const badges = getDayBadges(date, dayEvents);
+  if (!badges.length) return '';
+
+  const badgesHtml = badges.map((badge) => renderDayBadge(badge, { escapeHtml })).join('');
+
+  return `<div class="day-badges">${badgesHtml}</div>`;
+}
+
+function getDayForecastClass(viewMode = 'week-compact') {
+  return viewMode === 'week-standard'
+    ? 'week-standard-day-forecast'
+    : viewMode === 'month'
+      ? 'month-day-forecast'
+      : viewMode === 'agenda'
+        ? 'agenda-day-forecast'
+        : 'week-day-forecast';
+}
+
+function renderWeatherIcon(icon, { escapeHtml }) {
+  return `<span class="forecast-condition"><ha-icon icon="${escapeHtml(icon)}"></ha-icon></span>`;
+}
+
+function renderForecastTemperatures(forecast, { escapeHtml }) {
+  return `<span class="forecast-temperatures">
+          <span class="forecast-temp-high">${escapeHtml(forecast.highTemp)}</span>
+          ${forecast.lowTemp ? `<span class="forecast-temp-low">${escapeHtml(forecast.lowTemp)}</span>` : ''}
+        </span>`;
+}
+
+function renderDayForecast(date, viewMode = 'week-compact', { escapeHtml, getForecastForDate }) {
+  const forecast = getForecastForDate(date);
+  if (!forecast) return '';
+  const forecastClass = getDayForecastClass(viewMode);
+
+  return `
+      <div class="${forecastClass}">
+        ${renderWeatherIcon(forecast.conditionIcon, { escapeHtml })}
+        ${renderForecastTemperatures(forecast, { escapeHtml })}
+      </div>
+    `;
+}
+
 function normalizeDayBadgeBlock(rule = {}, {
   normalizeEventTextValue,
   normalizeDayBadgeDisplayColor,
@@ -10608,27 +10668,10 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   renderDayBadges(date, dayEvents) {
-    const badges = this.getDayBadges(date, dayEvents);
-    if (!badges.length) return '';
-
-    const badgesHtml = badges.map((badge) => {
-      const style = [
-        badge.background_color ? `--dcc-day-badge-background: ${badge.background_color};` : '',
-        badge.color ? `--dcc-day-badge-color: ${badge.color};` : '',
-        badge.size ? `--dcc-day-badge-size: ${badge.size};` : '',
-        badge.font_size ? `--dcc-day-badge-font-size: ${badge.font_size};` : ''
-      ].join(' ');
-      const hasIcon = Boolean(badge.icon);
-      const hasText = Boolean(badge.text);
-      const content = [
-        hasIcon ? `<ha-icon icon="${this.escapeHtml(badge.icon)}"></ha-icon>` : '',
-        hasText ? `<span class="day-badge-text">${this.escapeHtml(badge.text)}</span>` : ''
-      ].join('');
-      const classes = ['day-badge', hasIcon ? 'has-icon' : '', hasText ? 'has-text' : ''].filter(Boolean).join(' ');
-      return `<span class="${classes}" style="${style}">${content}</span>`;
-    }).join('');
-
-    return `<div class="day-badges">${badgesHtml}</div>`;
+    return renderDayBadges(date, dayEvents, {
+      escapeHtml: this.escapeHtml.bind(this),
+      getDayBadges: this.getDayBadges.bind(this)
+    });
   }
 
   renderDay(dayNum, date, isOtherMonth) {
@@ -13283,25 +13326,10 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   renderDayForecast(date, viewMode = 'week-compact') {
-    const forecast = this.getForecastForDate(date);
-    if (!forecast) return '';
-    const forecastClass = viewMode === 'week-standard'
-      ? 'week-standard-day-forecast'
-      : viewMode === 'month'
-        ? 'month-day-forecast'
-        : viewMode === 'agenda'
-          ? 'agenda-day-forecast'
-          : 'week-day-forecast';
-
-    return `
-      <div class="${forecastClass}">
-        <span class="forecast-condition"><ha-icon icon="${this.escapeHtml(forecast.conditionIcon)}"></ha-icon></span>
-        <span class="forecast-temperatures">
-          <span class="forecast-temp-high">${this.escapeHtml(forecast.highTemp)}</span>
-          ${forecast.lowTemp ? `<span class="forecast-temp-low">${this.escapeHtml(forecast.lowTemp)}</span>` : ''}
-        </span>
-      </div>
-    `;
+    return renderDayForecast(date, viewMode, {
+      escapeHtml: this.escapeHtml.bind(this),
+      getForecastForDate: this.getForecastForDate.bind(this)
+    });
   }
 
   formatDate(date) {

--- a/src/renderers/day-weather-renderer.js
+++ b/src/renderers/day-weather-renderer.js
@@ -1,0 +1,59 @@
+export function renderDayBadge(badge, { escapeHtml }) {
+  const style = [
+    badge.background_color ? `--dcc-day-badge-background: ${badge.background_color};` : '',
+    badge.color ? `--dcc-day-badge-color: ${badge.color};` : '',
+    badge.size ? `--dcc-day-badge-size: ${badge.size};` : '',
+    badge.font_size ? `--dcc-day-badge-font-size: ${badge.font_size};` : ''
+  ].join(' ');
+  const hasIcon = Boolean(badge.icon);
+  const hasText = Boolean(badge.text);
+  const content = [
+    hasIcon ? `<ha-icon icon="${escapeHtml(badge.icon)}"></ha-icon>` : '',
+    hasText ? `<span class="day-badge-text">${escapeHtml(badge.text)}</span>` : ''
+  ].join('');
+  const classes = ['day-badge', hasIcon ? 'has-icon' : '', hasText ? 'has-text' : ''].filter(Boolean).join(' ');
+  return `<span class="${classes}" style="${style}">${content}</span>`;
+}
+
+export function renderDayBadges(date, dayEvents, { escapeHtml, getDayBadges }) {
+  const badges = getDayBadges(date, dayEvents);
+  if (!badges.length) return '';
+
+  const badgesHtml = badges.map((badge) => renderDayBadge(badge, { escapeHtml })).join('');
+
+  return `<div class="day-badges">${badgesHtml}</div>`;
+}
+
+export function getDayForecastClass(viewMode = 'week-compact') {
+  return viewMode === 'week-standard'
+    ? 'week-standard-day-forecast'
+    : viewMode === 'month'
+      ? 'month-day-forecast'
+      : viewMode === 'agenda'
+        ? 'agenda-day-forecast'
+        : 'week-day-forecast';
+}
+
+export function renderWeatherIcon(icon, { escapeHtml }) {
+  return `<span class="forecast-condition"><ha-icon icon="${escapeHtml(icon)}"></ha-icon></span>`;
+}
+
+export function renderForecastTemperatures(forecast, { escapeHtml }) {
+  return `<span class="forecast-temperatures">
+          <span class="forecast-temp-high">${escapeHtml(forecast.highTemp)}</span>
+          ${forecast.lowTemp ? `<span class="forecast-temp-low">${escapeHtml(forecast.lowTemp)}</span>` : ''}
+        </span>`;
+}
+
+export function renderDayForecast(date, viewMode = 'week-compact', { escapeHtml, getForecastForDate }) {
+  const forecast = getForecastForDate(date);
+  if (!forecast) return '';
+  const forecastClass = getDayForecastClass(viewMode);
+
+  return `
+      <div class="${forecastClass}">
+        ${renderWeatherIcon(forecast.conditionIcon, { escapeHtml })}
+        ${renderForecastTemperatures(forecast, { escapeHtml })}
+      </div>
+    `;
+}

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -44,6 +44,10 @@ import {
   renderEditorWeekdayCheckboxes
 } from './renderers/editor-renderer.js';
 import {
+  renderDayBadges as renderDayBadgesHtml,
+  renderDayForecast as renderDayForecastHtml
+} from './renderers/day-weather-renderer.js';
+import {
   normalizeDayBadgeBlock as normalizeDayBadgeBlockHelper,
   normalizeDayBadgeConditions as normalizeDayBadgeConditionsHelper,
   normalizeDayBadgeDisplayColor as normalizeDayBadgeDisplayColorHelper,
@@ -6903,27 +6907,10 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   renderDayBadges(date, dayEvents) {
-    const badges = this.getDayBadges(date, dayEvents);
-    if (!badges.length) return '';
-
-    const badgesHtml = badges.map((badge) => {
-      const style = [
-        badge.background_color ? `--dcc-day-badge-background: ${badge.background_color};` : '',
-        badge.color ? `--dcc-day-badge-color: ${badge.color};` : '',
-        badge.size ? `--dcc-day-badge-size: ${badge.size};` : '',
-        badge.font_size ? `--dcc-day-badge-font-size: ${badge.font_size};` : ''
-      ].join(' ');
-      const hasIcon = Boolean(badge.icon);
-      const hasText = Boolean(badge.text);
-      const content = [
-        hasIcon ? `<ha-icon icon="${this.escapeHtml(badge.icon)}"></ha-icon>` : '',
-        hasText ? `<span class="day-badge-text">${this.escapeHtml(badge.text)}</span>` : ''
-      ].join('');
-      const classes = ['day-badge', hasIcon ? 'has-icon' : '', hasText ? 'has-text' : ''].filter(Boolean).join(' ');
-      return `<span class="${classes}" style="${style}">${content}</span>`;
-    }).join('');
-
-    return `<div class="day-badges">${badgesHtml}</div>`;
+    return renderDayBadgesHtml(date, dayEvents, {
+      escapeHtml: this.escapeHtml.bind(this),
+      getDayBadges: this.getDayBadges.bind(this)
+    });
   }
 
   renderDay(dayNum, date, isOtherMonth) {
@@ -9578,25 +9565,10 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   renderDayForecast(date, viewMode = 'week-compact') {
-    const forecast = this.getForecastForDate(date);
-    if (!forecast) return '';
-    const forecastClass = viewMode === 'week-standard'
-      ? 'week-standard-day-forecast'
-      : viewMode === 'month'
-        ? 'month-day-forecast'
-        : viewMode === 'agenda'
-          ? 'agenda-day-forecast'
-          : 'week-day-forecast';
-
-    return `
-      <div class="${forecastClass}">
-        <span class="forecast-condition"><ha-icon icon="${this.escapeHtml(forecast.conditionIcon)}"></ha-icon></span>
-        <span class="forecast-temperatures">
-          <span class="forecast-temp-high">${this.escapeHtml(forecast.highTemp)}</span>
-          ${forecast.lowTemp ? `<span class="forecast-temp-low">${this.escapeHtml(forecast.lowTemp)}</span>` : ''}
-        </span>
-      </div>
-    `;
+    return renderDayForecastHtml(date, viewMode, {
+      escapeHtml: this.escapeHtml.bind(this),
+      getForecastForDate: this.getForecastForDate.bind(this)
+    });
   }
 
   formatDate(date) {


### PR DESCRIPTION
### Motivation
- Move day badge and day weather/forecast HTML composition into a dedicated renderer to continue the Phase 23 modularization while preserving runtime and visual behavior.
- Keep state, weather discovery, subscriptions, and Home Assistant orchestration in the main card to avoid behavioral changes.

### Description
- Added `src/renderers/day-weather-renderer.js` exporting `renderDayBadges`, `renderDayBadge`, `renderDayForecast`, `renderWeatherIcon`, `renderForecastTemperatures`, and `getDayForecastClass` and moved pure output-only markup there.
- Updated `src/skylight-calendar-card.js` to import the new renderer and delegate `renderDayBadges()` and `renderDayForecast()` using narrow callbacks (`escapeHtml`, `getDayBadges`, `getForecastForDate`) without passing the full card instance.
- Preserved weather entity discovery, forecast cache/state, websocket subscriptions, day-badge resolution logic, CSS, DOM structure, classes, data attributes, translations, and public config behavior in the main card.
- Regenerated and committed the built artifact `skylight-calendar-card.js` and did not move unrelated renderers or change visual output.

### Testing
- Ran `npm ci --no-audit --fund=false`, `npm run build`, `node --check src/skylight-calendar-card.js`, `node --check src/renderers/day-weather-renderer.js`, and `node --check skylight-calendar-card.js`, all of which succeeded.
- Ran `npm test` with `233` tests passed and `0` failed, and ran `npm run test:visual` with `39` visual snapshots passing.
- Verified `git diff --exit-code -- skylight-calendar-card.js` after committing the regenerated artifact and confirmed the working tree is clean.
- No visual snapshot differences were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c6a967d9c83319c4c6d5216d72361)