### PR TITLE
Extract shared event HTML renderer

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3154,6 +3154,134 @@ function renderEventDetailsModal({
     `;
 }
 
+function renderEventIcon(event, {
+  getEventStyleOverrides,
+  eventCalendarFriendlyName = false,
+  hideEventCalendarBubble = false,
+  getModalCalendarBadgesForEvent,
+  getCalendarName,
+  escapeHtml
+}) {
+  const styleOverrides = getEventStyleOverrides(event);
+  const hideCalendarBubble = styleOverrides?.hide_event_calendar_bubble ?? hideEventCalendarBubble;
+
+  if (eventCalendarFriendlyName) {
+    const visibleBadges = getModalCalendarBadgesForEvent(event);
+    if (visibleBadges.length === 0) {
+      return '';
+    }
+
+    const namesHtml = visibleBadges
+      .map(calendar => `<div class="week-standard-event-calendar-name">${escapeHtml(getCalendarName(calendar.entityId))}</div>`)
+      .join('');
+
+    return `<div class="week-standard-event-icons">${namesHtml}</div>`;
+  }
+
+  if (hideCalendarBubble) {
+    return '';
+  }
+
+  const visibleBadges = getModalCalendarBadgesForEvent(event);
+  if (visibleBadges.length === 0) {
+    return '';
+  }
+
+  const badgesHtml = visibleBadges.map(calendar => {
+    const name = getCalendarName(calendar.entityId);
+    const initial = name.charAt(0).toUpperCase();
+    return `<div class="week-standard-event-icon" style="background: ${calendar.color}; color: white;">${initial}</div>`;
+  }).join('');
+
+  return `<div class="week-standard-event-icons">${badgesHtml}</div>`;
+}
+
+function renderCombinedCornerBubbles(event, {
+  shouldShowCombinedCornerBubbles,
+  getModalCalendarBadgesForEvent,
+  getCalendarName,
+  escapeHtml
+}) {
+  if (!shouldShowCombinedCornerBubbles(event)) return '';
+
+  const visibleBadges = getModalCalendarBadgesForEvent(event);
+  if (visibleBadges.length <= 1) return '';
+
+  const bubblesHtml = visibleBadges.map((calendar) => {
+    const name = getCalendarName(calendar.entityId);
+    const initial = name.charAt(0).toUpperCase();
+    return `<span class="combined-corner-bubble" style="background: ${calendar.color}; color: white;" title="${escapeHtml(name)}">${escapeHtml(initial)}</span>`;
+  }).join('');
+
+  return `<div class="combined-corner-bubbles">${bubblesHtml}</div>`;
+}
+
+function renderEventStyleIcon(iconConfig, { position = 'before_title', escapeHtml } = {}) {
+  if (!iconConfig || iconConfig.position !== position) return '';
+
+  const styleParts = [];
+  if (iconConfig.color) styleParts.push(`color: ${iconConfig.color};`);
+  if (iconConfig.size) styleParts.push(`--event-style-icon-size: ${iconConfig.size};`);
+  const styleAttr = styleParts.length ? ` style="${styleParts.join(' ')}"` : '';
+  const className = position === 'corner' ? 'event-style-icon event-style-icon-corner' : 'event-style-icon event-style-icon-before-title';
+  return `<ha-icon class="${className}" icon="${escapeHtml(iconConfig.icon)}"${styleAttr}></ha-icon>`;
+}
+
+function renderEventStyleCornerIcon(event, { getEventStyleIconConfig, escapeHtml }) {
+  return renderEventStyleIcon(getEventStyleIconConfig(event), { position: 'corner', escapeHtml });
+}
+
+function renderEventTitleWithPrefix(event, title, {
+  t,
+  escapeHtml,
+  getEventStyleOverrides,
+  getEventStyleIconConfig,
+  normalizeEventTitlePrefixMode,
+  configuredEventTitlePrefix,
+  getModalCalendarBadgesForEvent,
+  getCalendarName,
+  normalizeSingleColor,
+  getCalendarBadgeIcon,
+  normalizeBackgroundImageUrl
+}) {
+  const titleText = escapeHtml(title || t('untitledEvent'));
+  const styleOverrides = getEventStyleOverrides(event);
+  const titleIcon = renderEventStyleIcon(getEventStyleIconConfig(event), { position: 'before_title', escapeHtml });
+  const titleHtml = titleIcon ? `${titleIcon}<span>${titleText}</span>` : titleText;
+  const prefixMode = normalizeEventTitlePrefixMode(styleOverrides?.event_title_prefix ?? configuredEventTitlePrefix);
+  const visibleBadges = getModalCalendarBadgesForEvent(event);
+  if (prefixMode === 'none' || visibleBadges.length === 0) {
+    return titleIcon ? `<span class="event-title-with-prefix">${titleHtml}</span>` : titleText;
+  }
+
+  if (prefixMode === 'friendly_name') {
+    const calendarNames = visibleBadges
+      .map((calendar) => getCalendarName(calendar.entityId))
+      .filter(Boolean);
+    const uniqueCalendarNames = Array.from(new Set(calendarNames));
+    const calendarNameLabel = escapeHtml(uniqueCalendarNames.join(', '));
+    return `<span class="event-title-with-prefix"><span class="event-title-prefix-friendly-name">${calendarNameLabel}:</span>${titleHtml}</span>`;
+  }
+
+  const badgesHtml = visibleBadges.map((calendar) => {
+    const iconColor = normalizeSingleColor(calendar.color) || '#6b7280';
+    const configuredBadgeIcon = getCalendarBadgeIcon(calendar.entityId);
+    let badgeIconHtml = '';
+    if (configuredBadgeIcon && configuredBadgeIcon.startsWith('mdi:')) {
+      badgeIconHtml = `<ha-icon icon="${escapeHtml(configuredBadgeIcon)}"></ha-icon>`;
+    } else if (configuredBadgeIcon) {
+      const normalizedUrl = normalizeBackgroundImageUrl(configuredBadgeIcon) || configuredBadgeIcon;
+      badgeIconHtml = `<img src="${escapeHtml(normalizedUrl)}" alt="" loading="lazy">`;
+    } else {
+      const initial = escapeHtml(getCalendarName(calendar.entityId).charAt(0).toUpperCase());
+      badgeIconHtml = `<span>${initial}</span>`;
+    }
+    return `<span class="event-title-prefix-badge" style="background: ${iconColor}; color: white;">${badgeIconHtml}</span>`;
+  }).join('');
+
+  return `<span class="event-title-with-prefix"><span class="event-title-prefix-badges">${badgesHtml}</span>${titleHtml}</span>`;
+}
+
 function renderCalendarBadges({ badgeItems, hideCalendarNames = false, helpers }) {
   if (badgeItems.length === 0) return '';
 
@@ -10170,39 +10298,14 @@ class SkylightCalendarCard extends HTMLElement {
       return '';
     }
 
-    const styleOverrides = this.getEventStyleOverrides(event);
-    const useFriendlyName = this._config.event_calendar_friendly_name;
-    const hideCalendarBubble = styleOverrides?.hide_event_calendar_bubble ?? this._config.hide_event_calendar_bubble;
-
-    if (useFriendlyName) {
-      const visibleBadges = this.getModalCalendarBadgesForEvent(event);
-      if (visibleBadges.length === 0) {
-        return '';
-      }
-
-      const namesHtml = visibleBadges
-        .map(calendar => `<div class="week-standard-event-calendar-name">${this.escapeHtml(this.getCalendarName(calendar.entityId))}</div>`)
-        .join('');
-
-      return `<div class="week-standard-event-icons">${namesHtml}</div>`;
-    }
-
-    if (hideCalendarBubble) {
-      return '';
-    }
-
-    const visibleBadges = this.getModalCalendarBadgesForEvent(event);
-    if (visibleBadges.length === 0) {
-      return '';
-    }
-
-    const badgesHtml = visibleBadges.map(calendar => {
-      const name = this.getCalendarName(calendar.entityId);
-      const initial = name.charAt(0).toUpperCase();
-      return `<div class="week-standard-event-icon" style="background: ${calendar.color}; color: white;">${initial}</div>`;
-    }).join('');
-
-    return `<div class="week-standard-event-icons">${badgesHtml}</div>`;
+    return renderEventIcon(event, {
+      getEventStyleOverrides: (iconEvent) => this.getEventStyleOverrides(iconEvent),
+      eventCalendarFriendlyName: this._config.event_calendar_friendly_name,
+      hideEventCalendarBubble: this._config.hide_event_calendar_bubble,
+      getModalCalendarBadgesForEvent: (iconEvent) => this.getModalCalendarBadgesForEvent(iconEvent),
+      getCalendarName: (entityId) => this.getCalendarName(entityId),
+      escapeHtml: (value) => this.escapeHtml(value)
+    });
   }
 
 
@@ -10222,18 +10325,12 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   renderCombinedCornerBubbles(event) {
-    if (!this.shouldShowCombinedCornerBubbles(event)) return '';
-
-    const visibleBadges = this.getModalCalendarBadgesForEvent(event);
-    if (visibleBadges.length <= 1) return '';
-
-    const bubblesHtml = visibleBadges.map((calendar) => {
-      const name = this.getCalendarName(calendar.entityId);
-      const initial = name.charAt(0).toUpperCase();
-      return `<span class="combined-corner-bubble" style="background: ${calendar.color}; color: white;" title="${this.escapeHtml(name)}">${this.escapeHtml(initial)}</span>`;
-    }).join('');
-
-    return `<div class="combined-corner-bubbles">${bubblesHtml}</div>`;
+    return renderCombinedCornerBubbles(event, {
+      shouldShowCombinedCornerBubbles: (bubbleEvent) => this.shouldShowCombinedCornerBubbles(bubbleEvent),
+      getModalCalendarBadgesForEvent: (bubbleEvent) => this.getModalCalendarBadgesForEvent(bubbleEvent),
+      getCalendarName: (entityId) => this.getCalendarName(entityId),
+      escapeHtml: (value) => this.escapeHtml(value)
+    });
   }
 
   getEventStyleIconConfig(event) {
@@ -10250,58 +10347,33 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   renderEventStyleIcon(event, { position = 'before_title' } = {}) {
-    const iconConfig = this.getEventStyleIconConfig(event);
-    if (!iconConfig || iconConfig.position !== position) return '';
-
-    const styleParts = [];
-    if (iconConfig.color) styleParts.push(`color: ${iconConfig.color};`);
-    if (iconConfig.size) styleParts.push(`--event-style-icon-size: ${iconConfig.size};`);
-    const styleAttr = styleParts.length ? ` style="${styleParts.join(' ')}"` : '';
-    const className = position === 'corner' ? 'event-style-icon event-style-icon-corner' : 'event-style-icon event-style-icon-before-title';
-    return `<ha-icon class="${className}" icon="${this.escapeHtml(iconConfig.icon)}"${styleAttr}></ha-icon>`;
+    return renderEventStyleIcon(this.getEventStyleIconConfig(event), {
+      position,
+      escapeHtml: (value) => this.escapeHtml(value)
+    });
   }
 
   renderEventStyleCornerIcon(event) {
-    return this.renderEventStyleIcon(event, { position: 'corner' });
+    return renderEventStyleCornerIcon(event, {
+      getEventStyleIconConfig: (iconEvent) => this.getEventStyleIconConfig(iconEvent),
+      escapeHtml: (value) => this.escapeHtml(value)
+    });
   }
 
   renderEventTitleWithPrefix(event, title) {
-    const titleText = this.escapeHtml(title || this.t('untitledEvent'));
-    const styleOverrides = this.getEventStyleOverrides(event);
-    const titleIcon = this.renderEventStyleIcon(event, { position: 'before_title' });
-    const titleHtml = titleIcon ? `${titleIcon}<span>${titleText}</span>` : titleText;
-    const prefixMode = this.normalizeEventTitlePrefixMode(styleOverrides?.event_title_prefix ?? this._config.event_title_prefix);
-    const visibleBadges = this.getModalCalendarBadgesForEvent(event);
-    if (prefixMode === 'none' || visibleBadges.length === 0) {
-      return titleIcon ? `<span class="event-title-with-prefix">${titleHtml}</span>` : titleText;
-    }
-
-    if (prefixMode === 'friendly_name') {
-      const calendarNames = visibleBadges
-        .map((calendar) => this.getCalendarName(calendar.entityId))
-        .filter(Boolean);
-      const uniqueCalendarNames = Array.from(new Set(calendarNames));
-      const calendarNameLabel = this.escapeHtml(uniqueCalendarNames.join(', '));
-      return `<span class="event-title-with-prefix"><span class="event-title-prefix-friendly-name">${calendarNameLabel}:</span>${titleHtml}</span>`;
-    }
-
-    const badgesHtml = visibleBadges.map((calendar) => {
-      const iconColor = this.normalizeSingleColor(calendar.color) || '#6b7280';
-      const configuredBadgeIcon = this.getCalendarBadgeIcon(calendar.entityId);
-      let badgeIconHtml = '';
-      if (configuredBadgeIcon && configuredBadgeIcon.startsWith('mdi:')) {
-        badgeIconHtml = `<ha-icon icon="${this.escapeHtml(configuredBadgeIcon)}"></ha-icon>`;
-      } else if (configuredBadgeIcon) {
-        const normalizedUrl = this.normalizeBackgroundImageUrl(configuredBadgeIcon) || configuredBadgeIcon;
-        badgeIconHtml = `<img src="${this.escapeHtml(normalizedUrl)}" alt="" loading="lazy">`;
-      } else {
-        const initial = this.escapeHtml(this.getCalendarName(calendar.entityId).charAt(0).toUpperCase());
-        badgeIconHtml = `<span>${initial}</span>`;
-      }
-      return `<span class="event-title-prefix-badge" style="background: ${iconColor}; color: white;">${badgeIconHtml}</span>`;
-    }).join('');
-
-    return `<span class="event-title-with-prefix"><span class="event-title-prefix-badges">${badgesHtml}</span>${titleHtml}</span>`;
+    return renderEventTitleWithPrefix(event, title, {
+      t: (key) => this.t(key),
+      escapeHtml: (value) => this.escapeHtml(value),
+      getEventStyleOverrides: (titleEvent) => this.getEventStyleOverrides(titleEvent),
+      getEventStyleIconConfig: (titleEvent) => this.getEventStyleIconConfig(titleEvent),
+      normalizeEventTitlePrefixMode: (mode) => this.normalizeEventTitlePrefixMode(mode),
+      configuredEventTitlePrefix: this._config.event_title_prefix,
+      getModalCalendarBadgesForEvent: (titleEvent) => this.getModalCalendarBadgesForEvent(titleEvent),
+      getCalendarName: (entityId) => this.getCalendarName(entityId),
+      normalizeSingleColor: (color) => this.normalizeSingleColor(color),
+      getCalendarBadgeIcon: (entityId) => this.getCalendarBadgeIcon(entityId),
+      normalizeBackgroundImageUrl: (url) => this.normalizeBackgroundImageUrl(url)
+    });
   }
 
 

--- a/src/renderers/event-renderer.js
+++ b/src/renderers/event-renderer.js
@@ -1,0 +1,127 @@
+export function renderEventIcon(event, {
+  getEventStyleOverrides,
+  eventCalendarFriendlyName = false,
+  hideEventCalendarBubble = false,
+  getModalCalendarBadgesForEvent,
+  getCalendarName,
+  escapeHtml
+}) {
+  const styleOverrides = getEventStyleOverrides(event);
+  const hideCalendarBubble = styleOverrides?.hide_event_calendar_bubble ?? hideEventCalendarBubble;
+
+  if (eventCalendarFriendlyName) {
+    const visibleBadges = getModalCalendarBadgesForEvent(event);
+    if (visibleBadges.length === 0) {
+      return '';
+    }
+
+    const namesHtml = visibleBadges
+      .map(calendar => `<div class="week-standard-event-calendar-name">${escapeHtml(getCalendarName(calendar.entityId))}</div>`)
+      .join('');
+
+    return `<div class="week-standard-event-icons">${namesHtml}</div>`;
+  }
+
+  if (hideCalendarBubble) {
+    return '';
+  }
+
+  const visibleBadges = getModalCalendarBadgesForEvent(event);
+  if (visibleBadges.length === 0) {
+    return '';
+  }
+
+  const badgesHtml = visibleBadges.map(calendar => {
+    const name = getCalendarName(calendar.entityId);
+    const initial = name.charAt(0).toUpperCase();
+    return `<div class="week-standard-event-icon" style="background: ${calendar.color}; color: white;">${initial}</div>`;
+  }).join('');
+
+  return `<div class="week-standard-event-icons">${badgesHtml}</div>`;
+}
+
+export function renderCombinedCornerBubbles(event, {
+  shouldShowCombinedCornerBubbles,
+  getModalCalendarBadgesForEvent,
+  getCalendarName,
+  escapeHtml
+}) {
+  if (!shouldShowCombinedCornerBubbles(event)) return '';
+
+  const visibleBadges = getModalCalendarBadgesForEvent(event);
+  if (visibleBadges.length <= 1) return '';
+
+  const bubblesHtml = visibleBadges.map((calendar) => {
+    const name = getCalendarName(calendar.entityId);
+    const initial = name.charAt(0).toUpperCase();
+    return `<span class="combined-corner-bubble" style="background: ${calendar.color}; color: white;" title="${escapeHtml(name)}">${escapeHtml(initial)}</span>`;
+  }).join('');
+
+  return `<div class="combined-corner-bubbles">${bubblesHtml}</div>`;
+}
+
+export function renderEventStyleIcon(iconConfig, { position = 'before_title', escapeHtml } = {}) {
+  if (!iconConfig || iconConfig.position !== position) return '';
+
+  const styleParts = [];
+  if (iconConfig.color) styleParts.push(`color: ${iconConfig.color};`);
+  if (iconConfig.size) styleParts.push(`--event-style-icon-size: ${iconConfig.size};`);
+  const styleAttr = styleParts.length ? ` style="${styleParts.join(' ')}"` : '';
+  const className = position === 'corner' ? 'event-style-icon event-style-icon-corner' : 'event-style-icon event-style-icon-before-title';
+  return `<ha-icon class="${className}" icon="${escapeHtml(iconConfig.icon)}"${styleAttr}></ha-icon>`;
+}
+
+export function renderEventStyleCornerIcon(event, { getEventStyleIconConfig, escapeHtml }) {
+  return renderEventStyleIcon(getEventStyleIconConfig(event), { position: 'corner', escapeHtml });
+}
+
+export function renderEventTitleWithPrefix(event, title, {
+  t,
+  escapeHtml,
+  getEventStyleOverrides,
+  getEventStyleIconConfig,
+  normalizeEventTitlePrefixMode,
+  configuredEventTitlePrefix,
+  getModalCalendarBadgesForEvent,
+  getCalendarName,
+  normalizeSingleColor,
+  getCalendarBadgeIcon,
+  normalizeBackgroundImageUrl
+}) {
+  const titleText = escapeHtml(title || t('untitledEvent'));
+  const styleOverrides = getEventStyleOverrides(event);
+  const titleIcon = renderEventStyleIcon(getEventStyleIconConfig(event), { position: 'before_title', escapeHtml });
+  const titleHtml = titleIcon ? `${titleIcon}<span>${titleText}</span>` : titleText;
+  const prefixMode = normalizeEventTitlePrefixMode(styleOverrides?.event_title_prefix ?? configuredEventTitlePrefix);
+  const visibleBadges = getModalCalendarBadgesForEvent(event);
+  if (prefixMode === 'none' || visibleBadges.length === 0) {
+    return titleIcon ? `<span class="event-title-with-prefix">${titleHtml}</span>` : titleText;
+  }
+
+  if (prefixMode === 'friendly_name') {
+    const calendarNames = visibleBadges
+      .map((calendar) => getCalendarName(calendar.entityId))
+      .filter(Boolean);
+    const uniqueCalendarNames = Array.from(new Set(calendarNames));
+    const calendarNameLabel = escapeHtml(uniqueCalendarNames.join(', '));
+    return `<span class="event-title-with-prefix"><span class="event-title-prefix-friendly-name">${calendarNameLabel}:</span>${titleHtml}</span>`;
+  }
+
+  const badgesHtml = visibleBadges.map((calendar) => {
+    const iconColor = normalizeSingleColor(calendar.color) || '#6b7280';
+    const configuredBadgeIcon = getCalendarBadgeIcon(calendar.entityId);
+    let badgeIconHtml = '';
+    if (configuredBadgeIcon && configuredBadgeIcon.startsWith('mdi:')) {
+      badgeIconHtml = `<ha-icon icon="${escapeHtml(configuredBadgeIcon)}"></ha-icon>`;
+    } else if (configuredBadgeIcon) {
+      const normalizedUrl = normalizeBackgroundImageUrl(configuredBadgeIcon) || configuredBadgeIcon;
+      badgeIconHtml = `<img src="${escapeHtml(normalizedUrl)}" alt="" loading="lazy">`;
+    } else {
+      const initial = escapeHtml(getCalendarName(calendar.entityId).charAt(0).toUpperCase());
+      badgeIconHtml = `<span>${initial}</span>`;
+    }
+    return `<span class="event-title-prefix-badge" style="background: ${iconColor}; color: white;">${badgeIconHtml}</span>`;
+  }).join('');
+
+  return `<span class="event-title-with-prefix"><span class="event-title-prefix-badges">${badgesHtml}</span>${titleHtml}</span>`;
+}

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -154,6 +154,13 @@ import {
 import { renderAgendaView } from './renderers/agenda-renderer.js';
 import { renderEventDetailsModal } from './renderers/event-modal-renderer.js';
 import {
+  renderCombinedCornerBubbles as renderCombinedCornerBubblesHtml,
+  renderEventIcon as renderEventIconHtml,
+  renderEventStyleCornerIcon as renderEventStyleCornerIconHtml,
+  renderEventStyleIcon as renderEventStyleIconHtml,
+  renderEventTitleWithPrefix as renderEventTitleWithPrefixHtml
+} from './renderers/event-renderer.js';
+import {
   renderCalendarBadgeIcon as renderCalendarBadgeIconMarkup,
   renderCalendarBadgeLabel as renderCalendarBadgeLabelMarkup,
   renderCalendarBadges as renderCalendarBadgesMarkup,
@@ -6409,39 +6416,14 @@ class SkylightCalendarCard extends HTMLElement {
       return '';
     }
 
-    const styleOverrides = this.getEventStyleOverrides(event);
-    const useFriendlyName = this._config.event_calendar_friendly_name;
-    const hideCalendarBubble = styleOverrides?.hide_event_calendar_bubble ?? this._config.hide_event_calendar_bubble;
-
-    if (useFriendlyName) {
-      const visibleBadges = this.getModalCalendarBadgesForEvent(event);
-      if (visibleBadges.length === 0) {
-        return '';
-      }
-
-      const namesHtml = visibleBadges
-        .map(calendar => `<div class="week-standard-event-calendar-name">${this.escapeHtml(this.getCalendarName(calendar.entityId))}</div>`)
-        .join('');
-
-      return `<div class="week-standard-event-icons">${namesHtml}</div>`;
-    }
-
-    if (hideCalendarBubble) {
-      return '';
-    }
-
-    const visibleBadges = this.getModalCalendarBadgesForEvent(event);
-    if (visibleBadges.length === 0) {
-      return '';
-    }
-
-    const badgesHtml = visibleBadges.map(calendar => {
-      const name = this.getCalendarName(calendar.entityId);
-      const initial = name.charAt(0).toUpperCase();
-      return `<div class="week-standard-event-icon" style="background: ${calendar.color}; color: white;">${initial}</div>`;
-    }).join('');
-
-    return `<div class="week-standard-event-icons">${badgesHtml}</div>`;
+    return renderEventIconHtml(event, {
+      getEventStyleOverrides: (iconEvent) => this.getEventStyleOverrides(iconEvent),
+      eventCalendarFriendlyName: this._config.event_calendar_friendly_name,
+      hideEventCalendarBubble: this._config.hide_event_calendar_bubble,
+      getModalCalendarBadgesForEvent: (iconEvent) => this.getModalCalendarBadgesForEvent(iconEvent),
+      getCalendarName: (entityId) => this.getCalendarName(entityId),
+      escapeHtml: (value) => this.escapeHtml(value)
+    });
   }
 
 
@@ -6461,18 +6443,12 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   renderCombinedCornerBubbles(event) {
-    if (!this.shouldShowCombinedCornerBubbles(event)) return '';
-
-    const visibleBadges = this.getModalCalendarBadgesForEvent(event);
-    if (visibleBadges.length <= 1) return '';
-
-    const bubblesHtml = visibleBadges.map((calendar) => {
-      const name = this.getCalendarName(calendar.entityId);
-      const initial = name.charAt(0).toUpperCase();
-      return `<span class="combined-corner-bubble" style="background: ${calendar.color}; color: white;" title="${this.escapeHtml(name)}">${this.escapeHtml(initial)}</span>`;
-    }).join('');
-
-    return `<div class="combined-corner-bubbles">${bubblesHtml}</div>`;
+    return renderCombinedCornerBubblesHtml(event, {
+      shouldShowCombinedCornerBubbles: (bubbleEvent) => this.shouldShowCombinedCornerBubbles(bubbleEvent),
+      getModalCalendarBadgesForEvent: (bubbleEvent) => this.getModalCalendarBadgesForEvent(bubbleEvent),
+      getCalendarName: (entityId) => this.getCalendarName(entityId),
+      escapeHtml: (value) => this.escapeHtml(value)
+    });
   }
 
   getEventStyleIconConfig(event) {
@@ -6489,58 +6465,33 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   renderEventStyleIcon(event, { position = 'before_title' } = {}) {
-    const iconConfig = this.getEventStyleIconConfig(event);
-    if (!iconConfig || iconConfig.position !== position) return '';
-
-    const styleParts = [];
-    if (iconConfig.color) styleParts.push(`color: ${iconConfig.color};`);
-    if (iconConfig.size) styleParts.push(`--event-style-icon-size: ${iconConfig.size};`);
-    const styleAttr = styleParts.length ? ` style="${styleParts.join(' ')}"` : '';
-    const className = position === 'corner' ? 'event-style-icon event-style-icon-corner' : 'event-style-icon event-style-icon-before-title';
-    return `<ha-icon class="${className}" icon="${this.escapeHtml(iconConfig.icon)}"${styleAttr}></ha-icon>`;
+    return renderEventStyleIconHtml(this.getEventStyleIconConfig(event), {
+      position,
+      escapeHtml: (value) => this.escapeHtml(value)
+    });
   }
 
   renderEventStyleCornerIcon(event) {
-    return this.renderEventStyleIcon(event, { position: 'corner' });
+    return renderEventStyleCornerIconHtml(event, {
+      getEventStyleIconConfig: (iconEvent) => this.getEventStyleIconConfig(iconEvent),
+      escapeHtml: (value) => this.escapeHtml(value)
+    });
   }
 
   renderEventTitleWithPrefix(event, title) {
-    const titleText = this.escapeHtml(title || this.t('untitledEvent'));
-    const styleOverrides = this.getEventStyleOverrides(event);
-    const titleIcon = this.renderEventStyleIcon(event, { position: 'before_title' });
-    const titleHtml = titleIcon ? `${titleIcon}<span>${titleText}</span>` : titleText;
-    const prefixMode = this.normalizeEventTitlePrefixMode(styleOverrides?.event_title_prefix ?? this._config.event_title_prefix);
-    const visibleBadges = this.getModalCalendarBadgesForEvent(event);
-    if (prefixMode === 'none' || visibleBadges.length === 0) {
-      return titleIcon ? `<span class="event-title-with-prefix">${titleHtml}</span>` : titleText;
-    }
-
-    if (prefixMode === 'friendly_name') {
-      const calendarNames = visibleBadges
-        .map((calendar) => this.getCalendarName(calendar.entityId))
-        .filter(Boolean);
-      const uniqueCalendarNames = Array.from(new Set(calendarNames));
-      const calendarNameLabel = this.escapeHtml(uniqueCalendarNames.join(', '));
-      return `<span class="event-title-with-prefix"><span class="event-title-prefix-friendly-name">${calendarNameLabel}:</span>${titleHtml}</span>`;
-    }
-
-    const badgesHtml = visibleBadges.map((calendar) => {
-      const iconColor = this.normalizeSingleColor(calendar.color) || '#6b7280';
-      const configuredBadgeIcon = this.getCalendarBadgeIcon(calendar.entityId);
-      let badgeIconHtml = '';
-      if (configuredBadgeIcon && configuredBadgeIcon.startsWith('mdi:')) {
-        badgeIconHtml = `<ha-icon icon="${this.escapeHtml(configuredBadgeIcon)}"></ha-icon>`;
-      } else if (configuredBadgeIcon) {
-        const normalizedUrl = this.normalizeBackgroundImageUrl(configuredBadgeIcon) || configuredBadgeIcon;
-        badgeIconHtml = `<img src="${this.escapeHtml(normalizedUrl)}" alt="" loading="lazy">`;
-      } else {
-        const initial = this.escapeHtml(this.getCalendarName(calendar.entityId).charAt(0).toUpperCase());
-        badgeIconHtml = `<span>${initial}</span>`;
-      }
-      return `<span class="event-title-prefix-badge" style="background: ${iconColor}; color: white;">${badgeIconHtml}</span>`;
-    }).join('');
-
-    return `<span class="event-title-with-prefix"><span class="event-title-prefix-badges">${badgesHtml}</span>${titleHtml}</span>`;
+    return renderEventTitleWithPrefixHtml(event, title, {
+      t: (key) => this.t(key),
+      escapeHtml: (value) => this.escapeHtml(value),
+      getEventStyleOverrides: (titleEvent) => this.getEventStyleOverrides(titleEvent),
+      getEventStyleIconConfig: (titleEvent) => this.getEventStyleIconConfig(titleEvent),
+      normalizeEventTitlePrefixMode: (mode) => this.normalizeEventTitlePrefixMode(mode),
+      configuredEventTitlePrefix: this._config.event_title_prefix,
+      getModalCalendarBadgesForEvent: (titleEvent) => this.getModalCalendarBadgesForEvent(titleEvent),
+      getCalendarName: (entityId) => this.getCalendarName(entityId),
+      normalizeSingleColor: (color) => this.normalizeSingleColor(color),
+      getCalendarBadgeIcon: (entityId) => this.getCalendarBadgeIcon(entityId),
+      normalizeBackgroundImageUrl: (url) => this.normalizeBackgroundImageUrl(url)
+    });
   }
 
 


### PR DESCRIPTION
### Motivation
- Continue Phase 24 modularization by moving shared, output-only event HTML/string composition into a dedicated renderer module to reduce main-card surface area. 
- Keep runtime behavior, DOM structure, CSS classes, data attributes, click/modal/service behavior, and public config semantics identical. 
- Favor narrow inputs and helper callbacks so the new module has no dependency on the card instance state or lifecycle.

### Description
- Added `src/renderers/event-renderer.js` which exports `renderEventIcon`, `renderCombinedCornerBubbles`, `renderEventStyleIcon`, `renderEventStyleCornerIcon`, and `renderEventTitleWithPrefix` that produce the same HTML fragments previously authored inline in the main card. 
- Updated `src/skylight-calendar-card.js` to import these functions and delegate output-only event fragments to the renderer while passing explicit helper callbacks (translations, escaping, calendar name/color lookups, style/icon configs, modal-badge getters, and normalization helpers). 
- Preserved card responsibilities including click handlers, modal open/close behavior, Home Assistant service calls, DOM reads/writes, event selection/edit/delete/forward behavior, view placement/layout, CSS, lifecycle, and preference persistence. 
- Did not move unrelated renderers or change CSS, DOM structure, class names, data attributes, public config option names, translations, combined-bubble logic, `event_title_prefix`, or `hide_times_for_calendars` behavior.

### Testing
- Ran dependency install and build: `npm ci --no-audit --fund=false` and `npm run build` which regenerated the root `skylight-calendar-card.js` artifact and it was included with the source changes. 
- Performed syntax checks: `node --check src/skylight-calendar-card.js`, `node --check src/renderers/event-renderer.js`, and `node --check skylight-calendar-card.js` (all succeeded). 
- Ran unit tests: `npm test` (233 tests passed, 0 failed). 
- Ran visual tests: `npm run test:visual` (39 Playwright visual tests passed, no snapshot differences reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c7280b71883319768791c1952d77c)