### PR TITLE
Extract shared day-cell renderer

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3693,6 +3693,67 @@ ${renderEventFields({
     `;
 }
 
+function renderDayCellHeader({
+  date,
+  dayEventsForMatching,
+  dayNum,
+  helpers
+}) {
+  return `
+        <div class="day-header-row">
+          <div class="day-number">${dayNum}</div>
+          ${helpers.renderDayBadges(date, dayEventsForMatching)}
+          ${helpers.renderDayForecast(date, 'month')}
+        </div>`;
+}
+
+function renderDayCellEvents({
+  date,
+  dayEvents,
+  hiddenEventCount,
+  visibleEvents,
+  helpers
+}) {
+  return `
+        ${dayEvents.slice(0, visibleEvents).map(event => helpers.renderMonthDayEvent(event, date)).join('')}
+        ${hiddenEventCount > 0 ? `<div class="more-events" data-click-target="more-events">${helpers.t('moreEvents', { count: hiddenEventCount })}</div>` : ''}`;
+}
+
+function renderDayCell({
+  date,
+  dayEvents,
+  dayEventsForMatching,
+  dayNum,
+  dayStyle,
+  hiddenEventCount,
+  isOtherMonth,
+  isToday,
+  visibleEvents,
+  helpers
+}) {
+  let classes = 'day-cell';
+  if (isOtherMonth) classes += ' other-month';
+  if (isToday) classes += ' today';
+  classes += dayStyle.className ? ` ${dayStyle.className}` : '';
+  const dayStyleAttr = dayStyle.style ? ` style="${dayStyle.style}"` : '';
+
+  return `
+      <div class="${classes}" data-date="${date.toISOString()}"${dayStyleAttr}>${renderDayCellHeader({
+        date,
+        dayEventsForMatching,
+        dayNum,
+        helpers
+      })}${renderDayCellEvents({
+        date,
+        dayEvents,
+        hiddenEventCount,
+        visibleEvents,
+        helpers
+      })}
+      </div>
+    `;
+}
+
 function renderWeekCompactView({
   config,
   weekDays,
@@ -10758,24 +10819,25 @@ class SkylightCalendarCard extends HTMLElement {
     const visibleEvents = hasOverflow ? Math.max(0, maxVisible - 1) : maxVisible;
     const hiddenEventCount = Math.max(0, dayEvents.length - visibleEvents);
 
-    let classes = 'day-cell';
-    if (isOtherMonth) classes += ' other-month';
-    if (isToday) classes += ' today';
     const dayStyle = this.getDayStyleAttributes(date, dayEventsForMatching, isToday);
-    classes += dayStyle.className ? ` ${dayStyle.className}` : '';
-    const dayStyleAttr = dayStyle.style ? ` style="${dayStyle.style}"` : '';
 
-    return `
-      <div class="${classes}" data-date="${date.toISOString()}"${dayStyleAttr}>
-        <div class="day-header-row">
-          <div class="day-number">${dayNum}</div>
-          ${this.renderDayBadges(date, dayEventsForMatching)}
-          ${this.renderDayForecast(date, 'month')}
-        </div>
-        ${dayEvents.slice(0, visibleEvents).map(event => this.renderMonthDayEvent(event, date)).join('')}
-        ${hiddenEventCount > 0 ? `<div class="more-events" data-click-target="more-events">${this.t('moreEvents', { count: hiddenEventCount })}</div>` : ''}
-      </div>
-    `;
+    return renderDayCell({
+      date,
+      dayEvents,
+      dayEventsForMatching,
+      dayNum,
+      dayStyle,
+      hiddenEventCount,
+      isOtherMonth,
+      isToday,
+      visibleEvents,
+      helpers: {
+        renderDayBadges: this.renderDayBadges.bind(this),
+        renderDayForecast: this.renderDayForecast.bind(this),
+        renderMonthDayEvent: this.renderMonthDayEvent.bind(this),
+        t: this.t.bind(this)
+      }
+    });
   }
 
   renderMonthDayEvent(event, date) {

--- a/src/renderers/day-cell-renderer.js
+++ b/src/renderers/day-cell-renderer.js
@@ -1,0 +1,60 @@
+export function renderDayCellHeader({
+  date,
+  dayEventsForMatching,
+  dayNum,
+  helpers
+}) {
+  return `
+        <div class="day-header-row">
+          <div class="day-number">${dayNum}</div>
+          ${helpers.renderDayBadges(date, dayEventsForMatching)}
+          ${helpers.renderDayForecast(date, 'month')}
+        </div>`;
+}
+
+export function renderDayCellEvents({
+  date,
+  dayEvents,
+  hiddenEventCount,
+  visibleEvents,
+  helpers
+}) {
+  return `
+        ${dayEvents.slice(0, visibleEvents).map(event => helpers.renderMonthDayEvent(event, date)).join('')}
+        ${hiddenEventCount > 0 ? `<div class="more-events" data-click-target="more-events">${helpers.t('moreEvents', { count: hiddenEventCount })}</div>` : ''}`;
+}
+
+export function renderDayCell({
+  date,
+  dayEvents,
+  dayEventsForMatching,
+  dayNum,
+  dayStyle,
+  hiddenEventCount,
+  isOtherMonth,
+  isToday,
+  visibleEvents,
+  helpers
+}) {
+  let classes = 'day-cell';
+  if (isOtherMonth) classes += ' other-month';
+  if (isToday) classes += ' today';
+  classes += dayStyle.className ? ` ${dayStyle.className}` : '';
+  const dayStyleAttr = dayStyle.style ? ` style="${dayStyle.style}"` : '';
+
+  return `
+      <div class="${classes}" data-date="${date.toISOString()}"${dayStyleAttr}>${renderDayCellHeader({
+        date,
+        dayEventsForMatching,
+        dayNum,
+        helpers
+      })}${renderDayCellEvents({
+        date,
+        dayEvents,
+        hiddenEventCount,
+        visibleEvents,
+        helpers
+      })}
+      </div>
+    `;
+}

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -167,6 +167,7 @@ import {
   renderCalendarBadgesInline as renderCalendarBadgesInlineMarkup
 } from './renderers/calendar-badge-renderer.js';
 import { renderCreateEventForm, renderEditEventForm } from './renderers/event-form-renderer.js';
+import { renderDayCell } from './renderers/day-cell-renderer.js';
 import { renderWeekCompactView } from './renderers/week-compact-renderer.js';
 import { renderWeekStandardView } from './renderers/week-standard-renderer.js';
 import {
@@ -6876,24 +6877,25 @@ class SkylightCalendarCard extends HTMLElement {
     const visibleEvents = hasOverflow ? Math.max(0, maxVisible - 1) : maxVisible;
     const hiddenEventCount = Math.max(0, dayEvents.length - visibleEvents);
 
-    let classes = 'day-cell';
-    if (isOtherMonth) classes += ' other-month';
-    if (isToday) classes += ' today';
     const dayStyle = this.getDayStyleAttributes(date, dayEventsForMatching, isToday);
-    classes += dayStyle.className ? ` ${dayStyle.className}` : '';
-    const dayStyleAttr = dayStyle.style ? ` style="${dayStyle.style}"` : '';
 
-    return `
-      <div class="${classes}" data-date="${date.toISOString()}"${dayStyleAttr}>
-        <div class="day-header-row">
-          <div class="day-number">${dayNum}</div>
-          ${this.renderDayBadges(date, dayEventsForMatching)}
-          ${this.renderDayForecast(date, 'month')}
-        </div>
-        ${dayEvents.slice(0, visibleEvents).map(event => this.renderMonthDayEvent(event, date)).join('')}
-        ${hiddenEventCount > 0 ? `<div class="more-events" data-click-target="more-events">${this.t('moreEvents', { count: hiddenEventCount })}</div>` : ''}
-      </div>
-    `;
+    return renderDayCell({
+      date,
+      dayEvents,
+      dayEventsForMatching,
+      dayNum,
+      dayStyle,
+      hiddenEventCount,
+      isOtherMonth,
+      isToday,
+      visibleEvents,
+      helpers: {
+        renderDayBadges: this.renderDayBadges.bind(this),
+        renderDayForecast: this.renderDayForecast.bind(this),
+        renderMonthDayEvent: this.renderMonthDayEvent.bind(this),
+        t: this.t.bind(this)
+      }
+    });
   }
 
   renderMonthDayEvent(event, date) {


### PR DESCRIPTION
### Motivation
- Centralize month day-cell HTML composition to a dedicated renderer so month/rolling renderers can reuse identical markup while keeping card orchestration in the main element.
- Preserve every runtime and visual behavior while enabling future modular refactors that avoid duplicating string/HTML composition across renderers.

### Description
- Added `src/renderers/day-cell-renderer.js` which exports `renderDayCell`, `renderDayCellHeader`, and `renderDayCellEvents`, moving day-number/header markup, day badge/weather placement, visible month event rows, overflow (`.more-events`), `data-date` attribute output, class composition, and day style attribute output into the module.
- Updated `src/skylight-calendar-card.js` to import `renderDayCell` and delegate `renderDay(...)` to it while passing explicit inputs and narrow helper callbacks (`renderDayBadges`, `renderDayForecast`, `renderMonthDayEvent`, `t`).
- Kept event gathering/filtering/sorting, `getDayStyleAttributes`, click handlers, modal open/close behavior, DOM measurement, compact height behavior, `ResizeObserver` handling, layout logic, CSS, lifecycle, and Home Assistant orchestration in `src/skylight-calendar-card.js` (these were intentionally not moved).
- Did not move unrelated renderers, did not rename classes/attributes/config keys/translations, and preserved DOM structure, CSS class names, data attributes, and day-badge/weather/day-style behaviors.
- Regenerated the root `skylight-calendar-card.js` via Rollup and included the bundled renderer in the generated artifact.

### Testing
- Ran `npm ci --no-audit --fund=false` successfully and built with `npm run build` which produced a regenerated `skylight-calendar-card.js` artifact.
- Verified syntax checks with `node --check src/skylight-calendar-card.js`, `node --check src/renderers/day-cell-renderer.js`, and `node --check skylight-calendar-card.js`, all passing.
- Ran unit tests with `npm test` and all tests passed (`233` tests passed).
- Ran visual tests with `npm run test:visual` and all visual/regression snapshots passed (39 Playwright tests), producing no unintended snapshot differences.
- Confirmed the Rollup-generated root artifact was regenerated and included in the repository after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c7891f3388331b8594a52c9e1ded9)