### PR TITLE
Extract header rendering into renderer module

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3693,6 +3693,127 @@ ${renderEventFields({
     `;
 }
 
+function renderStandardHeader({
+  canAddEvents,
+  shouldShowControls,
+  helpers
+}) {
+  return `
+      <div class="header">
+        <div class="header-left">
+          ${helpers.renderDashboardNavButton()}
+          ${helpers.renderHeaderTitle()}
+        </div>
+        ${shouldShowControls ? `
+          <div class="header-controls">
+            ${canAddEvents ? `<button class="add-event-button" id="add-event-btn"><span class="icon">+</span>${helpers.t('addEvent')}</button>` : ''}
+            ${helpers.renderThemeToggle()}
+            <div class="period-controls">
+              ${helpers.renderPeriodNavigationButtons('previous')}
+              <div class="month-year">${helpers.getPeriodLabel()}</div>
+              ${helpers.renderPeriodNavigationButtons('next')}
+              ${helpers.renderPeriodNavigationButtons('today')}
+            </div>
+            ${helpers.renderViewModeButtons()}
+          </div>
+        ` : ''}
+      </div>
+    `;
+}
+
+function renderCompactHeader({
+  canAddEvents,
+  shouldShowCalendars,
+  shouldShowControls,
+  helpers
+}) {
+  return `
+      <div class="header header-compact">
+        <div class="compact-header-left">
+          ${helpers.renderDashboardNavButton()}
+          ${helpers.renderHeaderTitle()}
+          ${shouldShowCalendars ? helpers.renderCalendarBadgesInline() : ''}
+        </div>
+        ${shouldShowControls ? `
+          <div class="header-controls compact-header-controls">
+            <div class="compact-period-controls">
+              ${helpers.renderPeriodNavigationButtons('previous')}
+              <div class="month-year">${helpers.getPeriodLabel()}</div>
+              ${helpers.renderPeriodNavigationButtons('next')}
+              ${helpers.renderPeriodNavigationButtons('today')}
+            </div>
+            ${canAddEvents ? `<button class="compact-add-event-button" id="add-event-btn" aria-label="${helpers.t('addEvent')}" title="${helpers.t('addEvent')}">+</button>` : ''}
+            ${helpers.renderThemeToggle()}
+            ${helpers.renderViewModeButtons()}
+          </div>
+        ` : ''}
+      </div>
+    `;
+}
+
+function renderHeaderTitle({
+  title,
+  headerTime,
+  headerWeather,
+  helpers
+}) {
+  return `
+      <div class="header-title-wrap">
+        <h2 class="header-title">${helpers.escapeHtml(title || '')}</h2>
+        ${headerTime ? `<span class="header-time">${helpers.escapeHtml(headerTime)}</span>` : ''}
+        ${headerWeather ? `<span class="header-weather"><ha-icon icon="${helpers.escapeHtml(headerWeather.conditionIcon)}"></ha-icon>${helpers.escapeHtml(headerWeather.temperature)}</span>` : ''}
+      </div>
+    `;
+}
+
+function renderDashboardNavButton({ shouldShow, helpers }) {
+  if (!shouldShow) return '';
+  return `<button class="dashboard-nav-button" id="header-dashboard-btn" aria-label="${helpers.t('openDashboard')}" title="${helpers.t('openDashboard')}">⌂</button>`;
+}
+
+function renderPeriodNavigationButtons({
+  buttonType,
+  hideNavigationButtons,
+  shouldDisablePreviousNavigation,
+  helpers
+}) {
+  if (hideNavigationButtons) return '';
+
+  if (buttonType === 'previous') {
+    return `<button class="nav-button" id="prev-period" ${shouldDisablePreviousNavigation ? 'disabled' : ''}>‹</button>`;
+  }
+
+  if (buttonType === 'next') {
+    return '<button class="nav-button" id="next-period">›</button>';
+  }
+
+  if (buttonType === 'today') {
+    return `<button class="today-button" id="today">${helpers.t('today')}</button>`;
+  }
+
+  return '';
+}
+
+function renderViewModeButtons({ hideViewSelector, viewMode, helpers }) {
+  if (hideViewSelector) return '';
+
+  return `
+      <div class="view-mode-buttons">
+        <select class="view-mode-select" id="view-mode-select" aria-label="Select calendar view">
+          <option value="month" ${viewMode === 'month' ? 'selected' : ''}>${helpers.t('month')}</option>
+          <option value="week-compact" ${viewMode === 'week-compact' ? 'selected' : ''}>${helpers.t('week')}</option>
+          <option value="week-standard" ${viewMode === 'week-standard' ? 'selected' : ''}>${helpers.t('schedule')}</option>
+          <option value="agenda" ${viewMode === 'agenda' ? 'selected' : ''}>${helpers.t('agenda')}</option>
+        </select>
+      </div>
+    `;
+}
+
+function renderThemeToggle({ hideDarkModeToggle, isDarkMode }) {
+  if (hideDarkModeToggle) return '';
+  return `<button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">${isDarkMode ? '☀︎' : '☾'}</button>`;
+}
+
 function renderDayCellHeader({
   date,
   dayEventsForMatching,
@@ -9614,32 +9735,30 @@ class SkylightCalendarCard extends HTMLElement {
     }
   }
 
+  getHeaderRenderHelpers() {
+    return {
+      escapeHtml: (value) => this.escapeHtml(value),
+      getPeriodLabel: () => this.getPeriodLabel(),
+      renderCalendarBadgesInline: () => this.renderCalendarBadgesInline(),
+      renderDashboardNavButton: () => this.renderDashboardNavButton(),
+      renderHeaderTitle: () => this.renderHeaderTitle(),
+      renderPeriodNavigationButtons: (buttonType) => this.renderPeriodNavigationButtons(buttonType),
+      renderThemeToggle: () => this.renderThemeToggle(),
+      renderViewModeButtons: () => this.renderViewModeButtons(),
+      t: (key, params) => this.t(key, params)
+    };
+  }
+
   renderStandardHeader() {
     const writableCalendars = this.getWritableCalendars();
     const canAddEvents = this._config.enable_event_management && writableCalendars.length > 0 && !this._config.hide_add_event_button;
     const shouldShowControls = !this._config.hide_controls;
 
-    return `
-      <div class="header">
-        <div class="header-left">
-          ${this.renderDashboardNavButton()}
-          ${this.renderHeaderTitle()}
-        </div>
-        ${shouldShowControls ? `
-          <div class="header-controls">
-            ${canAddEvents ? `<button class="add-event-button" id="add-event-btn"><span class="icon">+</span>${this.t('addEvent')}</button>` : ''}
-            ${this.renderThemeToggle()}
-            <div class="period-controls">
-              ${this.renderPeriodNavigationButtons('previous')}
-              <div class="month-year">${this.getPeriodLabel()}</div>
-              ${this.renderPeriodNavigationButtons('next')}
-              ${this.renderPeriodNavigationButtons('today')}
-            </div>
-            ${this.renderViewModeButtons()}
-          </div>
-        ` : ''}
-      </div>
-    `;
+    return renderStandardHeader({
+      canAddEvents,
+      shouldShowControls,
+      helpers: this.getHeaderRenderHelpers()
+    });
   }
 
   renderCompactHeader() {
@@ -9648,28 +9767,12 @@ class SkylightCalendarCard extends HTMLElement {
     const shouldShowCalendars = !this._config.hide_calendars;
     const shouldShowControls = !this._config.hide_controls;
 
-    return `
-      <div class="header header-compact">
-        <div class="compact-header-left">
-          ${this.renderDashboardNavButton()}
-          ${this.renderHeaderTitle()}
-          ${shouldShowCalendars ? this.renderCalendarBadgesInline() : ''}
-        </div>
-        ${shouldShowControls ? `
-          <div class="header-controls compact-header-controls">
-            <div class="compact-period-controls">
-              ${this.renderPeriodNavigationButtons('previous')}
-              <div class="month-year">${this.getPeriodLabel()}</div>
-              ${this.renderPeriodNavigationButtons('next')}
-              ${this.renderPeriodNavigationButtons('today')}
-            </div>
-            ${canAddEvents ? `<button class="compact-add-event-button" id="add-event-btn" aria-label="${this.t('addEvent')}" title="${this.t('addEvent')}">+</button>` : ''}
-            ${this.renderThemeToggle()}
-            ${this.renderViewModeButtons()}
-          </div>
-        ` : ''}
-      </div>
-    `;
+    return renderCompactHeader({
+      canAddEvents,
+      shouldShowCalendars,
+      shouldShowControls,
+      helpers: this.getHeaderRenderHelpers()
+    });
   }
 
   getCalendarBadgeRenderHelpers() {
@@ -9698,56 +9801,43 @@ class SkylightCalendarCard extends HTMLElement {
   renderHeaderTitle() {
     const headerTime = this.getFormattedHeaderSensorTime();
     const headerWeather = this.getHeaderWeatherData();
-    return `
-      <div class="header-title-wrap">
-        <h2 class="header-title">${this.escapeHtml(this._config.title || '')}</h2>
-        ${headerTime ? `<span class="header-time">${this.escapeHtml(headerTime)}</span>` : ''}
-        ${headerWeather ? `<span class="header-weather"><ha-icon icon="${this.escapeHtml(headerWeather.conditionIcon)}"></ha-icon>${this.escapeHtml(headerWeather.temperature)}</span>` : ''}
-      </div>
-    `;
+    return renderHeaderTitle({
+      title: this._config.title,
+      headerTime,
+      headerWeather,
+      helpers: this.getHeaderRenderHelpers()
+    });
   }
 
   renderDashboardNavButton() {
-    if (!this.shouldShowDashboardNavButton()) return '';
-    return `<button class="dashboard-nav-button" id="header-dashboard-btn" aria-label="${this.t('openDashboard')}" title="${this.t('openDashboard')}">⌂</button>`;
+    return renderDashboardNavButton({
+      shouldShow: this.shouldShowDashboardNavButton(),
+      helpers: this.getHeaderRenderHelpers()
+    });
   }
 
   renderPeriodNavigationButtons(buttonType) {
-    if (this._config.hide_navigation_buttons) return '';
-
-    if (buttonType === 'previous') {
-      return `<button class="nav-button" id="prev-period" ${this.shouldDisablePreviousNavigation() ? 'disabled' : ''}>‹</button>`;
-    }
-
-    if (buttonType === 'next') {
-      return '<button class="nav-button" id="next-period">›</button>';
-    }
-
-    if (buttonType === 'today') {
-      return `<button class="today-button" id="today">${this.t('today')}</button>`;
-    }
-
-    return '';
+    return renderPeriodNavigationButtons({
+      buttonType,
+      hideNavigationButtons: this._config.hide_navigation_buttons,
+      shouldDisablePreviousNavigation: this.shouldDisablePreviousNavigation(),
+      helpers: this.getHeaderRenderHelpers()
+    });
   }
 
   renderViewModeButtons() {
-    if (this._config.hide_view_selector) return '';
-
-    return `
-      <div class="view-mode-buttons">
-        <select class="view-mode-select" id="view-mode-select" aria-label="Select calendar view">
-          <option value="month" ${this._viewMode === 'month' ? 'selected' : ''}>${this.t('month')}</option>
-          <option value="week-compact" ${this._viewMode === 'week-compact' ? 'selected' : ''}>${this.t('week')}</option>
-          <option value="week-standard" ${this._viewMode === 'week-standard' ? 'selected' : ''}>${this.t('schedule')}</option>
-          <option value="agenda" ${this._viewMode === 'agenda' ? 'selected' : ''}>${this.t('agenda')}</option>
-        </select>
-      </div>
-    `;
+    return renderViewModeButtons({
+      hideViewSelector: this._config.hide_view_selector,
+      viewMode: this._viewMode,
+      helpers: this.getHeaderRenderHelpers()
+    });
   }
 
   renderThemeToggle() {
-    if (this._config.hide_dark_mode_toggle) return '';
-    return `<button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">${this._isDarkMode ? '☀︎' : '☾'}</button>`;
+    return renderThemeToggle({
+      hideDarkModeToggle: this._config.hide_dark_mode_toggle,
+      isDarkMode: this._isDarkMode
+    });
   }
 
   getPeriodLabel() {

--- a/src/renderers/header-renderer.js
+++ b/src/renderers/header-renderer.js
@@ -1,0 +1,120 @@
+export function renderStandardHeader({
+  canAddEvents,
+  shouldShowControls,
+  helpers
+}) {
+  return `
+      <div class="header">
+        <div class="header-left">
+          ${helpers.renderDashboardNavButton()}
+          ${helpers.renderHeaderTitle()}
+        </div>
+        ${shouldShowControls ? `
+          <div class="header-controls">
+            ${canAddEvents ? `<button class="add-event-button" id="add-event-btn"><span class="icon">+</span>${helpers.t('addEvent')}</button>` : ''}
+            ${helpers.renderThemeToggle()}
+            <div class="period-controls">
+              ${helpers.renderPeriodNavigationButtons('previous')}
+              <div class="month-year">${helpers.getPeriodLabel()}</div>
+              ${helpers.renderPeriodNavigationButtons('next')}
+              ${helpers.renderPeriodNavigationButtons('today')}
+            </div>
+            ${helpers.renderViewModeButtons()}
+          </div>
+        ` : ''}
+      </div>
+    `;
+}
+
+export function renderCompactHeader({
+  canAddEvents,
+  shouldShowCalendars,
+  shouldShowControls,
+  helpers
+}) {
+  return `
+      <div class="header header-compact">
+        <div class="compact-header-left">
+          ${helpers.renderDashboardNavButton()}
+          ${helpers.renderHeaderTitle()}
+          ${shouldShowCalendars ? helpers.renderCalendarBadgesInline() : ''}
+        </div>
+        ${shouldShowControls ? `
+          <div class="header-controls compact-header-controls">
+            <div class="compact-period-controls">
+              ${helpers.renderPeriodNavigationButtons('previous')}
+              <div class="month-year">${helpers.getPeriodLabel()}</div>
+              ${helpers.renderPeriodNavigationButtons('next')}
+              ${helpers.renderPeriodNavigationButtons('today')}
+            </div>
+            ${canAddEvents ? `<button class="compact-add-event-button" id="add-event-btn" aria-label="${helpers.t('addEvent')}" title="${helpers.t('addEvent')}">+</button>` : ''}
+            ${helpers.renderThemeToggle()}
+            ${helpers.renderViewModeButtons()}
+          </div>
+        ` : ''}
+      </div>
+    `;
+}
+
+export function renderHeaderTitle({
+  title,
+  headerTime,
+  headerWeather,
+  helpers
+}) {
+  return `
+      <div class="header-title-wrap">
+        <h2 class="header-title">${helpers.escapeHtml(title || '')}</h2>
+        ${headerTime ? `<span class="header-time">${helpers.escapeHtml(headerTime)}</span>` : ''}
+        ${headerWeather ? `<span class="header-weather"><ha-icon icon="${helpers.escapeHtml(headerWeather.conditionIcon)}"></ha-icon>${helpers.escapeHtml(headerWeather.temperature)}</span>` : ''}
+      </div>
+    `;
+}
+
+export function renderDashboardNavButton({ shouldShow, helpers }) {
+  if (!shouldShow) return '';
+  return `<button class="dashboard-nav-button" id="header-dashboard-btn" aria-label="${helpers.t('openDashboard')}" title="${helpers.t('openDashboard')}">⌂</button>`;
+}
+
+export function renderPeriodNavigationButtons({
+  buttonType,
+  hideNavigationButtons,
+  shouldDisablePreviousNavigation,
+  helpers
+}) {
+  if (hideNavigationButtons) return '';
+
+  if (buttonType === 'previous') {
+    return `<button class="nav-button" id="prev-period" ${shouldDisablePreviousNavigation ? 'disabled' : ''}>‹</button>`;
+  }
+
+  if (buttonType === 'next') {
+    return '<button class="nav-button" id="next-period">›</button>';
+  }
+
+  if (buttonType === 'today') {
+    return `<button class="today-button" id="today">${helpers.t('today')}</button>`;
+  }
+
+  return '';
+}
+
+export function renderViewModeButtons({ hideViewSelector, viewMode, helpers }) {
+  if (hideViewSelector) return '';
+
+  return `
+      <div class="view-mode-buttons">
+        <select class="view-mode-select" id="view-mode-select" aria-label="Select calendar view">
+          <option value="month" ${viewMode === 'month' ? 'selected' : ''}>${helpers.t('month')}</option>
+          <option value="week-compact" ${viewMode === 'week-compact' ? 'selected' : ''}>${helpers.t('week')}</option>
+          <option value="week-standard" ${viewMode === 'week-standard' ? 'selected' : ''}>${helpers.t('schedule')}</option>
+          <option value="agenda" ${viewMode === 'agenda' ? 'selected' : ''}>${helpers.t('agenda')}</option>
+        </select>
+      </div>
+    `;
+}
+
+export function renderThemeToggle({ hideDarkModeToggle, isDarkMode }) {
+  if (hideDarkModeToggle) return '';
+  return `<button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">${isDarkMode ? '☀︎' : '☾'}</button>`;
+}

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -167,6 +167,15 @@ import {
   renderCalendarBadgesInline as renderCalendarBadgesInlineMarkup
 } from './renderers/calendar-badge-renderer.js';
 import { renderCreateEventForm, renderEditEventForm } from './renderers/event-form-renderer.js';
+import {
+  renderCompactHeader as renderCompactHeaderMarkup,
+  renderDashboardNavButton as renderDashboardNavButtonMarkup,
+  renderHeaderTitle as renderHeaderTitleMarkup,
+  renderPeriodNavigationButtons as renderPeriodNavigationButtonsMarkup,
+  renderStandardHeader as renderStandardHeaderMarkup,
+  renderThemeToggle as renderThemeToggleMarkup,
+  renderViewModeButtons as renderViewModeButtonsMarkup
+} from './renderers/header-renderer.js';
 import { renderDayCell } from './renderers/day-cell-renderer.js';
 import { renderWeekCompactView } from './renderers/week-compact-renderer.js';
 import { renderWeekStandardView } from './renderers/week-standard-renderer.js';
@@ -5672,32 +5681,30 @@ class SkylightCalendarCard extends HTMLElement {
     }
   }
 
+  getHeaderRenderHelpers() {
+    return {
+      escapeHtml: (value) => this.escapeHtml(value),
+      getPeriodLabel: () => this.getPeriodLabel(),
+      renderCalendarBadgesInline: () => this.renderCalendarBadgesInline(),
+      renderDashboardNavButton: () => this.renderDashboardNavButton(),
+      renderHeaderTitle: () => this.renderHeaderTitle(),
+      renderPeriodNavigationButtons: (buttonType) => this.renderPeriodNavigationButtons(buttonType),
+      renderThemeToggle: () => this.renderThemeToggle(),
+      renderViewModeButtons: () => this.renderViewModeButtons(),
+      t: (key, params) => this.t(key, params)
+    };
+  }
+
   renderStandardHeader() {
     const writableCalendars = this.getWritableCalendars();
     const canAddEvents = this._config.enable_event_management && writableCalendars.length > 0 && !this._config.hide_add_event_button;
     const shouldShowControls = !this._config.hide_controls;
 
-    return `
-      <div class="header">
-        <div class="header-left">
-          ${this.renderDashboardNavButton()}
-          ${this.renderHeaderTitle()}
-        </div>
-        ${shouldShowControls ? `
-          <div class="header-controls">
-            ${canAddEvents ? `<button class="add-event-button" id="add-event-btn"><span class="icon">+</span>${this.t('addEvent')}</button>` : ''}
-            ${this.renderThemeToggle()}
-            <div class="period-controls">
-              ${this.renderPeriodNavigationButtons('previous')}
-              <div class="month-year">${this.getPeriodLabel()}</div>
-              ${this.renderPeriodNavigationButtons('next')}
-              ${this.renderPeriodNavigationButtons('today')}
-            </div>
-            ${this.renderViewModeButtons()}
-          </div>
-        ` : ''}
-      </div>
-    `;
+    return renderStandardHeaderMarkup({
+      canAddEvents,
+      shouldShowControls,
+      helpers: this.getHeaderRenderHelpers()
+    });
   }
 
   renderCompactHeader() {
@@ -5706,28 +5713,12 @@ class SkylightCalendarCard extends HTMLElement {
     const shouldShowCalendars = !this._config.hide_calendars;
     const shouldShowControls = !this._config.hide_controls;
 
-    return `
-      <div class="header header-compact">
-        <div class="compact-header-left">
-          ${this.renderDashboardNavButton()}
-          ${this.renderHeaderTitle()}
-          ${shouldShowCalendars ? this.renderCalendarBadgesInline() : ''}
-        </div>
-        ${shouldShowControls ? `
-          <div class="header-controls compact-header-controls">
-            <div class="compact-period-controls">
-              ${this.renderPeriodNavigationButtons('previous')}
-              <div class="month-year">${this.getPeriodLabel()}</div>
-              ${this.renderPeriodNavigationButtons('next')}
-              ${this.renderPeriodNavigationButtons('today')}
-            </div>
-            ${canAddEvents ? `<button class="compact-add-event-button" id="add-event-btn" aria-label="${this.t('addEvent')}" title="${this.t('addEvent')}">+</button>` : ''}
-            ${this.renderThemeToggle()}
-            ${this.renderViewModeButtons()}
-          </div>
-        ` : ''}
-      </div>
-    `;
+    return renderCompactHeaderMarkup({
+      canAddEvents,
+      shouldShowCalendars,
+      shouldShowControls,
+      helpers: this.getHeaderRenderHelpers()
+    });
   }
 
   getCalendarBadgeRenderHelpers() {
@@ -5756,56 +5747,43 @@ class SkylightCalendarCard extends HTMLElement {
   renderHeaderTitle() {
     const headerTime = this.getFormattedHeaderSensorTime();
     const headerWeather = this.getHeaderWeatherData();
-    return `
-      <div class="header-title-wrap">
-        <h2 class="header-title">${this.escapeHtml(this._config.title || '')}</h2>
-        ${headerTime ? `<span class="header-time">${this.escapeHtml(headerTime)}</span>` : ''}
-        ${headerWeather ? `<span class="header-weather"><ha-icon icon="${this.escapeHtml(headerWeather.conditionIcon)}"></ha-icon>${this.escapeHtml(headerWeather.temperature)}</span>` : ''}
-      </div>
-    `;
+    return renderHeaderTitleMarkup({
+      title: this._config.title,
+      headerTime,
+      headerWeather,
+      helpers: this.getHeaderRenderHelpers()
+    });
   }
 
   renderDashboardNavButton() {
-    if (!this.shouldShowDashboardNavButton()) return '';
-    return `<button class="dashboard-nav-button" id="header-dashboard-btn" aria-label="${this.t('openDashboard')}" title="${this.t('openDashboard')}">⌂</button>`;
+    return renderDashboardNavButtonMarkup({
+      shouldShow: this.shouldShowDashboardNavButton(),
+      helpers: this.getHeaderRenderHelpers()
+    });
   }
 
   renderPeriodNavigationButtons(buttonType) {
-    if (this._config.hide_navigation_buttons) return '';
-
-    if (buttonType === 'previous') {
-      return `<button class="nav-button" id="prev-period" ${this.shouldDisablePreviousNavigation() ? 'disabled' : ''}>‹</button>`;
-    }
-
-    if (buttonType === 'next') {
-      return '<button class="nav-button" id="next-period">›</button>';
-    }
-
-    if (buttonType === 'today') {
-      return `<button class="today-button" id="today">${this.t('today')}</button>`;
-    }
-
-    return '';
+    return renderPeriodNavigationButtonsMarkup({
+      buttonType,
+      hideNavigationButtons: this._config.hide_navigation_buttons,
+      shouldDisablePreviousNavigation: this.shouldDisablePreviousNavigation(),
+      helpers: this.getHeaderRenderHelpers()
+    });
   }
 
   renderViewModeButtons() {
-    if (this._config.hide_view_selector) return '';
-
-    return `
-      <div class="view-mode-buttons">
-        <select class="view-mode-select" id="view-mode-select" aria-label="Select calendar view">
-          <option value="month" ${this._viewMode === 'month' ? 'selected' : ''}>${this.t('month')}</option>
-          <option value="week-compact" ${this._viewMode === 'week-compact' ? 'selected' : ''}>${this.t('week')}</option>
-          <option value="week-standard" ${this._viewMode === 'week-standard' ? 'selected' : ''}>${this.t('schedule')}</option>
-          <option value="agenda" ${this._viewMode === 'agenda' ? 'selected' : ''}>${this.t('agenda')}</option>
-        </select>
-      </div>
-    `;
+    return renderViewModeButtonsMarkup({
+      hideViewSelector: this._config.hide_view_selector,
+      viewMode: this._viewMode,
+      helpers: this.getHeaderRenderHelpers()
+    });
   }
 
   renderThemeToggle() {
-    if (this._config.hide_dark_mode_toggle) return '';
-    return `<button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">${this._isDarkMode ? '☀︎' : '☾'}</button>`;
+    return renderThemeToggleMarkup({
+      hideDarkModeToggle: this._config.hide_dark_mode_toggle,
+      isDarkMode: this._isDarkMode
+    });
   }
 
   getPeriodLabel() {


### PR DESCRIPTION
### Motivation
- Move header HTML/string composition out of the main card into a focused renderer to continue the Phase 26 modularization while preserving runtime and visual behavior.
- Keep interaction, state, Home Assistant orchestration, and DOM measurement logic in the main card so only output-only rendering is extracted.

### Description
- Added `src/renderers/header-renderer.js` which implements header-only output helpers: `renderStandardHeader`, `renderCompactHeader`, `renderHeaderTitle`, `renderDashboardNavButton`, `renderPeriodNavigationButtons`, `renderViewModeButtons`, and `renderThemeToggle`.
- Updated `src/skylight-calendar-card.js` to import the new renderer functions and delegate header composition via a new `getHeaderRenderHelpers()` method that passes narrow helper callbacks and explicit inputs rather than the whole card instance.
- Intentionally left navigation handlers, click listeners, view-change handlers, dark-mode preference mutation, dashboard navigation behavior, header time/weather entity subscriptions, and Home Assistant orchestration in `src/skylight-calendar-card.js` because those are state/behavior concerns and not output-only rendering.
- Did not move or alter unrelated renderers, and did not change CSS, DOM structure, IDs, classes, data attributes, public config names, translations, button behavior, navigation behavior, or visual output.
- Regenerated the shipped artifact `skylight-calendar-card.js` with Rollup and committed the updated artifact alongside the source changes.

### Testing
- Ran `npm ci --no-audit --fund=false`, `npm run build`, and validated that the root `skylight-calendar-card.js` artifact was regenerated and clean after the change.
- Performed syntax checks with `node --check src/skylight-calendar-card.js`, `node --check src/renderers/header-renderer.js`, and `node --check skylight-calendar-card.js` and they succeeded.
- Executed unit tests with `npm test` and the full test suite passed (all tests green).
- Executed visual tests with `npm run test:visual` and Playwright visual suite passed with no visual snapshot differences.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c80dc21c483318934bc67b849f3ae)