### PR TITLE
Phase 28: Document module map and renderer-wrapper checkpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ The project was formerly named Skylight Calendar Card. The public name is now Da
 
 Current modules are organized around these boundaries. Future modules may be added, but new modules should preserve the same separation principles and keep card-instance orchestration separate from pure/data-only helpers.
 
-* `src/skylight-calendar-card.js`: main custom element, lifecycle, Home Assistant orchestration, rendering/templates, DOM measurement, scroll restoration, CSS, modal/editor DOM behavior, and event handlers.
+* `src/skylight-calendar-card.js`: main custom element, lifecycle, Home Assistant orchestration, view composition, renderer callback wiring, DOM measurement, scroll restoration, modal/editor DOM behavior, preference persistence, service behavior, and event handlers.
 * `src/translations.js`: translation data.
 * `src/constants.js`: shared static constants.
 * `src/defaults.js`: default config values, option lists, aliases, and stub config creation.
@@ -50,11 +50,13 @@ Current modules are organized around these boundaries. Future modules may be add
 * `src/views/week-view-model.js`: week and rolling-days view-model helpers.
 * `src/views/agenda-view-model.js`: agenda visible-range and rolling-days view-model helpers.
 * `src/calendars/calendar-entities.js`: calendar entity metadata, colors, names, virtual calendar badges, writable calendars, and person mappings.
+* `src/renderers/`: extracted markup renderers for header, month, day cells, week compact, week standard, agenda, shared events, modals/forms, editor controls, calendar badges, and day/weather helpers. Renderers receive explicit data and callbacks from the card.
+* `src/styles/card-styles.js`: static card CSS used by the main custom element.
 
 ## Modularization guardrails
 
 * Prefer extracting pure/data-only logic before rendering or DOM logic.
-* Keep render methods, Lit/HTML templates, CSS, DOM querying, lifecycle methods, modal rendering, editor rendering, and Home Assistant service orchestration in `src/skylight-calendar-card.js` unless a prompt explicitly asks to move that area.
+* Keep lifecycle methods, card-instance view composition, renderer callback wiring, DOM querying, modal behavior, editor behavior, preference persistence, ResizeObserver/compact-height behavior, and Home Assistant service orchestration in `src/skylight-calendar-card.js` unless a prompt explicitly asks to move that area.
 * New modules should receive explicit inputs/helpers rather than importing or depending on card instance state.
 * Do not pass the whole card instance into helper modules unless explicitly justified.
 * Preserve public config option names, custom element names, CSS class names, DOM structure, and visual behavior.
@@ -63,7 +65,7 @@ Current modules are organized around these boundaries. Future modules may be add
 
 ## Working in `src/`
 
-Most source work should start in `src/`. `src/skylight-calendar-card.js` remains large and tightly coupled because it owns lifecycle, rendering, DOM, CSS, and orchestration. Before editing:
+Most source work should start in `src/`. `src/skylight-calendar-card.js` remains large and tightly coupled because it owns lifecycle, view composition, renderer callback wiring, DOM behavior, and orchestration. Before editing:
 
 1. Find the existing feature area and existing module boundary.
 2. Reuse existing modules/helpers before adding new ones.

--- a/src/README.md
+++ b/src/README.md
@@ -4,45 +4,84 @@
 
 ## Main custom element
 
-`src/skylight-calendar-card.js` remains the Rollup entry point and main custom element source. It still owns the card-instance responsibilities that have not been extracted:
+`src/skylight-calendar-card.js` remains the Rollup entry point and main custom element source. After the renderer extractions through Phase 27, it still intentionally owns card-instance responsibilities that depend on live Home Assistant state, DOM state, browser APIs, or custom-element lifecycle:
 
-- custom element lifecycle
-- Home Assistant integration and orchestration
-- rendering methods, Lit/HTML templates, and view composition
-- CSS
-- DOM measurement
-- scroll restoration
-- modal and editor DOM behavior
-- event handlers
+- custom element lifecycle and registration compatibility
+- config normalization orchestration and preference persistence
+- Home Assistant integration, service calls, capability checks, and event fetching
+- view composition and renderer callback wiring
+- DOM reads/writes, ResizeObserver handling, compact-height measurement, and scroll restoration
+- modal behavior and editor/card event handlers
+- compatibility wrapper methods that keep extracted renderers isolated from card internals
 
-Do not move renderers, CSS, DOM structure, modal/editor rendering, or service orchestration unless a change is explicitly scoped to do that work.
+Do not move lifecycle, service orchestration, DOM structure, modal behavior, event handlers, or compatibility aliases unless a change is explicitly scoped to do that work.
 
 ## Extracted module areas
 
-The current post-Phase 13 module layout keeps pure/data-only helpers outside the main custom element while leaving rendering in `src/skylight-calendar-card.js`:
+The current post-Phase 27 module layout keeps pure/data helpers and renderer markup helpers outside the main custom element while leaving card-instance orchestration in `src/skylight-calendar-card.js`:
+
+### Core data, defaults, and translations
 
 - `constants.js`: shared static constants used across source modules and the card.
 - `defaults.js`: default config values, option lists, config aliases, and stub config creation.
 - `translations.js`: translation strings and locale data.
-- `utils/`: pure utility helpers for dates, normalization, and strings.
+
+### Utilities and view models
+
+- `utils/date-utils.js`: date parsing, local date formatting, range chunking, and ISO week helpers.
+- `utils/normalization-utils.js`: small normalization helpers for enums, booleans, dashboard paths, and entity maps.
+- `utils/string-utils.js`: string and HTML-attribute escaping helpers.
+- `views/month-view-model.js`: month-grid date and visible-range view-model helpers.
+- `views/week-view-model.js`: week and rolling-days view-model helpers.
+- `views/agenda-view-model.js`: agenda window, visible-range, and rolling-days view-model helpers.
+
+### Calendar, event, weather, badge, and rule helpers
+
+- `calendars/calendar-entities.js`: calendar entity metadata, colors, names, virtual calendar badges, writable calendars, and person mappings.
 - `events/event-normalizer.js`: Home Assistant calendar event normalization and combined-event data shaping.
-- `events/event-form.js`: event form validation and create/update data normalization.
+- `events/event-form.js`: event form validation, recurrence helpers, and create/update data normalization.
 - `events/event-service.js`: Home Assistant calendar event service and WebSocket payload helpers.
 - `events/event-display.js`: non-rendering event display decisions, including time/location visibility, badge data, and schedule visual metadata.
 - `rules/condition-matcher.js`: condition and value matching helpers for rule evaluation.
 - `rules/style-rules.js`: style rule normalization and matching helpers.
-- `badges/day-badges.js`: day badge normalization, matching, and display data helpers.
+- `badges/day-badges.js`: day badge normalization, matching, template resolution, and display data helpers.
 - `weather/weather-utils.js`: weather formatting, icon, temperature, and forecast utility helpers.
 - `weather/weather-service.js`: weather entity discovery and Home Assistant weather service payload helpers.
 - `editor/editor-schema.js`: editor default values, option metadata, and config normalization helpers for the editor.
-- `views/month-view-model.js`: month-grid date and visible-range view-model helpers.
-- `views/week-view-model.js`: week and rolling-days view-model helpers.
-- `views/agenda-view-model.js`: agenda visible-range and rolling-days view-model helpers.
-- `calendars/calendar-entities.js`: calendar entity metadata, colors, names, virtual calendar badges, writable calendars, and person mappings.
+
+### Renderers and styles
+
+Renderer modules return existing markup for specific card regions. They receive explicit data and helper callbacks from the main card instead of importing card-instance state.
+
+- `renderers/header-renderer.js`: standard/compact header, title, navigation, view selector, dashboard button, and theme toggle markup.
+- `renderers/month-renderer.js`: month view shell, day headers, month day grid, and week-number row cells.
+- `renderers/day-cell-renderer.js`: month day-cell markup.
+- `renderers/week-compact-renderer.js`: compact week view markup.
+- `renderers/week-standard-renderer.js`: schedule/week-standard view markup.
+- `renderers/agenda-renderer.js`: agenda view markup.
+- `renderers/event-renderer.js`: shared event bubble/icon/title/corner-bubble markup helpers.
+- `renderers/event-modal-renderer.js`: event detail modal markup.
+- `renderers/event-form-renderer.js`: create/edit event form modal markup.
+- `renderers/editor-renderer.js`: reusable editor section, color input, and weekday checkbox markup.
+- `renderers/calendar-badge-renderer.js`: calendar badge containers, labels, and icons.
+- `renderers/day-weather-renderer.js`: day badge and day forecast markup.
+- `styles/card-styles.js`: static card CSS string used by the main custom element.
+
+## Renderer wrapper checkpoint
+
+Phase 28 reviewed the remaining render-related methods in `src/skylight-calendar-card.js` as a conservative checkpoint. The remaining wrappers are intentionally kept when they do at least one of the following:
+
+- compose card-instance state before calling an extracted renderer;
+- provide callback bridges so renderers do not depend on the card instance;
+- preserve compatibility with existing tests or legacy method call sites;
+- perform DOM, Home Assistant, modal, preference, or service orchestration that belongs in the main custom element.
+
+Only obviously unused wrappers should be removed in future phases, and only after confirming they are not referenced by `src/`, tests, renderer callbacks, or compatibility paths.
 
 ## Guardrails for future phases
 
-- Prefer direct module tests for extracted pure/data helpers before moving any renderer code.
+- Prefer direct module tests for extracted pure/data helpers before moving any additional behavior.
 - Keep helpers explicit: pass inputs and callbacks instead of importing or depending on the card instance.
 - Preserve public config option names, custom element names, CSS class names, DOM structure, translations, and visual behavior unless a prompt explicitly requests a behavior change.
 - Preserve both `daylight-calendar-card` and legacy `skylight-calendar-card` compatibility.
+- Treat visual/layout changes as potentially breaking for dashboard users.


### PR DESCRIPTION
### Motivation
- Capture a conservative post-Phase-15–27 checkpoint documenting extracted renderers, styles, and current module map. 
- Confirm which render-wrapper methods remain intentionally in the main card and avoid risky removals at this stage. 
- Keep the change small and behavior-preserving while improving developer guidance for future modularization phases.

### Description
- Updated `src/README.md` to reflect the post-Phase-27 module layout, enumerate extracted renderer modules under `src/renderers/`, and clarify the main card responsibilities (lifecycle, view composition, renderer callback wiring, DOM/ResizeObserver/compact-height handling, preference persistence, modal/editor behavior, and service orchestration). 
- Updated `AGENTS.md` to match the same module-boundary guidance and to explicitly mention `src/renderers/` and `src/styles/card-styles.js`. 
- Performed a conservative review of render-wrapper methods and removed nothing because remaining wrappers are used for orchestration, renderer callback bridges, compatibility, or card-instance responsibilities. 
- No renderer extractions, runtime behavior changes, CSS, DOM structure, class/ID/data-attribute, config name, or translation changes were made.

### Testing
- Ran `npm ci --no-audit --fund=false` which completed successfully. 
- Ran `npm run build` (Rollup executed); the build completed and the root `skylight-calendar-card.js` artifact remained unchanged relative to the committed file. 
- Verified `node --check src/skylight-calendar-card.js` and `node --check skylight-calendar-card.js` with no errors. 
- Ran `npm test` (unit Node tests) — all tests passed (`233` tests passed, `0` failed). 
- Ran `npm run test:visual` (Playwright visual tests) — all visual tests passed (`39` passed). 
- No visual snapshot differences were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c935c02688331967b837a28b4c701)