### PR TITLE
Phase 29: Extract Home Assistant state helpers into src/ha/ha-state-helpers.js

### DIFF
--- a/ha-state-helpers.test.mjs
+++ b/ha-state-helpers.test.mjs
@@ -1,0 +1,61 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  getEntityFriendlyName,
+  getEntityIcon,
+  getEntityPicture,
+  getEntityPictureUrl,
+  getEntityState,
+  getFormattedHeaderSensorTime,
+  getHeaderWeatherDisplayData,
+  getPersonEntityPictureUrl,
+  getSensorDisplayValue
+} from './src/ha/ha-state-helpers.js';
+
+const hass = {
+  hassUrl: (path) => `https://ha.local${path}`,
+  states: {
+    'sensor.time': { state: '13:45', attributes: { friendly_name: 'Clock', icon: ' mdi:clock ', entity_picture: '/api/clock.png' } },
+    'sensor.unknown': { state: 'unknown', attributes: {} },
+    'sensor.unavailable': { state: 'unavailable', attributes: {} },
+    'weather.home': { state: 'sunny', attributes: { temperature: 72, temperature_unit: '°F' } },
+    'person.ian': { state: 'home', attributes: { entity_picture: '/api/ian.png' } }
+  }
+};
+
+test('entity state helpers handle missing hass and missing entities', () => {
+  assert.equal(getEntityState(null, 'sensor.time'), null);
+  assert.equal(getEntityState(hass, 'sensor.missing'), null);
+  assert.equal(getEntityFriendlyName(null, 'sensor.time'), 'sensor.time');
+  assert.equal(getEntityIcon(hass, 'sensor.missing', 'mdi:help'), 'mdi:help');
+  assert.equal(getEntityPicture(hass, 'sensor.missing', '/fallback.png'), '/fallback.png');
+});
+
+test('entity metadata helpers return friendly names, icons, and picture URLs with fallbacks', () => {
+  assert.equal(getEntityFriendlyName(hass, 'sensor.time'), 'Clock');
+  assert.equal(getEntityFriendlyName(hass, 'sensor.missing', 'Fallback name'), 'Fallback name');
+  assert.equal(getEntityIcon(hass, 'sensor.time'), 'mdi:clock');
+  assert.equal(getEntityPicture(hass, 'sensor.time'), '/api/clock.png');
+  assert.equal(getEntityPictureUrl(hass, 'sensor.time'), 'https://ha.local/api/clock.png');
+  assert.equal(getPersonEntityPictureUrl(hass, hass.states['person.ian']), 'https://ha.local/api/ian.png');
+});
+
+test('sensor display helper suppresses unknown and unavailable states', () => {
+  assert.equal(getSensorDisplayValue(hass, 'sensor.time'), '13:45');
+  assert.equal(getSensorDisplayValue(hass, 'sensor.unknown'), '');
+  assert.equal(getSensorDisplayValue(hass, 'sensor.unavailable'), '');
+  assert.equal(getSensorDisplayValue(hass, 'sensor.missing', 'fallback'), 'fallback');
+});
+
+test('header time and weather helpers format data from Home Assistant state', () => {
+  const parseTimeValue = (value) => value === '13:45' ? new Date('2026-06-25T13:45:00Z') : null;
+  const formatTime = (date) => date.toISOString().slice(11, 16);
+
+  assert.equal(getFormattedHeaderSensorTime(hass, 'sensor.time', parseTimeValue, formatTime), '13:45');
+  assert.equal(getFormattedHeaderSensorTime(hass, 'sensor.unknown', parseTimeValue, formatTime), '');
+  assert.deepEqual(getHeaderWeatherDisplayData(hass, 'weather.home'), {
+    conditionIcon: 'mdi:weather-sunny',
+    temperature: '72°'
+  });
+  assert.equal(getHeaderWeatherDisplayData(hass, 'weather.missing'), null);
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "rollup -c",
     "check:build": "npm run build && git diff --exit-code -- skylight-calendar-card.js",
-    "test": "node --test skylight-calendar-card.test.js",
+    "test": "node --test skylight-calendar-card.test.js ha-state-helpers.test.mjs",
     "test:visual": "playwright test"
   },
   "devDependencies": {

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -5120,6 +5120,94 @@ function getHeaderWeatherEntityRenderSignature(entityState) {
   });
 }
 
+function getEntityState(hass, entityId) {
+  if (!hass || !entityId) return null;
+  return hass.states?.[entityId] || null;
+}
+
+function getEntityFriendlyName(hass, entityId, fallback = entityId) {
+  const friendlyName = getEntityState(hass, entityId)?.attributes?.friendly_name;
+  return friendlyName || fallback;
+}
+
+function getEntityIcon(hass, entityId, fallback = null) {
+  const icon = getEntityState(hass, entityId)?.attributes?.icon;
+  return typeof icon === 'string' && icon.trim() ? icon.trim() : fallback;
+}
+
+function getEntityPicture(hass, entityId, fallback = null) {
+  const picture = getEntityState(hass, entityId)?.attributes?.entity_picture;
+  return typeof picture === 'string' && picture.trim() ? picture.trim() : fallback;
+}
+
+function resolveEntityPictureUrl(hass, picture, fallback = null) {
+  if (typeof picture !== 'string' || !picture.trim()) return fallback;
+  const trimmedPicture = picture.trim();
+  if (trimmedPicture.startsWith('/') && typeof hass?.hassUrl === 'function') {
+    return hass.hassUrl(trimmedPicture);
+  }
+  return trimmedPicture;
+}
+
+function getEntityPictureUrl(hass, entityId, fallback = null) {
+  return resolveEntityPictureUrl(hass, getEntityPicture(hass, entityId), fallback);
+}
+
+function getSensorDisplayValue(hass, entityId, fallback = '') {
+  const state = getEntityState(hass, entityId)?.state;
+  if (state === undefined || state === null || state === 'unknown' || state === 'unavailable') return fallback;
+  const displayState = String(state).trim();
+  return displayState || fallback;
+}
+
+function getFormattedHeaderSensorTime(hass, entityId, parseTimeValue, formatTime, fallback = '') {
+  const sensorState = getSensorDisplayValue(hass, entityId, null);
+  if (!sensorState || typeof parseTimeValue !== 'function' || typeof formatTime !== 'function') return fallback;
+  const parsed = parseTimeValue(sensorState);
+  return parsed ? formatTime(parsed) : fallback;
+}
+
+function getHeaderWeatherDisplayData(hass, entityId) {
+  return normalizeHeaderWeatherData(getEntityState(hass, entityId));
+}
+
+function getHeaderEntityRenderSignatureFromState(entityState) {
+  return getHeaderWeatherEntityRenderSignature(entityState);
+}
+
+function getHeaderEntityRenderSignature(hass, entityId) {
+  return getHeaderEntityRenderSignatureFromState(getEntityState(hass, entityId));
+}
+
+function getPersonStateLabel(personState) {
+  if (!personState || !personState.state || ['unknown', 'unavailable'].includes(personState.state)) {
+    return '';
+  }
+
+  if (personState.state === 'home') return 'Home';
+  if (personState.state === 'not_home') return 'Away';
+
+  return String(personState.state)
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function getPersonEntityPictureUrl(hass, personState) {
+  return resolveEntityPictureUrl(hass, personState?.attributes?.entity_picture, null);
+}
+
+function getEntityRenderSignature(hass, entityIds = []) {
+  return JSON.stringify(entityIds.map((entityId) => {
+    const entityState = getEntityState(hass, entityId);
+    return {
+      entityId,
+      state: entityState?.state ?? null,
+      picture: entityState?.attributes?.entity_picture ?? null,
+      friendlyName: entityState?.attributes?.friendly_name ?? null
+    };
+  }));
+}
+
 function isWeatherEntityId(entityId) {
   return !!entityId && entityId.startsWith('weather.');
 }
@@ -13511,16 +13599,18 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getHeaderEntityRenderSignature(entityState) {
-    return getHeaderWeatherEntityRenderSignature(entityState);
+    return getHeaderEntityRenderSignatureFromState(entityState);
   }
 
   getFormattedHeaderSensorTime() {
     const sensorEntityId = this._config?.header_time_sensor;
     if (!sensorEntityId) return '';
-    const sensorState = this._hass?.states?.[sensorEntityId]?.state;
-    const parsed = this.parseTimeValue(sensorState);
-    if (!parsed) return '';
-    return this.formatTime(parsed);
+    return getFormattedHeaderSensorTime(
+      this._hass,
+      sensorEntityId,
+      (value) => this.parseTimeValue(value),
+      (date) => this.formatTime(date)
+    );
   }
 
   normalizeWeatherTemperature(value) {
@@ -13534,8 +13624,7 @@ class SkylightCalendarCard extends HTMLElement {
   getHeaderWeatherData() {
     const sensorEntityId = this._config?.header_weather_sensor;
     if (!sensorEntityId) return null;
-    const weatherEntity = this._hass?.states?.[sensorEntityId];
-    return normalizeHeaderWeatherData(weatherEntity);
+    return getHeaderWeatherDisplayData(this._hass, sensorEntityId);
   }
 
   getFormattedHeaderWeather() {
@@ -13616,26 +13705,11 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   formatPersonStateLabel(personState) {
-    if (!personState || !personState.state || ['unknown', 'unavailable'].includes(personState.state)) {
-      return '';
-    }
-
-    if (personState.state === 'home') return 'Home';
-    if (personState.state === 'not_home') return 'Away';
-
-    return String(personState.state)
-      .replace(/_/g, ' ')
-      .replace(/\b\w/g, (char) => char.toUpperCase());
+    return getPersonStateLabel(personState);
   }
 
   getPersonEntityPictureUrl(personState) {
-    const picture = personState?.attributes?.entity_picture;
-    if (typeof picture !== 'string' || !picture.trim()) return null;
-    const trimmedPicture = picture.trim();
-    if (trimmedPicture.startsWith('/') && typeof this._hass?.hassUrl === 'function') {
-      return this._hass.hassUrl(trimmedPicture);
-    }
-    return trimmedPicture;
+    return getPersonEntityPictureUrl(this._hass, personState);
   }
 
   getCalendarBadgePersonRenderSignature(hass = this._hass) {
@@ -13645,15 +13719,7 @@ class SkylightCalendarCard extends HTMLElement {
 
     if (personEntityIds.length === 0) return '';
 
-    return JSON.stringify(personEntityIds.map((entityId) => {
-      const entityState = hass?.states?.[entityId];
-      return {
-        entityId,
-        state: entityState?.state ?? null,
-        picture: entityState?.attributes?.entity_picture ?? null,
-        friendlyName: entityState?.attributes?.friendly_name ?? null
-      };
-    }));
+    return getEntityRenderSignature(hass, personEntityIds);
   }
 
   renderCalendarBadgeLabel(badgeItem, badgeTextColor) {
@@ -14080,7 +14146,7 @@ class SkylightCalendarCardEditor extends HTMLElement {
   }
 
   getEntityFriendlyName(entityId) {
-    return this._hass?.states?.[entityId]?.attributes?.friendly_name || entityId;
+    return getEntityFriendlyName(this._hass, entityId);
   }
 
   getConfiguredEntityIndex(entityId) {

--- a/src/ha/ha-state-helpers.js
+++ b/src/ha/ha-state-helpers.js
@@ -1,0 +1,92 @@
+import {
+  getHeaderWeatherEntityRenderSignature,
+  normalizeHeaderWeatherData
+} from '../weather/weather-utils.js';
+
+export function getEntityState(hass, entityId) {
+  if (!hass || !entityId) return null;
+  return hass.states?.[entityId] || null;
+}
+
+export function getEntityFriendlyName(hass, entityId, fallback = entityId) {
+  const friendlyName = getEntityState(hass, entityId)?.attributes?.friendly_name;
+  return friendlyName || fallback;
+}
+
+export function getEntityIcon(hass, entityId, fallback = null) {
+  const icon = getEntityState(hass, entityId)?.attributes?.icon;
+  return typeof icon === 'string' && icon.trim() ? icon.trim() : fallback;
+}
+
+export function getEntityPicture(hass, entityId, fallback = null) {
+  const picture = getEntityState(hass, entityId)?.attributes?.entity_picture;
+  return typeof picture === 'string' && picture.trim() ? picture.trim() : fallback;
+}
+
+export function resolveEntityPictureUrl(hass, picture, fallback = null) {
+  if (typeof picture !== 'string' || !picture.trim()) return fallback;
+  const trimmedPicture = picture.trim();
+  if (trimmedPicture.startsWith('/') && typeof hass?.hassUrl === 'function') {
+    return hass.hassUrl(trimmedPicture);
+  }
+  return trimmedPicture;
+}
+
+export function getEntityPictureUrl(hass, entityId, fallback = null) {
+  return resolveEntityPictureUrl(hass, getEntityPicture(hass, entityId), fallback);
+}
+
+export function getSensorDisplayValue(hass, entityId, fallback = '') {
+  const state = getEntityState(hass, entityId)?.state;
+  if (state === undefined || state === null || state === 'unknown' || state === 'unavailable') return fallback;
+  const displayState = String(state).trim();
+  return displayState || fallback;
+}
+
+export function getFormattedHeaderSensorTime(hass, entityId, parseTimeValue, formatTime, fallback = '') {
+  const sensorState = getSensorDisplayValue(hass, entityId, null);
+  if (!sensorState || typeof parseTimeValue !== 'function' || typeof formatTime !== 'function') return fallback;
+  const parsed = parseTimeValue(sensorState);
+  return parsed ? formatTime(parsed) : fallback;
+}
+
+export function getHeaderWeatherDisplayData(hass, entityId) {
+  return normalizeHeaderWeatherData(getEntityState(hass, entityId));
+}
+
+export function getHeaderEntityRenderSignatureFromState(entityState) {
+  return getHeaderWeatherEntityRenderSignature(entityState);
+}
+
+export function getHeaderEntityRenderSignature(hass, entityId) {
+  return getHeaderEntityRenderSignatureFromState(getEntityState(hass, entityId));
+}
+
+export function getPersonStateLabel(personState) {
+  if (!personState || !personState.state || ['unknown', 'unavailable'].includes(personState.state)) {
+    return '';
+  }
+
+  if (personState.state === 'home') return 'Home';
+  if (personState.state === 'not_home') return 'Away';
+
+  return String(personState.state)
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+export function getPersonEntityPictureUrl(hass, personState) {
+  return resolveEntityPictureUrl(hass, personState?.attributes?.entity_picture, null);
+}
+
+export function getEntityRenderSignature(hass, entityIds = []) {
+  return JSON.stringify(entityIds.map((entityId) => {
+    const entityState = getEntityState(hass, entityId);
+    return {
+      entityId,
+      state: entityState?.state ?? null,
+      picture: entityState?.attributes?.entity_picture ?? null,
+      friendlyName: entityState?.attributes?.friendly_name ?? null
+    };
+  }));
+}

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -100,13 +100,20 @@ import {
   normalizeLegacyDayStyleMatch as normalizeRuleLegacyDayStyleMatch
 } from './rules/style-rules.js';
 import {
-  getHeaderWeatherEntityRenderSignature,
   getWeatherEntityForecast,
   mapWeatherConditionToIcon as mapWeatherConditionToIconHelper,
   normalizeForecastForDate,
-  normalizeHeaderWeatherData,
   normalizeWeatherTemperature as normalizeWeatherTemperatureHelper
 } from './weather/weather-utils.js';
+import {
+  getEntityFriendlyName as getEntityFriendlyNameHelper,
+  getEntityRenderSignature as getEntityRenderSignatureHelper,
+  getFormattedHeaderSensorTime as getFormattedHeaderSensorTimeHelper,
+  getHeaderEntityRenderSignatureFromState,
+  getHeaderWeatherDisplayData,
+  getPersonEntityPictureUrl as getPersonEntityPictureUrlHelper,
+  getPersonStateLabel as getPersonStateLabelHelper
+} from './ha/ha-state-helpers.js';
 import {
   buildWeatherForecastRequestMessage,
   buildWeatherForecastSubscriptionMessage,
@@ -6672,16 +6679,18 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getHeaderEntityRenderSignature(entityState) {
-    return getHeaderWeatherEntityRenderSignature(entityState);
+    return getHeaderEntityRenderSignatureFromState(entityState);
   }
 
   getFormattedHeaderSensorTime() {
     const sensorEntityId = this._config?.header_time_sensor;
     if (!sensorEntityId) return '';
-    const sensorState = this._hass?.states?.[sensorEntityId]?.state;
-    const parsed = this.parseTimeValue(sensorState);
-    if (!parsed) return '';
-    return this.formatTime(parsed);
+    return getFormattedHeaderSensorTimeHelper(
+      this._hass,
+      sensorEntityId,
+      (value) => this.parseTimeValue(value),
+      (date) => this.formatTime(date)
+    );
   }
 
   normalizeWeatherTemperature(value) {
@@ -6695,8 +6704,7 @@ class SkylightCalendarCard extends HTMLElement {
   getHeaderWeatherData() {
     const sensorEntityId = this._config?.header_weather_sensor;
     if (!sensorEntityId) return null;
-    const weatherEntity = this._hass?.states?.[sensorEntityId];
-    return normalizeHeaderWeatherData(weatherEntity);
+    return getHeaderWeatherDisplayData(this._hass, sensorEntityId);
   }
 
   getFormattedHeaderWeather() {
@@ -6777,26 +6785,11 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   formatPersonStateLabel(personState) {
-    if (!personState || !personState.state || ['unknown', 'unavailable'].includes(personState.state)) {
-      return '';
-    }
-
-    if (personState.state === 'home') return 'Home';
-    if (personState.state === 'not_home') return 'Away';
-
-    return String(personState.state)
-      .replace(/_/g, ' ')
-      .replace(/\b\w/g, (char) => char.toUpperCase());
+    return getPersonStateLabelHelper(personState);
   }
 
   getPersonEntityPictureUrl(personState) {
-    const picture = personState?.attributes?.entity_picture;
-    if (typeof picture !== 'string' || !picture.trim()) return null;
-    const trimmedPicture = picture.trim();
-    if (trimmedPicture.startsWith('/') && typeof this._hass?.hassUrl === 'function') {
-      return this._hass.hassUrl(trimmedPicture);
-    }
-    return trimmedPicture;
+    return getPersonEntityPictureUrlHelper(this._hass, personState);
   }
 
   getCalendarBadgePersonRenderSignature(hass = this._hass) {
@@ -6806,15 +6799,7 @@ class SkylightCalendarCard extends HTMLElement {
 
     if (personEntityIds.length === 0) return '';
 
-    return JSON.stringify(personEntityIds.map((entityId) => {
-      const entityState = hass?.states?.[entityId];
-      return {
-        entityId,
-        state: entityState?.state ?? null,
-        picture: entityState?.attributes?.entity_picture ?? null,
-        friendlyName: entityState?.attributes?.friendly_name ?? null
-      };
-    }));
+    return getEntityRenderSignatureHelper(hass, personEntityIds);
   }
 
   renderCalendarBadgeLabel(badgeItem, badgeTextColor) {
@@ -7241,7 +7226,7 @@ class SkylightCalendarCardEditor extends HTMLElement {
   }
 
   getEntityFriendlyName(entityId) {
-    return this._hass?.states?.[entityId]?.attributes?.friendly_name || entityId;
+    return getEntityFriendlyNameHelper(this._hass, entityId);
   }
 
   getConfiguredEntityIndex(entityId) {


### PR DESCRIPTION
### Motivation
- Continue the modularization by extracting pure, stateless Home Assistant state/read helpers so the main card stays focused on lifecycle, orchestration, and DOM behavior.
- Make HA state read helpers small, importable, and directly unit-testable without changing card runtime behavior.

### Description
- Added `src/ha/ha-state-helpers.js` which exports small, pure helpers including `getEntityState`, `getEntityFriendlyName`, `getEntityIcon`, `getEntityPicture`, `resolveEntityPictureUrl`/`getEntityPictureUrl`, `getSensorDisplayValue`, `getFormattedHeaderSensorTime`, `getHeaderWeatherDisplayData`, `getHeaderEntityRenderSignatureFromState`/`getHeaderEntityRenderSignature`, `getPersonStateLabel`, `getPersonEntityPictureUrl`, and `getEntityRenderSignature`.
- Updated `src/skylight-calendar-card.js` and the editor to delegate stateless Home Assistant reads (header time/weather formatting, person badge label/picture, render signatures, and editor friendly-name lookups) to the new helpers while explicitly keeping lifecycle, subscriptions, websocket/service calls, event/weather fetch orchestration, DOM reads/writes, rendering, and preference persistence in the main card.
- Added `ha-state-helpers.test.mjs` with unit tests for missing `hass`, missing entities, friendly-name/icon/picture fallbacks, unknown/unavailable sensor states, and header time/weather formatting, and updated the `test` script in `package.json` to run the new test file alongside the existing suite.
- Regenerated the root ship artifact via Rollup so the built `skylight-calendar-card.js` reflects the refactor; the change is behavior-preserving and does not alter rendering, CSS, DOM structure, public config keys, translations, or runtime service/subscription behavior.

### Testing
- `npm ci --no-audit --fund=false` — succeeded.
- `npm run build` — Rollup built successfully and regenerated the root `skylight-calendar-card.js` artifact.
- `node --check` on `src/skylight-calendar-card.js`, `src/ha/ha-state-helpers.js`, and `skylight-calendar-card.js` — all passed syntax checks.
- `npm test` — full unit test run passed (all tests passed).
- `npm run test:visual` — visual tests passed with no snapshot updates required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c973a5fc88331b20bfd14a8f98546)