### PR TITLE
Extract color and config normalizers

### DIFF
--- a/color-config-normalizers.test.mjs
+++ b/color-config-normalizers.test.mjs
@@ -1,0 +1,92 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  colorToHex,
+  colorWithAlpha,
+  getContrastColor,
+  normalizeColorMap,
+  normalizeSingleColor,
+  parseColorToRgb
+} from './src/utils/color-utils.js';
+import {
+  normalizeBackgroundOpacity,
+  normalizeCombineBackground,
+  normalizeDefaultHiddenCalendars,
+  normalizeEventModalSize,
+  normalizeEventTitlePrefixMode,
+  normalizePastEventMode,
+  normalizeThemeMode
+} from './src/config/config-normalizers.js';
+
+test('color utilities normalize named color aliases and hex values', () => {
+  assert.equal(normalizeSingleColor(' Lime / Green '), '#00FF00');
+  assert.equal(normalizeSingleColor('(dark green)'), '#008000');
+  assert.equal(colorToHex('#abc'), '#AABBCC');
+  assert.equal(colorToHex('#a1B2c3'), '#A1B2C3');
+});
+
+test('color utilities parse rgb and rgba channels without changing clamping behavior', () => {
+  assert.deepEqual(parseColorToRgb('rgb(1, 2, 3)'), { r: 1, g: 2, b: 3 });
+  assert.deepEqual(parseColorToRgb('rgba(10 20 30 / 0.4)'), { r: 10, g: 20, b: 30 });
+  assert.deepEqual(parseColorToRgb('rgb(300, -5, 2.4)'), { r: 255, g: 0, b: 2 });
+});
+
+test('color utilities preserve invalid color fallback behavior', () => {
+  assert.equal(colorToHex('not-a-color'), null);
+  assert.equal(parseColorToRgb('not-a-color'), null);
+  assert.equal(colorWithAlpha('not-a-color', 0.4), 'not-a-color');
+  assert.deepEqual(normalizeColorMap({ a: ' red ', b: '', c: null, d: undefined }), { a: '#FF0000' });
+});
+
+test('contrast colors preserve card color name outputs', () => {
+  assert.equal(getContrastColor('#ffffff'), 'black');
+  assert.equal(getContrastColor('#000000'), 'white');
+  assert.equal(getContrastColor('not-a-color'), 'white');
+});
+
+test('background opacity clamps finite values and preserves fallback for invalid values', () => {
+  assert.equal(normalizeBackgroundOpacity(120, 10), 100);
+  assert.equal(normalizeBackgroundOpacity(-5, 10), 0);
+  assert.equal(normalizeBackgroundOpacity('55', 10), 55);
+  assert.equal(normalizeBackgroundOpacity('bad', 10), 10);
+});
+
+test('config enum normalizers preserve aliases and fallbacks', () => {
+  assert.equal(normalizeThemeMode(true), 'dark');
+  assert.equal(normalizeThemeMode(false), 'auto');
+  assert.equal(normalizeThemeMode('LIGHT'), 'light');
+  assert.equal(normalizeThemeMode('unknown'), 'auto');
+  assert.equal(normalizeEventTitlePrefixMode('icon'), 'badge_icon');
+  assert.equal(normalizeEventTitlePrefixMode('friendly'), 'friendly_name');
+  assert.equal(normalizeEventTitlePrefixMode('unknown'), 'none');
+  assert.equal(normalizePastEventMode('muted'), 'muted');
+  assert.equal(normalizePastEventMode('unknown'), 'none');
+});
+
+test('combine background accepts modes and hex colors with primary fallback', () => {
+  assert.equal(normalizeCombineBackground('neutral'), 'neutral');
+  assert.equal(normalizeCombineBackground('#abc'), '#AABBCC');
+  assert.equal(normalizeCombineBackground('lime'), '#00FF00');
+  assert.equal(normalizeCombineBackground('not-a-color'), 'primary');
+  assert.equal(normalizeCombineBackground(''), 'primary');
+});
+
+test('default hidden calendar normalization filters unknowns and applies visibility overrides', () => {
+  assert.deepEqual(normalizeDefaultHiddenCalendars({
+    entities: ['calendar.a', 'calendar.b', 'calendar.c'],
+    default_hidden_calendars: ['calendar.a', 'calendar.unknown'],
+    default_calendar_visibility: {
+      'calendar.a': 'show',
+      'calendar.b': 'hidden',
+      'calendar.c': false,
+      'calendar.unknown': 'hidden'
+    }
+  }), ['calendar.b', 'calendar.c']);
+});
+
+test('event modal size falls back to the default medium size', () => {
+  assert.equal(normalizeEventModalSize('wide'), 'wide');
+  assert.equal(normalizeEventModalSize(' FULL '), 'full');
+  assert.equal(normalizeEventModalSize('giant'), 'medium');
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "rollup -c",
     "check:build": "npm run build && git diff --exit-code -- skylight-calendar-card.js",
-    "test": "node --test skylight-calendar-card.test.js ha-state-helpers.test.mjs",
+    "test": "node --test skylight-calendar-card.test.js ha-state-helpers.test.mjs color-config-normalizers.test.mjs",
     "test:visual": "playwright test"
   },
   "devDependencies": {

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -626,21 +626,21 @@ function normalizeDefaultDarkMode(value) {
   });
 }
 
-function normalizePastEventMode(value) {
+function normalizePastEventMode$1(value) {
   return normalizeEnumValue(value, {
     allowed: PAST_EVENT_MODE_OPTIONS,
     fallback: DEFAULT_PAST_EVENT_MODE
   });
 }
 
-function normalizeDayBadgeLayoutWeek(value) {
+function normalizeDayBadgeLayoutWeek$1(value) {
   return normalizeEnumValue(value, {
     allowed: DAY_BADGE_LAYOUT_WEEK_OPTIONS,
     fallback: DEFAULT_DAY_BADGE_LAYOUT_WEEK
   });
 }
 
-function normalizeEventModalSize(value) {
+function normalizeEventModalSize$1(value) {
   const normalized = String(value || '').trim().toLowerCase();
   return EVENT_MODAL_SIZE_OPTIONS.includes(normalized) ? normalized : DEFAULT_EVENT_MODAL_SIZE;
 }
@@ -727,7 +727,7 @@ class SkylightCalendarCardEditor extends HTMLElement {
         ? 'week-standard'
         : config.default_view;
     const normalizedPastEventMode = config.past_event_mode !== undefined && config.past_event_mode !== null && config.past_event_mode !== ''
-      ? normalizePastEventMode(config.past_event_mode)
+      ? normalizePastEventMode$1(config.past_event_mode)
       : (config.hide_the_past ? 'hide' : createDefaultStubConfig().past_event_mode);
 
     this._config = {
@@ -737,8 +737,8 @@ class SkylightCalendarCardEditor extends HTMLElement {
       past_event_mode: normalizedPastEventMode,
       color_scheme: normalizeDefaultDarkMode(config.color_scheme),
       header_dashboard_path: normalizeDashboardPath(config.header_dashboard_path),
-      event_modal_size: normalizeEventModalSize(config.event_modal_size),
-      day_badge_layout_week: normalizeDayBadgeLayoutWeek(config.day_badge_layout_week)
+      event_modal_size: normalizeEventModalSize$1(config.event_modal_size),
+      day_badge_layout_week: normalizeDayBadgeLayoutWeek$1(config.day_badge_layout_week)
     };
     this.syncCombineBackgroundEditorState(this._config.combine_background);
 
@@ -6720,6 +6720,225 @@ function getIsoWeekNumber(date) {
   return Math.ceil((((utcDate - yearStart) / 86400000) + 1) / 7);
 }
 
+function normalizeSingleColor(colorValue) {
+  if (colorValue === undefined || colorValue === null) {
+    return colorValue;
+  }
+
+  const trimmed = String(colorValue).trim();
+  if (!trimmed) return trimmed;
+
+  const normalizedName = trimmed
+    .toLowerCase()
+    .replace(/[()]/g, '')
+    .replace(/\s*\/\s*/g, '/')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const mappedColor = COMMON_NAMED_COLORS[normalizedName];
+  if (mappedColor) {
+    return mappedColor;
+  }
+
+  return trimmed;
+}
+
+function normalizeColorMap(colorMap, { normalizeColor = normalizeSingleColor } = {}) {
+  if (!colorMap || typeof colorMap !== 'object') return {};
+
+  return Object.entries(colorMap).reduce((acc, [entityId, color]) => {
+    const normalized = normalizeColor(color);
+    if (normalized !== undefined && normalized !== null && normalized !== '') {
+      acc[entityId] = normalized;
+    }
+    return acc;
+  }, {});
+}
+
+function colorToHex(color, { normalizeColor = normalizeSingleColor } = {}) {
+  if (!color) return null;
+
+  const normalizedColor = normalizeColor(color);
+  if (typeof normalizedColor !== 'string') return null;
+
+  const hex3Match = normalizedColor.match(/^#([\da-fA-F]{3})$/);
+  if (hex3Match) {
+    const [r, g, b] = hex3Match[1].split('');
+    return `#${r}${r}${g}${g}${b}${b}`.toUpperCase();
+  }
+
+  const hex6Match = normalizedColor.match(/^#([\da-fA-F]{6})$/);
+  if (hex6Match) {
+    return `#${hex6Match[1].toUpperCase()}`;
+  }
+
+  return null;
+}
+
+function parseColorToRgb(color, {
+  normalizeColor = normalizeSingleColor,
+  resolveComputedCssColorToRgb = null
+} = {}) {
+  const normalizedColor = normalizeColor(color);
+  if (typeof normalizedColor === 'string') {
+    const rgbMatch = normalizedColor
+      .match(/^rgba?\((.+)\)$/i);
+    if (rgbMatch) {
+      const normalizedChannels = rgbMatch[1]
+        .replace(/\s*\/\s*.*/, '')
+        .replace(/,/g, ' ')
+        .trim()
+        .split(/\s+/)
+        .slice(0, 3)
+        .map((channel) => Number(channel));
+
+      if (normalizedChannels.length === 3 && normalizedChannels.every((value) => Number.isFinite(value))) {
+        const [r, g, b] = normalizedChannels.map((value) => Math.max(0, Math.min(255, Math.round(value))));
+        return { r, g, b };
+      }
+    }
+  }
+
+  const hex = colorToHex(normalizedColor, { normalizeColor });
+  if (hex) {
+    return {
+      r: parseInt(hex.slice(1, 3), 16),
+      g: parseInt(hex.slice(3, 5), 16),
+      b: parseInt(hex.slice(5, 7), 16)
+    };
+  }
+
+  return typeof resolveComputedCssColorToRgb === 'function'
+    ? resolveComputedCssColorToRgb(normalizedColor)
+    : null;
+}
+
+function colorWithAlpha(color, alpha = 1, { colorToRgb = parseColorToRgb } = {}) {
+  const rgb = colorToRgb(color);
+  if (!rgb) return color;
+
+  const clamped = Math.max(0, Math.min(1, alpha));
+  return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${clamped})`;
+}
+
+function blendRgb(top, bottom, topAlpha = 1) {
+  if (!top && !bottom) return null;
+  if (!top) return bottom;
+  if (!bottom) return top;
+  const clampedAlpha = Math.max(0, Math.min(1, topAlpha));
+  return {
+    r: Math.round((top.r * clampedAlpha) + (bottom.r * (1 - clampedAlpha))),
+    g: Math.round((top.g * clampedAlpha) + (bottom.g * (1 - clampedAlpha))),
+    b: Math.round((top.b * clampedAlpha) + (bottom.b * (1 - clampedAlpha)))
+  };
+}
+
+function getContrastColor(backgroundColor, { colorToRgb = parseColorToRgb } = {}) {
+  const rgb = colorToRgb(backgroundColor);
+  if (!rgb) return 'white';
+
+  const luminance = (0.299 * rgb.r + 0.587 * rgb.g + 0.114 * rgb.b) / 255;
+  return luminance > 0.6 ? 'black' : 'white';
+}
+
+function normalizeThemeMode(value) {
+  if (value === true) return 'dark';
+  if (value === false || value === undefined || value === null || value === '') return DEFAULT_THEME_MODE;
+
+  return normalizeEnumValue(value, {
+    allowed: THEME_MODE_OPTIONS,
+    fallback: DEFAULT_THEME_MODE
+  });
+}
+
+function normalizeEventTitlePrefixMode(value) {
+  return normalizeEnumValue(value, {
+    aliases: EVENT_TITLE_PREFIX_ALIASES,
+    allowed: EVENT_TITLE_PREFIX_OPTIONS,
+    fallback: DEFAULT_EVENT_TITLE_PREFIX
+  });
+}
+
+function normalizePastEventMode(value) {
+  return normalizeEnumValue(value, {
+    allowed: PAST_EVENT_MODE_OPTIONS,
+    fallback: DEFAULT_PAST_EVENT_MODE
+  });
+}
+
+function normalizeDayBadgeLayoutWeek(value) {
+  return normalizeEnumValue(value, {
+    allowed: DAY_BADGE_LAYOUT_WEEK_OPTIONS,
+    fallback: DEFAULT_DAY_BADGE_LAYOUT_WEEK
+  });
+}
+
+function normalizeDefaultHiddenCalendars(config = {}) {
+  const knownEntities = new Set(Array.isArray(config.entities) ? config.entities : []);
+  const hiddenCalendars = new Set();
+
+  if (Array.isArray(config.default_hidden_calendars)) {
+    config.default_hidden_calendars.forEach((entityId) => {
+      if (knownEntities.has(entityId)) hiddenCalendars.add(entityId);
+    });
+  }
+
+  const visibilityMap = config.default_calendar_visibility || config.calendar_visibility || {};
+  if (visibilityMap && typeof visibilityMap === 'object' && !Array.isArray(visibilityMap)) {
+    Object.entries(visibilityMap).forEach(([entityId, value]) => {
+      if (!knownEntities.has(entityId)) return;
+      const normalizedValue = typeof value === 'string' ? value.trim().toLowerCase() : value;
+      if (HIDDEN_CALENDAR_VISIBILITY_VALUES.includes(normalizedValue)) {
+        hiddenCalendars.add(entityId);
+      } else if (VISIBLE_CALENDAR_VISIBILITY_VALUES.includes(normalizedValue)) {
+        hiddenCalendars.delete(entityId);
+      }
+    });
+  }
+
+  return Array.from(hiddenCalendars);
+}
+
+function normalizeCombineStyle(styleValue) {
+  return normalizeEnumValue(styleValue, {
+    allowed: COMBINE_STYLE_OPTIONS,
+    fallback: DEFAULT_COMBINE_STYLE
+  });
+}
+
+function normalizeEventColorMode(modeValue) {
+  return normalizeEnumValue(modeValue, {
+    allowed: EVENT_COLOR_MODE_OPTIONS,
+    fallback: DEFAULT_EVENT_COLOR_MODE
+  });
+}
+
+function normalizeCombineBackground(backgroundValue, { colorToHex: normalizeColorToHex = colorToHex } = {}) {
+  const normalized = String(backgroundValue || '').trim();
+  if (!normalized) return DEFAULT_COMBINE_BACKGROUND;
+
+  const lower = normalized.toLowerCase();
+  if (COMBINE_BACKGROUND_MODE_OPTIONS.includes(lower)) {
+    return lower;
+  }
+
+  const hex = normalizeColorToHex(normalized);
+  return hex || DEFAULT_COMBINE_BACKGROUND;
+}
+
+function normalizeBackgroundOpacity(opacityValue, fallback = 0) {
+  const numericOpacity = Number(opacityValue);
+  if (!Number.isFinite(numericOpacity)) {
+    return fallback;
+  }
+
+  return Math.min(100, Math.max(0, numericOpacity));
+}
+
+function normalizeEventModalSize(value) {
+  const normalized = String(value || '').trim().toLowerCase();
+  return EVENT_MODAL_SIZE_OPTIONS.includes(normalized) ? normalized : DEFAULT_EVENT_MODAL_SIZE;
+}
+
 function normalizeEventTextValue(value) {
   return String(value || '')
     .normalize('NFKC')
@@ -9433,35 +9652,19 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   normalizeDefaultDarkMode(value) {
-    if (value === true) return 'dark';
-    if (value === false || value === undefined || value === null || value === '') return DEFAULT_THEME_MODE;
-
-    return this.normalizeEnumValue(value, {
-      allowed: THEME_MODE_OPTIONS,
-      fallback: DEFAULT_THEME_MODE
-    });
+    return normalizeThemeMode(value);
   }
 
   normalizeEventTitlePrefixMode(value) {
-    return this.normalizeEnumValue(value, {
-      aliases: EVENT_TITLE_PREFIX_ALIASES,
-      allowed: EVENT_TITLE_PREFIX_OPTIONS,
-      fallback: DEFAULT_EVENT_TITLE_PREFIX
-    });
+    return normalizeEventTitlePrefixMode(value);
   }
 
   normalizePastEventMode(value) {
-    return this.normalizeEnumValue(value, {
-      allowed: PAST_EVENT_MODE_OPTIONS,
-      fallback: DEFAULT_PAST_EVENT_MODE
-    });
+    return normalizePastEventMode(value);
   }
 
   normalizeDayBadgeLayoutWeek(value) {
-    return this.normalizeEnumValue(value, {
-      allowed: DAY_BADGE_LAYOUT_WEEK_OPTIONS,
-      fallback: DEFAULT_DAY_BADGE_LAYOUT_WEEK
-    });
+    return normalizeDayBadgeLayoutWeek(value);
   }
 
   normalizeEntityStringMap(value) {
@@ -9525,29 +9728,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   normalizeDefaultHiddenCalendars(config = {}) {
-    const knownEntities = new Set(Array.isArray(config.entities) ? config.entities : []);
-    const hiddenCalendars = new Set();
-
-    if (Array.isArray(config.default_hidden_calendars)) {
-      config.default_hidden_calendars.forEach((entityId) => {
-        if (knownEntities.has(entityId)) hiddenCalendars.add(entityId);
-      });
-    }
-
-    const visibilityMap = config.default_calendar_visibility || config.calendar_visibility || {};
-    if (visibilityMap && typeof visibilityMap === 'object' && !Array.isArray(visibilityMap)) {
-      Object.entries(visibilityMap).forEach(([entityId, value]) => {
-        if (!knownEntities.has(entityId)) return;
-        const normalizedValue = typeof value === 'string' ? value.trim().toLowerCase() : value;
-        if (HIDDEN_CALENDAR_VISIBILITY_VALUES.includes(normalizedValue)) {
-          hiddenCalendars.add(entityId);
-        } else if (VISIBLE_CALENDAR_VISIBILITY_VALUES.includes(normalizedValue)) {
-          hiddenCalendars.delete(entityId);
-        }
-      });
-    }
-
-    return Array.from(hiddenCalendars);
+    return normalizeDefaultHiddenCalendars(config);
   }
 
   loadPersistedPreferences() {
@@ -9970,91 +10151,38 @@ class SkylightCalendarCard extends HTMLElement {
 
 
   normalizeColorMap(colorMap) {
-    if (!colorMap || typeof colorMap !== 'object') return {};
-
-    return Object.entries(colorMap).reduce((acc, [entityId, color]) => {
-      const normalized = this.normalizeSingleColor(color);
-      if (normalized !== undefined && normalized !== null && normalized !== '') {
-        acc[entityId] = normalized;
-      }
-      return acc;
-    }, {});
+    return normalizeColorMap(colorMap, {
+      normalizeColor: this.normalizeSingleColor.bind(this)
+    });
   }
 
   normalizeSingleColor(colorValue) {
-    if (colorValue === undefined || colorValue === null) {
-      return colorValue;
-    }
-
-    const trimmed = String(colorValue).trim();
-    if (!trimmed) return trimmed;
-
-    const normalizedName = trimmed
-      .toLowerCase()
-      .replace(/[()]/g, '')
-      .replace(/\s*\/\s*/g, '/')
-      .replace(/\s+/g, ' ')
-      .trim();
-    const mappedColor = SkylightCalendarCard.COMMON_NAMED_COLORS[normalizedName];
-    if (mappedColor) {
-      return mappedColor;
-    }
-
-    return trimmed;
+    return normalizeSingleColor(colorValue);
   }
 
   colorToHex(color) {
-    if (!color) return null;
-
-    const normalizedColor = this.normalizeSingleColor(color);
-    if (typeof normalizedColor !== 'string') return null;
-
-    const hex3Match = normalizedColor.match(/^#([\da-fA-F]{3})$/);
-    if (hex3Match) {
-      const [r, g, b] = hex3Match[1].split('');
-      return `#${r}${r}${g}${g}${b}${b}`.toUpperCase();
-    }
-
-    const hex6Match = normalizedColor.match(/^#([\da-fA-F]{6})$/);
-    if (hex6Match) {
-      return `#${hex6Match[1].toUpperCase()}`;
-    }
-
-    return null;
+    return colorToHex(color, {
+      normalizeColor: this.normalizeSingleColor.bind(this)
+    });
   }
 
   colorToRgb(color) {
-    const normalizedColor = this.normalizeSingleColor(color);
-    if (typeof normalizedColor === 'string') {
-      const rgbMatch = normalizedColor
-        .match(/^rgba?\((.+)\)$/i);
-      if (rgbMatch) {
-        const normalizedChannels = rgbMatch[1]
-          .replace(/\s*\/\s*.*/, '')
-          .replace(/,/g, ' ')
-          .trim()
-          .split(/\s+/)
-          .slice(0, 3)
-          .map((channel) => Number(channel));
-
-        if (normalizedChannels.length === 3 && normalizedChannels.every((value) => Number.isFinite(value))) {
-          const [r, g, b] = normalizedChannels.map((value) => Math.max(0, Math.min(255, Math.round(value))));
-          return { r, g, b };
-        }
-      }
-    }
-
-    const hex = this.colorToHex(normalizedColor);
-    if (hex) {
-      return {
-        r: parseInt(hex.slice(1, 3), 16),
-        g: parseInt(hex.slice(3, 5), 16),
-        b: parseInt(hex.slice(5, 7), 16)
-      };
-    }
-
-    return this.resolveComputedCssColorToRgb(normalizedColor);
+    return parseColorToRgb(color, {
+      normalizeColor: this.normalizeSingleColor.bind(this),
+      resolveComputedCssColorToRgb: this.resolveComputedCssColorToRgb.bind(this)
+    });
   }
+
+  colorWithAlpha(color, alpha = 1) {
+    return colorWithAlpha(color, alpha, {
+      colorToRgb: this.colorToRgb.bind(this)
+    });
+  }
+
+  blendRgb(top, bottom, topAlpha = 1) {
+    return blendRgb(top, bottom, topAlpha);
+  }
+
 
 
   resolveComputedCssColorToRgb(color) {
@@ -10085,52 +10213,18 @@ class SkylightCalendarCard extends HTMLElement {
     };
   }
 
-  colorWithAlpha(color, alpha = 1) {
-    const rgb = this.colorToRgb(color);
-    if (!rgb) return color;
-
-    const clamped = Math.max(0, Math.min(1, alpha));
-    return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${clamped})`;
-  }
-
-  blendRgb(top, bottom, topAlpha = 1) {
-    if (!top && !bottom) return null;
-    if (!top) return bottom;
-    if (!bottom) return top;
-    const clampedAlpha = Math.max(0, Math.min(1, topAlpha));
-    return {
-      r: Math.round((top.r * clampedAlpha) + (bottom.r * (1 - clampedAlpha))),
-      g: Math.round((top.g * clampedAlpha) + (bottom.g * (1 - clampedAlpha))),
-      b: Math.round((top.b * clampedAlpha) + (bottom.b * (1 - clampedAlpha)))
-    };
-  }
-
-
   normalizeCombineStyle(styleValue) {
-    return this.normalizeEnumValue(styleValue, {
-      allowed: COMBINE_STYLE_OPTIONS,
-      fallback: DEFAULT_COMBINE_STYLE
-    });
+    return normalizeCombineStyle(styleValue);
   }
 
   normalizeEventColorMode(modeValue) {
-    return this.normalizeEnumValue(modeValue, {
-      allowed: EVENT_COLOR_MODE_OPTIONS,
-      fallback: DEFAULT_EVENT_COLOR_MODE
-    });
+    return normalizeEventColorMode(modeValue);
   }
 
   normalizeCombineBackground(backgroundValue) {
-    const normalized = String(backgroundValue || '').trim();
-    if (!normalized) return DEFAULT_COMBINE_BACKGROUND;
-
-    const lower = normalized.toLowerCase();
-    if (COMBINE_BACKGROUND_MODE_OPTIONS.includes(lower)) {
-      return lower;
-    }
-
-    const hex = this.colorToHex(normalized);
-    return hex || DEFAULT_COMBINE_BACKGROUND;
+    return normalizeCombineBackground(backgroundValue, {
+      colorToHex: this.colorToHex.bind(this)
+    });
   }
 
   getEmptyAdvancedMatch() {
@@ -13526,11 +13620,9 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getContractColor(backgroundColor) {
-    const rgb = this.colorToRgb(backgroundColor);
-    if (!rgb) return 'white';
-
-    const luminance = (0.299 * rgb.r + 0.587 * rgb.g + 0.114 * rgb.b) / 255;
-    return luminance > 0.6 ? 'black' : 'white';
+    return getContrastColor(backgroundColor, {
+      colorToRgb: this.colorToRgb.bind(this)
+    });
   }
 
   getIndicatorColors(visibleColors, combineStyle, combineBackgroundOption) {
@@ -16059,17 +16151,11 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   normalizeBackgroundOpacity(opacityValue, fallback = 0) {
-    const numericOpacity = Number(opacityValue);
-    if (!Number.isFinite(numericOpacity)) {
-      return fallback;
-    }
-
-    return Math.min(100, Math.max(0, numericOpacity));
+    return normalizeBackgroundOpacity(opacityValue, fallback);
   }
 
   normalizeEventModalSize(value) {
-    const normalized = String(value || '').trim().toLowerCase();
-    return EVENT_MODAL_SIZE_OPTIONS.includes(normalized) ? normalized : DEFAULT_EVENT_MODAL_SIZE;
+    return normalizeEventModalSize(value);
   }
 
   getEventModalSizeClass() {

--- a/src/config/config-normalizers.js
+++ b/src/config/config-normalizers.js
@@ -1,0 +1,122 @@
+import {
+  COMBINE_BACKGROUND_MODE_OPTIONS,
+  COMBINE_STYLE_OPTIONS,
+  DAY_BADGE_LAYOUT_WEEK_OPTIONS,
+  DEFAULT_COMBINE_BACKGROUND,
+  DEFAULT_COMBINE_STYLE,
+  DEFAULT_DAY_BADGE_LAYOUT_WEEK,
+  DEFAULT_EVENT_COLOR_MODE,
+  DEFAULT_EVENT_MODAL_SIZE,
+  DEFAULT_EVENT_TITLE_PREFIX,
+  DEFAULT_PAST_EVENT_MODE,
+  DEFAULT_THEME_MODE,
+  EVENT_COLOR_MODE_OPTIONS,
+  EVENT_MODAL_SIZE_OPTIONS,
+  EVENT_TITLE_PREFIX_ALIASES,
+  EVENT_TITLE_PREFIX_OPTIONS,
+  HIDDEN_CALENDAR_VISIBILITY_VALUES,
+  PAST_EVENT_MODE_OPTIONS,
+  THEME_MODE_OPTIONS,
+  VISIBLE_CALENDAR_VISIBILITY_VALUES
+} from '../defaults.js';
+import { normalizeEnumValue } from '../utils/normalization-utils.js';
+import { colorToHex } from '../utils/color-utils.js';
+
+export function normalizeThemeMode(value) {
+  if (value === true) return 'dark';
+  if (value === false || value === undefined || value === null || value === '') return DEFAULT_THEME_MODE;
+
+  return normalizeEnumValue(value, {
+    allowed: THEME_MODE_OPTIONS,
+    fallback: DEFAULT_THEME_MODE
+  });
+}
+
+export function normalizeEventTitlePrefixMode(value) {
+  return normalizeEnumValue(value, {
+    aliases: EVENT_TITLE_PREFIX_ALIASES,
+    allowed: EVENT_TITLE_PREFIX_OPTIONS,
+    fallback: DEFAULT_EVENT_TITLE_PREFIX
+  });
+}
+
+export function normalizePastEventMode(value) {
+  return normalizeEnumValue(value, {
+    allowed: PAST_EVENT_MODE_OPTIONS,
+    fallback: DEFAULT_PAST_EVENT_MODE
+  });
+}
+
+export function normalizeDayBadgeLayoutWeek(value) {
+  return normalizeEnumValue(value, {
+    allowed: DAY_BADGE_LAYOUT_WEEK_OPTIONS,
+    fallback: DEFAULT_DAY_BADGE_LAYOUT_WEEK
+  });
+}
+
+export function normalizeDefaultHiddenCalendars(config = {}) {
+  const knownEntities = new Set(Array.isArray(config.entities) ? config.entities : []);
+  const hiddenCalendars = new Set();
+
+  if (Array.isArray(config.default_hidden_calendars)) {
+    config.default_hidden_calendars.forEach((entityId) => {
+      if (knownEntities.has(entityId)) hiddenCalendars.add(entityId);
+    });
+  }
+
+  const visibilityMap = config.default_calendar_visibility || config.calendar_visibility || {};
+  if (visibilityMap && typeof visibilityMap === 'object' && !Array.isArray(visibilityMap)) {
+    Object.entries(visibilityMap).forEach(([entityId, value]) => {
+      if (!knownEntities.has(entityId)) return;
+      const normalizedValue = typeof value === 'string' ? value.trim().toLowerCase() : value;
+      if (HIDDEN_CALENDAR_VISIBILITY_VALUES.includes(normalizedValue)) {
+        hiddenCalendars.add(entityId);
+      } else if (VISIBLE_CALENDAR_VISIBILITY_VALUES.includes(normalizedValue)) {
+        hiddenCalendars.delete(entityId);
+      }
+    });
+  }
+
+  return Array.from(hiddenCalendars);
+}
+
+export function normalizeCombineStyle(styleValue) {
+  return normalizeEnumValue(styleValue, {
+    allowed: COMBINE_STYLE_OPTIONS,
+    fallback: DEFAULT_COMBINE_STYLE
+  });
+}
+
+export function normalizeEventColorMode(modeValue) {
+  return normalizeEnumValue(modeValue, {
+    allowed: EVENT_COLOR_MODE_OPTIONS,
+    fallback: DEFAULT_EVENT_COLOR_MODE
+  });
+}
+
+export function normalizeCombineBackground(backgroundValue, { colorToHex: normalizeColorToHex = colorToHex } = {}) {
+  const normalized = String(backgroundValue || '').trim();
+  if (!normalized) return DEFAULT_COMBINE_BACKGROUND;
+
+  const lower = normalized.toLowerCase();
+  if (COMBINE_BACKGROUND_MODE_OPTIONS.includes(lower)) {
+    return lower;
+  }
+
+  const hex = normalizeColorToHex(normalized);
+  return hex || DEFAULT_COMBINE_BACKGROUND;
+}
+
+export function normalizeBackgroundOpacity(opacityValue, fallback = 0) {
+  const numericOpacity = Number(opacityValue);
+  if (!Number.isFinite(numericOpacity)) {
+    return fallback;
+  }
+
+  return Math.min(100, Math.max(0, numericOpacity));
+}
+
+export function normalizeEventModalSize(value) {
+  const normalized = String(value || '').trim().toLowerCase();
+  return EVENT_MODAL_SIZE_OPTIONS.includes(normalized) ? normalized : DEFAULT_EVENT_MODAL_SIZE;
+}

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -76,6 +76,27 @@ import {
   normalizeEntityStringMap,
   normalizeEnumValue
 } from './utils/normalization-utils.js';
+import {
+  blendRgb as blendRgbHelper,
+  colorToHex as colorToHexHelper,
+  colorWithAlpha as colorWithAlphaHelper,
+  getContrastColor as getContrastColorHelper,
+  normalizeColorMap as normalizeColorMapHelper,
+  normalizeSingleColor as normalizeSingleColorHelper,
+  parseColorToRgb as parseColorToRgbHelper
+} from './utils/color-utils.js';
+import {
+  normalizeBackgroundOpacity as normalizeBackgroundOpacityHelper,
+  normalizeCombineBackground as normalizeCombineBackgroundHelper,
+  normalizeCombineStyle as normalizeCombineStyleHelper,
+  normalizeDayBadgeLayoutWeek as normalizeDayBadgeLayoutWeekHelper,
+  normalizeDefaultHiddenCalendars as normalizeDefaultHiddenCalendarsHelper,
+  normalizeEventColorMode as normalizeEventColorModeHelper,
+  normalizeEventModalSize as normalizeEventModalSizeHelper,
+  normalizeEventTitlePrefixMode as normalizeEventTitlePrefixModeHelper,
+  normalizePastEventMode as normalizePastEventModeHelper,
+  normalizeThemeMode as normalizeThemeModeHelper
+} from './config/config-normalizers.js';
 import { escapeHtmlAttribute, normalizeEventTextValue } from './utils/string-utils.js';
 import {
   getEventDateTimeInfo as getNormalizedEventDateTimeInfo,
@@ -389,35 +410,19 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   normalizeDefaultDarkMode(value) {
-    if (value === true) return 'dark';
-    if (value === false || value === undefined || value === null || value === '') return DEFAULT_THEME_MODE;
-
-    return this.normalizeEnumValue(value, {
-      allowed: THEME_MODE_OPTIONS,
-      fallback: DEFAULT_THEME_MODE
-    });
+    return normalizeThemeModeHelper(value);
   }
 
   normalizeEventTitlePrefixMode(value) {
-    return this.normalizeEnumValue(value, {
-      aliases: EVENT_TITLE_PREFIX_ALIASES,
-      allowed: EVENT_TITLE_PREFIX_OPTIONS,
-      fallback: DEFAULT_EVENT_TITLE_PREFIX
-    });
+    return normalizeEventTitlePrefixModeHelper(value);
   }
 
   normalizePastEventMode(value) {
-    return this.normalizeEnumValue(value, {
-      allowed: PAST_EVENT_MODE_OPTIONS,
-      fallback: DEFAULT_PAST_EVENT_MODE
-    });
+    return normalizePastEventModeHelper(value);
   }
 
   normalizeDayBadgeLayoutWeek(value) {
-    return this.normalizeEnumValue(value, {
-      allowed: DAY_BADGE_LAYOUT_WEEK_OPTIONS,
-      fallback: DEFAULT_DAY_BADGE_LAYOUT_WEEK
-    });
+    return normalizeDayBadgeLayoutWeekHelper(value);
   }
 
   normalizeEntityStringMap(value) {
@@ -481,29 +486,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   normalizeDefaultHiddenCalendars(config = {}) {
-    const knownEntities = new Set(Array.isArray(config.entities) ? config.entities : []);
-    const hiddenCalendars = new Set();
-
-    if (Array.isArray(config.default_hidden_calendars)) {
-      config.default_hidden_calendars.forEach((entityId) => {
-        if (knownEntities.has(entityId)) hiddenCalendars.add(entityId);
-      });
-    }
-
-    const visibilityMap = config.default_calendar_visibility || config.calendar_visibility || {};
-    if (visibilityMap && typeof visibilityMap === 'object' && !Array.isArray(visibilityMap)) {
-      Object.entries(visibilityMap).forEach(([entityId, value]) => {
-        if (!knownEntities.has(entityId)) return;
-        const normalizedValue = typeof value === 'string' ? value.trim().toLowerCase() : value;
-        if (HIDDEN_CALENDAR_VISIBILITY_VALUES.includes(normalizedValue)) {
-          hiddenCalendars.add(entityId);
-        } else if (VISIBLE_CALENDAR_VISIBILITY_VALUES.includes(normalizedValue)) {
-          hiddenCalendars.delete(entityId);
-        }
-      });
-    }
-
-    return Array.from(hiddenCalendars);
+    return normalizeDefaultHiddenCalendarsHelper(config);
   }
 
   loadPersistedPreferences() {
@@ -926,91 +909,38 @@ class SkylightCalendarCard extends HTMLElement {
 
 
   normalizeColorMap(colorMap) {
-    if (!colorMap || typeof colorMap !== 'object') return {};
-
-    return Object.entries(colorMap).reduce((acc, [entityId, color]) => {
-      const normalized = this.normalizeSingleColor(color);
-      if (normalized !== undefined && normalized !== null && normalized !== '') {
-        acc[entityId] = normalized;
-      }
-      return acc;
-    }, {});
+    return normalizeColorMapHelper(colorMap, {
+      normalizeColor: this.normalizeSingleColor.bind(this)
+    });
   }
 
   normalizeSingleColor(colorValue) {
-    if (colorValue === undefined || colorValue === null) {
-      return colorValue;
-    }
-
-    const trimmed = String(colorValue).trim();
-    if (!trimmed) return trimmed;
-
-    const normalizedName = trimmed
-      .toLowerCase()
-      .replace(/[()]/g, '')
-      .replace(/\s*\/\s*/g, '/')
-      .replace(/\s+/g, ' ')
-      .trim();
-    const mappedColor = SkylightCalendarCard.COMMON_NAMED_COLORS[normalizedName];
-    if (mappedColor) {
-      return mappedColor;
-    }
-
-    return trimmed;
+    return normalizeSingleColorHelper(colorValue);
   }
 
   colorToHex(color) {
-    if (!color) return null;
-
-    const normalizedColor = this.normalizeSingleColor(color);
-    if (typeof normalizedColor !== 'string') return null;
-
-    const hex3Match = normalizedColor.match(/^#([\da-fA-F]{3})$/);
-    if (hex3Match) {
-      const [r, g, b] = hex3Match[1].split('');
-      return `#${r}${r}${g}${g}${b}${b}`.toUpperCase();
-    }
-
-    const hex6Match = normalizedColor.match(/^#([\da-fA-F]{6})$/);
-    if (hex6Match) {
-      return `#${hex6Match[1].toUpperCase()}`;
-    }
-
-    return null;
+    return colorToHexHelper(color, {
+      normalizeColor: this.normalizeSingleColor.bind(this)
+    });
   }
 
   colorToRgb(color) {
-    const normalizedColor = this.normalizeSingleColor(color);
-    if (typeof normalizedColor === 'string') {
-      const rgbMatch = normalizedColor
-        .match(/^rgba?\((.+)\)$/i);
-      if (rgbMatch) {
-        const normalizedChannels = rgbMatch[1]
-          .replace(/\s*\/\s*.*/, '')
-          .replace(/,/g, ' ')
-          .trim()
-          .split(/\s+/)
-          .slice(0, 3)
-          .map((channel) => Number(channel));
-
-        if (normalizedChannels.length === 3 && normalizedChannels.every((value) => Number.isFinite(value))) {
-          const [r, g, b] = normalizedChannels.map((value) => Math.max(0, Math.min(255, Math.round(value))));
-          return { r, g, b };
-        }
-      }
-    }
-
-    const hex = this.colorToHex(normalizedColor);
-    if (hex) {
-      return {
-        r: parseInt(hex.slice(1, 3), 16),
-        g: parseInt(hex.slice(3, 5), 16),
-        b: parseInt(hex.slice(5, 7), 16)
-      };
-    }
-
-    return this.resolveComputedCssColorToRgb(normalizedColor);
+    return parseColorToRgbHelper(color, {
+      normalizeColor: this.normalizeSingleColor.bind(this),
+      resolveComputedCssColorToRgb: this.resolveComputedCssColorToRgb.bind(this)
+    });
   }
+
+  colorWithAlpha(color, alpha = 1) {
+    return colorWithAlphaHelper(color, alpha, {
+      colorToRgb: this.colorToRgb.bind(this)
+    });
+  }
+
+  blendRgb(top, bottom, topAlpha = 1) {
+    return blendRgbHelper(top, bottom, topAlpha);
+  }
+
 
 
   resolveComputedCssColorToRgb(color) {
@@ -1041,52 +971,18 @@ class SkylightCalendarCard extends HTMLElement {
     };
   }
 
-  colorWithAlpha(color, alpha = 1) {
-    const rgb = this.colorToRgb(color);
-    if (!rgb) return color;
-
-    const clamped = Math.max(0, Math.min(1, alpha));
-    return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${clamped})`;
-  }
-
-  blendRgb(top, bottom, topAlpha = 1) {
-    if (!top && !bottom) return null;
-    if (!top) return bottom;
-    if (!bottom) return top;
-    const clampedAlpha = Math.max(0, Math.min(1, topAlpha));
-    return {
-      r: Math.round((top.r * clampedAlpha) + (bottom.r * (1 - clampedAlpha))),
-      g: Math.round((top.g * clampedAlpha) + (bottom.g * (1 - clampedAlpha))),
-      b: Math.round((top.b * clampedAlpha) + (bottom.b * (1 - clampedAlpha)))
-    };
-  }
-
-
   normalizeCombineStyle(styleValue) {
-    return this.normalizeEnumValue(styleValue, {
-      allowed: COMBINE_STYLE_OPTIONS,
-      fallback: DEFAULT_COMBINE_STYLE
-    });
+    return normalizeCombineStyleHelper(styleValue);
   }
 
   normalizeEventColorMode(modeValue) {
-    return this.normalizeEnumValue(modeValue, {
-      allowed: EVENT_COLOR_MODE_OPTIONS,
-      fallback: DEFAULT_EVENT_COLOR_MODE
-    });
+    return normalizeEventColorModeHelper(modeValue);
   }
 
   normalizeCombineBackground(backgroundValue) {
-    const normalized = String(backgroundValue || '').trim();
-    if (!normalized) return DEFAULT_COMBINE_BACKGROUND;
-
-    const lower = normalized.toLowerCase();
-    if (COMBINE_BACKGROUND_MODE_OPTIONS.includes(lower)) {
-      return lower;
-    }
-
-    const hex = this.colorToHex(normalized);
-    return hex || DEFAULT_COMBINE_BACKGROUND;
+    return normalizeCombineBackgroundHelper(backgroundValue, {
+      colorToHex: this.colorToHex.bind(this)
+    });
   }
 
   getEmptyAdvancedMatch() {
@@ -4482,11 +4378,9 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getContractColor(backgroundColor) {
-    const rgb = this.colorToRgb(backgroundColor);
-    if (!rgb) return 'white';
-
-    const luminance = (0.299 * rgb.r + 0.587 * rgb.g + 0.114 * rgb.b) / 255;
-    return luminance > 0.6 ? 'black' : 'white';
+    return getContrastColorHelper(backgroundColor, {
+      colorToRgb: this.colorToRgb.bind(this)
+    });
   }
 
   getIndicatorColors(visibleColors, combineStyle, combineBackgroundOption) {
@@ -7015,17 +6909,11 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   normalizeBackgroundOpacity(opacityValue, fallback = 0) {
-    const numericOpacity = Number(opacityValue);
-    if (!Number.isFinite(numericOpacity)) {
-      return fallback;
-    }
-
-    return Math.min(100, Math.max(0, numericOpacity));
+    return normalizeBackgroundOpacityHelper(opacityValue, fallback);
   }
 
   normalizeEventModalSize(value) {
-    const normalized = String(value || '').trim().toLowerCase();
-    return EVENT_MODAL_SIZE_OPTIONS.includes(normalized) ? normalized : DEFAULT_EVENT_MODAL_SIZE;
+    return normalizeEventModalSizeHelper(value);
   }
 
   getEventModalSizeClass() {

--- a/src/utils/color-utils.js
+++ b/src/utils/color-utils.js
@@ -1,0 +1,121 @@
+import { COMMON_NAMED_COLORS } from '../constants.js';
+
+export function normalizeSingleColor(colorValue) {
+  if (colorValue === undefined || colorValue === null) {
+    return colorValue;
+  }
+
+  const trimmed = String(colorValue).trim();
+  if (!trimmed) return trimmed;
+
+  const normalizedName = trimmed
+    .toLowerCase()
+    .replace(/[()]/g, '')
+    .replace(/\s*\/\s*/g, '/')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const mappedColor = COMMON_NAMED_COLORS[normalizedName];
+  if (mappedColor) {
+    return mappedColor;
+  }
+
+  return trimmed;
+}
+
+export function normalizeColorMap(colorMap, { normalizeColor = normalizeSingleColor } = {}) {
+  if (!colorMap || typeof colorMap !== 'object') return {};
+
+  return Object.entries(colorMap).reduce((acc, [entityId, color]) => {
+    const normalized = normalizeColor(color);
+    if (normalized !== undefined && normalized !== null && normalized !== '') {
+      acc[entityId] = normalized;
+    }
+    return acc;
+  }, {});
+}
+
+export function colorToHex(color, { normalizeColor = normalizeSingleColor } = {}) {
+  if (!color) return null;
+
+  const normalizedColor = normalizeColor(color);
+  if (typeof normalizedColor !== 'string') return null;
+
+  const hex3Match = normalizedColor.match(/^#([\da-fA-F]{3})$/);
+  if (hex3Match) {
+    const [r, g, b] = hex3Match[1].split('');
+    return `#${r}${r}${g}${g}${b}${b}`.toUpperCase();
+  }
+
+  const hex6Match = normalizedColor.match(/^#([\da-fA-F]{6})$/);
+  if (hex6Match) {
+    return `#${hex6Match[1].toUpperCase()}`;
+  }
+
+  return null;
+}
+
+export function parseColorToRgb(color, {
+  normalizeColor = normalizeSingleColor,
+  resolveComputedCssColorToRgb = null
+} = {}) {
+  const normalizedColor = normalizeColor(color);
+  if (typeof normalizedColor === 'string') {
+    const rgbMatch = normalizedColor
+      .match(/^rgba?\((.+)\)$/i);
+    if (rgbMatch) {
+      const normalizedChannels = rgbMatch[1]
+        .replace(/\s*\/\s*.*/, '')
+        .replace(/,/g, ' ')
+        .trim()
+        .split(/\s+/)
+        .slice(0, 3)
+        .map((channel) => Number(channel));
+
+      if (normalizedChannels.length === 3 && normalizedChannels.every((value) => Number.isFinite(value))) {
+        const [r, g, b] = normalizedChannels.map((value) => Math.max(0, Math.min(255, Math.round(value))));
+        return { r, g, b };
+      }
+    }
+  }
+
+  const hex = colorToHex(normalizedColor, { normalizeColor });
+  if (hex) {
+    return {
+      r: parseInt(hex.slice(1, 3), 16),
+      g: parseInt(hex.slice(3, 5), 16),
+      b: parseInt(hex.slice(5, 7), 16)
+    };
+  }
+
+  return typeof resolveComputedCssColorToRgb === 'function'
+    ? resolveComputedCssColorToRgb(normalizedColor)
+    : null;
+}
+
+export function colorWithAlpha(color, alpha = 1, { colorToRgb = parseColorToRgb } = {}) {
+  const rgb = colorToRgb(color);
+  if (!rgb) return color;
+
+  const clamped = Math.max(0, Math.min(1, alpha));
+  return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${clamped})`;
+}
+
+export function blendRgb(top, bottom, topAlpha = 1) {
+  if (!top && !bottom) return null;
+  if (!top) return bottom;
+  if (!bottom) return top;
+  const clampedAlpha = Math.max(0, Math.min(1, topAlpha));
+  return {
+    r: Math.round((top.r * clampedAlpha) + (bottom.r * (1 - clampedAlpha))),
+    g: Math.round((top.g * clampedAlpha) + (bottom.g * (1 - clampedAlpha))),
+    b: Math.round((top.b * clampedAlpha) + (bottom.b * (1 - clampedAlpha)))
+  };
+}
+
+export function getContrastColor(backgroundColor, { colorToRgb = parseColorToRgb } = {}) {
+  const rgb = colorToRgb(backgroundColor);
+  if (!rgb) return 'white';
+
+  const luminance = (0.299 * rgb.r + 0.587 * rgb.g + 0.114 * rgb.b) / 255;
+  return luminance > 0.6 ? 'black' : 'white';
+}


### PR DESCRIPTION
### Motivation
- Reduce the size and responsibilities of the main card by extracting pure color, style, and config normalization helpers into focused modules. 
- Make color and config normalization reusable, easier to unit-test, and independent of card lifecycle and DOM logic. 
- Preserve existing runtime behavior, visual output, public config, and the generated shipped artifact while enabling further modularization.

### Description
- Moved pure color helpers into `src/utils/color-utils.js`, including `normalizeSingleColor`, `normalizeColorMap`, `colorToHex`, `parseColorToRgb`, `colorWithAlpha`, `blendRgb`, and `getContrastColor` and updated the main card to delegate to these helpers. 
- Moved config/style normalizers into `src/config/config-normalizers.js`, including `normalizeThemeMode`, `normalizeEventTitlePrefixMode`, `normalizePastEventMode`, `normalizeDayBadgeLayoutWeek`, `normalizeDefaultHiddenCalendars`, `normalizeCombineStyle`, `normalizeEventColorMode`, `normalizeCombineBackground`, `normalizeBackgroundOpacity`, and `normalizeEventModalSize`, and updated the main card to call them. 
- Kept DOM-dependent behavior and lifecycle in `src/skylight-calendar-card.js`, specifically the computed-CSS color resolver (`resolveComputedCssColorToRgb`) and media-query/theme listeners, and passed the computed-color resolver as a callback into the pure color helpers where needed. 
- Added a focused unit test `color-config-normalizers.test.mjs` and wired it into `npm test`, and regenerated the Rollup root artifact `skylight-calendar-card.js` to reflect the refactor.

### Testing
- Ran dependency install and build with `npm ci --no-audit --fund=false` and `npm run build`, and confirmed the Rollup-generated `skylight-calendar-card.js` was regenerated and committed. 
- Performed static checks with `node --check` for `src/skylight-calendar-card.js`, `src/utils/color-utils.js`, `src/config/config-normalizers.js`, and the root `skylight-calendar-card.js` successfully. 
- Ran unit tests with `npm test` which executed all node tests (including the new `color-config-normalizers.test.mjs`) and all tests passed (246 tests). 
- Ran visual tests with `npm run test:visual` and all 39 Playwright visual tests passed with no snapshot regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb7884974833188d40d8bc968672d)