### PR TITLE
Extract calendar event fetch helpers into src/events/event-fetcher.js

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -7994,6 +7994,151 @@ function getScheduleVisualInfo(event, { getEventDateTimeInfo, shouldRenderTimedE
   };
 }
 
+async function fetchEventsByCalendarInRange({
+  hass,
+  entities = [],
+  startDate,
+  endDate,
+  getDateRangeChunks,
+  formatLocalDate,
+  getCalendarColor,
+  getEventIdentityKey,
+  normalizeCalendarEvent
+}) {
+  const chunks = getDateRangeChunks(startDate, endDate, 30);
+  const eventsByCalendar = await Promise.all(
+    entities.map((entityId, index) => fetchEventsForCalendar({
+      hass,
+      entityId,
+      colorIndex: index,
+      chunks,
+      formatLocalDate,
+      getCalendarColor,
+      getEventIdentityKey,
+      normalizeCalendarEvent
+    }))
+  );
+
+  return entities.reduce((acc, entityId, index) => {
+    acc[entityId] = eventsByCalendar[index] || [];
+    return acc;
+  }, {});
+}
+
+async function fetchEventsForCalendar({
+  hass,
+  entityId,
+  colorIndex = 0,
+  chunks = [],
+  formatLocalDate,
+  getCalendarColor,
+  getEventIdentityKey,
+  normalizeCalendarEvent
+}) {
+  const seen = new Set();
+  const color = getCalendarColor(entityId, colorIndex);
+
+  const chunkEventLists = await Promise.all(
+    chunks.map(chunk => fetchEventsForChunk({ hass, entityId, chunk, formatLocalDate }))
+  );
+
+  const mergedEvents = [];
+  chunkEventLists.forEach(events => {
+    if (!events || !Array.isArray(events)) return;
+
+    events.forEach(event => {
+      const key = getEventIdentityKey(entityId, event);
+      if (seen.has(key)) return;
+      seen.add(key);
+
+      mergedEvents.push(normalizeCalendarEvent(event, { entityId, color }));
+    });
+  });
+
+  return mergedEvents;
+}
+
+async function fetchEventsForChunk({ hass, entityId, chunk, formatLocalDate }) {
+  const chunkStartStr = chunk.startDate.toISOString();
+  const chunkEndStr = chunk.endDate.toISOString();
+
+  try {
+    return await fetchEventsViaWebSocket({ hass, entityId, chunkStartStr, chunkEndStr });
+  } catch (error) {
+    try {
+      const startDateOnly = formatLocalDate(chunk.startDate);
+      const endDateOnly = formatLocalDate(chunk.endDate);
+      return await hass.callApi('GET', `calendars/${entityId}?start=${startDateOnly}T00:00:00Z&end=${endDateOnly}T23:59:59Z`);
+    } catch (error2) {
+      console.error(`Failed to fetch events for ${entityId}:`, error2.message || error2);
+      return [];
+    }
+  }
+}
+
+async function fetchEventsViaWebSocket({ hass, entityId, chunkStartStr, chunkEndStr }) {
+  return hass.callWS({
+    type: 'calendar/events',
+    entity_id: entityId,
+    start_date_time: chunkStartStr,
+    end_date_time: chunkEndStr
+  });
+}
+
+function mergeEvents(existingEvents, incomingEvents, { getEventIdentityKey, getEventStartDate }) {
+  const mergedByKey = new Map();
+
+  existingEvents.forEach(event => {
+    mergedByKey.set(getEventIdentityKey(event.entityId, event), event);
+  });
+
+  incomingEvents.forEach(event => {
+    mergedByKey.set(getEventIdentityKey(event.entityId, event), event);
+  });
+
+  return sortEventsByStartDate(Array.from(mergedByKey.values()), { getEventStartDate });
+}
+
+function sortEventsByStartDate(events, { getEventStartDate }) {
+  return [...events].sort((a, b) => getEventStartDate(a) - getEventStartDate(b));
+}
+
+function toStableString(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(item => toStableString(item)).join(',')}]`;
+  }
+
+  if (value && typeof value === 'object') {
+    const entries = Object.keys(value)
+      .sort()
+      .map(key => `${JSON.stringify(key)}:${toStableString(value[key])}`);
+    return `{${entries.join(',')}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
+function getCalendarDataSignature(events = []) {
+  return events
+    .map(event => {
+      const { entityId, color, ...eventData } = event;
+      return toStableString(eventData);
+    })
+    .sort()
+    .join('|');
+}
+
+function isDateRangeCoveredByLoadedEvents(loadedEventRange, targetStartDate, targetEndDate) {
+  if (!loadedEventRange) return false;
+
+  return targetStartDate >= loadedEventRange.startDate &&
+         targetEndDate <= loadedEventRange.endDate;
+}
+
+function shouldRefreshEvents({ lastFetch, now = Date.now(), maxAge = 60000 } = {}) {
+  return !lastFetch || (now - lastFetch > maxAge);
+}
+
 function getMonthGridDates(currentDate, firstDayOfWeek) {
   const year = currentDate.getFullYear();
   const month = currentDate.getMonth();
@@ -10869,17 +11014,17 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   async fetchEventsByCalendarInRange(startDate, endDate) {
-    const chunks = this.getDateRangeChunks(startDate, endDate, 30);
-    const eventsByCalendar = await Promise.all(
-      this._config.entities.map((entityId, index) =>
-        this.fetchEventsForCalendar(entityId, index, chunks)
-      )
-    );
-
-    return this._config.entities.reduce((acc, entityId, index) => {
-      acc[entityId] = eventsByCalendar[index] || [];
-      return acc;
-    }, {});
+    return fetchEventsByCalendarInRange({
+      hass: this._hass,
+      entities: this._config.entities,
+      startDate,
+      endDate,
+      getDateRangeChunks: this.getDateRangeChunks.bind(this),
+      formatLocalDate: this.formatLocalDate.bind(this),
+      getCalendarColor: this.getCalendarColor.bind(this),
+      getEventIdentityKey: this.getEventIdentityKey.bind(this),
+      normalizeCalendarEvent
+    });
   }
 
   getCalendarColor(entityId, index = 0) {
@@ -10891,100 +11036,49 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   async fetchEventsForCalendar(entityId, colorIndex, chunks) {
-    const seen = new Set();
-    const color = this.getCalendarColor(entityId, colorIndex);
-
-    const chunkEventLists = await Promise.all(
-      chunks.map(chunk => this.fetchEventsForChunk(entityId, chunk))
-    );
-
-    const mergedEvents = [];
-    chunkEventLists.forEach(events => {
-      if (!events || !Array.isArray(events)) return;
-
-      events.forEach(event => {
-        const key = this.getEventIdentityKey(entityId, event);
-        if (seen.has(key)) return;
-        seen.add(key);
-
-        mergedEvents.push(normalizeCalendarEvent(event, { entityId, color }));
-      });
+    return fetchEventsForCalendar({
+      hass: this._hass,
+      entityId,
+      colorIndex,
+      chunks,
+      formatLocalDate: this.formatLocalDate.bind(this),
+      getCalendarColor: this.getCalendarColor.bind(this),
+      getEventIdentityKey: this.getEventIdentityKey.bind(this),
+      normalizeCalendarEvent
     });
-
-    return mergedEvents;
   }
 
   async fetchEventsForChunk(entityId, chunk) {
-    const chunkStartStr = chunk.startDate.toISOString();
-    const chunkEndStr = chunk.endDate.toISOString();
-
-    try {
-      // Use WebSocket API to get calendar events.
-      // Home Assistant command name varies by version.
-      return await this.fetchEventsViaWebSocket(entityId, chunkStartStr, chunkEndStr);
-    } catch (error) {
-      // WebSocket API might not be available in older HA versions or for some integrations
-      // Try REST API fallback without logging (this is expected)
-      try {
-        const startDateOnly = this.formatLocalDate(chunk.startDate);
-        const endDateOnly = this.formatLocalDate(chunk.endDate);
-        return await this._hass.callApi('GET', `calendars/${entityId}?start=${startDateOnly}T00:00:00Z&end=${endDateOnly}T23:59:59Z`);
-      } catch (error2) {
-        // Both methods failed - this is a real error
-        console.error(`Failed to fetch events for ${entityId}:`, error2.message || error2);
-        return [];
-      }
-    }
+    return fetchEventsForChunk({
+      hass: this._hass,
+      entityId,
+      chunk,
+      formatLocalDate: this.formatLocalDate.bind(this)
+    });
   }
 
   async fetchEventsViaWebSocket(entityId, chunkStartStr, chunkEndStr) {
-    return this._hass.callWS({
-      type: 'calendar/events',
-      entity_id: entityId,
-      start_date_time: chunkStartStr,
-      end_date_time: chunkEndStr
+    return fetchEventsViaWebSocket({
+      hass: this._hass,
+      entityId,
+      chunkStartStr,
+      chunkEndStr
     });
   }
 
   mergeEvents(existingEvents, incomingEvents) {
-    const mergedByKey = new Map();
-
-    existingEvents.forEach(event => {
-      mergedByKey.set(this.getEventIdentityKey(event.entityId, event), event);
+    return mergeEvents(existingEvents, incomingEvents, {
+      getEventIdentityKey: this.getEventIdentityKey.bind(this),
+      getEventStartDate: this.getEventStartDate.bind(this)
     });
-
-    incomingEvents.forEach(event => {
-      mergedByKey.set(this.getEventIdentityKey(event.entityId, event), event);
-    });
-
-    const merged = Array.from(mergedByKey.values());
-    merged.sort((a, b) => this.getEventStartDate(a) - this.getEventStartDate(b));
-    return merged;
   }
 
   toStableString(value) {
-    if (Array.isArray(value)) {
-      return `[${value.map(item => this.toStableString(item)).join(',')}]`;
-    }
-
-    if (value && typeof value === 'object') {
-      const entries = Object.keys(value)
-        .sort()
-        .map(key => `${JSON.stringify(key)}:${this.toStableString(value[key])}`);
-      return `{${entries.join(',')}}`;
-    }
-
-    return JSON.stringify(value);
+    return toStableString(value);
   }
 
   getCalendarDataSignature(events = []) {
-    return events
-      .map(event => {
-        const { entityId, color, ...eventData } = event;
-        return this.toStableString(eventData);
-      })
-      .sort()
-      .join('|');
+    return getCalendarDataSignature(events);
   }
 
   async updateEvents({ preserveScroll = false } = {}) {
@@ -11030,9 +11124,9 @@ class SkylightCalendarCard extends HTMLElement {
         this._calendarDataSignatures[entityId] = this.getCalendarDataSignature(newEventsByCalendar[entityId]);
       });
 
-      const mergedEvents = Object.values(newEventsByCalendar)
-        .flat()
-        .sort((a, b) => this.getEventStartDate(a) - this.getEventStartDate(b));
+      const mergedEvents = sortEventsByStartDate(Object.values(newEventsByCalendar).flat(), {
+        getEventStartDate: this.getEventStartDate.bind(this)
+      });
 
       this._events = mergedEvents;
       this._loadedEventRange = { startDate, endDate };
@@ -11065,14 +11159,11 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   isDateRangeCoveredByLoadedEvents(targetStartDate, targetEndDate) {
-    if (!this._loadedEventRange) return false;
-
-    return targetStartDate >= this._loadedEventRange.startDate &&
-           targetEndDate <= this._loadedEventRange.endDate;
+    return isDateRangeCoveredByLoadedEvents(this._loadedEventRange, targetStartDate, targetEndDate);
   }
 
   async ensureEventsForCurrentRange({ force = false, renderIfCovered = false } = {}) {
-    const shouldRefreshForAge = !this._lastFetch || (Date.now() - this._lastFetch > 60000);
+    const shouldRefreshForAge = shouldRefreshEvents({ lastFetch: this._lastFetch });
     const { startDate: visibleStartDate, endDate: visibleEndDate } = this.getVisibleDateRange();
 
     // Background stale refreshes run through this path via hass updates.

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -4624,3 +4624,165 @@ test('event service helpers preserve create update and delete payload shapes', a
     recurrence_range: 'THISANDFUTURE'
   });
 });
+
+test('event fetcher stable stringify sorts object keys recursively', async () => {
+  const { toStableString } = await import('./src/events/event-fetcher.js');
+
+  assert.equal(
+    toStableString({ b: 2, a: { d: 4, c: 3 }, e: [{ g: 7, f: 6 }] }),
+    '{"a":{"c":3,"d":4},"b":2,"e":[{"f":6,"g":7}]}'
+  );
+});
+
+test('event fetcher calendar data signature ignores entity color and is order independent', async () => {
+  const { getCalendarDataSignature } = await import('./src/events/event-fetcher.js');
+  const first = getCalendarDataSignature([
+    { entityId: 'calendar.work', color: '#fff', summary: 'B', start: { date: '2026-01-02' } },
+    { entityId: 'calendar.work', color: '#000', summary: 'A', start: { date: '2026-01-01' } }
+  ]);
+  const second = getCalendarDataSignature([
+    { entityId: 'calendar.work', color: 'red', summary: 'A', start: { date: '2026-01-01' } },
+    { entityId: 'calendar.work', color: 'blue', summary: 'B', start: { date: '2026-01-02' } }
+  ]);
+
+  assert.equal(first, second);
+});
+
+test('event fetcher mergeEvents replaces duplicate keys and sorts by start date', async () => {
+  const { mergeEvents } = await import('./src/events/event-fetcher.js');
+  const merged = mergeEvents(
+    [
+      { entityId: 'calendar.work', uid: '1', summary: 'Old', start: '2026-01-03' },
+      { entityId: 'calendar.work', uid: '2', summary: 'Middle', start: '2026-01-02' }
+    ],
+    [
+      { entityId: 'calendar.work', uid: '1', summary: 'New', start: '2026-01-01' }
+    ],
+    {
+      getEventIdentityKey: (entityId, event) => `${entityId}:${event.uid}`,
+      getEventStartDate: event => new Date(event.start)
+    }
+  );
+
+  assert.deepEqual(merged.map(event => event.summary), ['New', 'Middle']);
+});
+
+test('event fetcher loaded range coverage and stale refresh decisions match boundaries', async () => {
+  const { isDateRangeCoveredByLoadedEvents, shouldRefreshEvents } = await import('./src/events/event-fetcher.js');
+  const loaded = {
+    startDate: new Date('2026-01-01T00:00:00Z'),
+    endDate: new Date('2026-01-31T23:59:59Z')
+  };
+
+  assert.equal(isDateRangeCoveredByLoadedEvents(null, loaded.startDate, loaded.endDate), false);
+  assert.equal(isDateRangeCoveredByLoadedEvents(loaded, loaded.startDate, loaded.endDate), true);
+  assert.equal(isDateRangeCoveredByLoadedEvents(loaded, new Date('2025-12-31T23:59:59Z'), loaded.endDate), false);
+  assert.equal(shouldRefreshEvents({ lastFetch: null, now: 100000 }), true);
+  assert.equal(shouldRefreshEvents({ lastFetch: 40000, now: 100000 }), false);
+  assert.equal(shouldRefreshEvents({ lastFetch: 39999, now: 100000 }), true);
+});
+
+test('event fetcher sends WebSocket calendar event payload unchanged', async () => {
+  const { fetchEventsViaWebSocket } = await import('./src/events/event-fetcher.js');
+  let payload;
+  const hass = {
+    callWS(message) {
+      payload = message;
+      return Promise.resolve([{ summary: 'WS event' }]);
+    }
+  };
+
+  const result = await fetchEventsViaWebSocket({
+    hass,
+    entityId: 'calendar.work',
+    chunkStartStr: '2026-01-01T00:00:00.000Z',
+    chunkEndStr: '2026-01-31T23:59:59.999Z'
+  });
+
+  assert.deepEqual(payload, {
+    type: 'calendar/events',
+    entity_id: 'calendar.work',
+    start_date_time: '2026-01-01T00:00:00.000Z',
+    end_date_time: '2026-01-31T23:59:59.999Z'
+  });
+  assert.deepEqual(result, [{ summary: 'WS event' }]);
+});
+
+test('event fetcher falls back to REST URL and returns empty array after failed fetches', async () => {
+  const { fetchEventsForChunk } = await import('./src/events/event-fetcher.js');
+  const chunk = {
+    startDate: new Date('2026-01-01T12:34:56Z'),
+    endDate: new Date('2026-01-31T12:34:56Z')
+  };
+  let restUrl;
+  const originalConsoleError = console.error;
+  console.error = () => {};
+  try {
+    const restEvents = await fetchEventsForChunk({
+      hass: {
+        callWS: () => Promise.reject(new Error('no ws')),
+        callApi(method, url) {
+          restUrl = url;
+          assert.equal(method, 'GET');
+          return Promise.resolve([{ summary: 'REST event' }]);
+        }
+      },
+      entityId: 'calendar.work',
+      chunk,
+      formatLocalDate: date => date.toISOString().slice(0, 10)
+    });
+
+    assert.deepEqual(restEvents, [{ summary: 'REST event' }]);
+    assert.equal(restUrl, 'calendars/calendar.work?start=2026-01-01T00:00:00Z&end=2026-01-31T23:59:59Z');
+
+    const failedEvents = await fetchEventsForChunk({
+      hass: {
+        callWS: () => Promise.reject(new Error('no ws')),
+        callApi: () => Promise.reject(new Error('no rest'))
+      },
+      entityId: 'calendar.work',
+      chunk,
+      formatLocalDate: date => date.toISOString().slice(0, 10)
+    });
+
+    assert.deepEqual(failedEvents, []);
+  } finally {
+    console.error = originalConsoleError;
+  }
+});
+
+test('event fetcher normalizes with calendar colors and de-duplicates chunk overlaps', async () => {
+  const { fetchEventsForCalendar } = await import('./src/events/event-fetcher.js');
+  const chunks = [
+    { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-01-02T00:00:00Z') },
+    { startDate: new Date('2026-01-02T00:00:00Z'), endDate: new Date('2026-01-03T00:00:00Z') }
+  ];
+  const hass = {
+    callWS: ({ start_date_time }) => Promise.resolve(
+      start_date_time === '2026-01-01T00:00:00.000Z'
+        ? [{ uid: '1', summary: 'First' }, { uid: '2', summary: 'Second' }]
+        : [{ uid: '1', summary: 'First duplicate' }]
+    )
+  };
+  const normalizedContexts = [];
+
+  const events = await fetchEventsForCalendar({
+    hass,
+    entityId: 'calendar.work',
+    colorIndex: 3,
+    chunks,
+    formatLocalDate: date => date.toISOString().slice(0, 10),
+    getCalendarColor: (entityId, index) => `${entityId}:${index}:color`,
+    getEventIdentityKey: (entityId, event) => `${entityId}:${event.uid}`,
+    normalizeCalendarEvent: (event, context) => {
+      normalizedContexts.push(context);
+      return { ...event, ...context };
+    }
+  });
+
+  assert.deepEqual(events.map(event => event.summary), ['First', 'Second']);
+  assert.deepEqual(normalizedContexts, [
+    { entityId: 'calendar.work', color: 'calendar.work:3:color' },
+    { entityId: 'calendar.work', color: 'calendar.work:3:color' }
+  ]);
+});

--- a/src/events/event-fetcher.js
+++ b/src/events/event-fetcher.js
@@ -1,0 +1,144 @@
+export async function fetchEventsByCalendarInRange({
+  hass,
+  entities = [],
+  startDate,
+  endDate,
+  getDateRangeChunks,
+  formatLocalDate,
+  getCalendarColor,
+  getEventIdentityKey,
+  normalizeCalendarEvent
+}) {
+  const chunks = getDateRangeChunks(startDate, endDate, 30);
+  const eventsByCalendar = await Promise.all(
+    entities.map((entityId, index) => fetchEventsForCalendar({
+      hass,
+      entityId,
+      colorIndex: index,
+      chunks,
+      formatLocalDate,
+      getCalendarColor,
+      getEventIdentityKey,
+      normalizeCalendarEvent
+    }))
+  );
+
+  return entities.reduce((acc, entityId, index) => {
+    acc[entityId] = eventsByCalendar[index] || [];
+    return acc;
+  }, {});
+}
+
+export async function fetchEventsForCalendar({
+  hass,
+  entityId,
+  colorIndex = 0,
+  chunks = [],
+  formatLocalDate,
+  getCalendarColor,
+  getEventIdentityKey,
+  normalizeCalendarEvent
+}) {
+  const seen = new Set();
+  const color = getCalendarColor(entityId, colorIndex);
+
+  const chunkEventLists = await Promise.all(
+    chunks.map(chunk => fetchEventsForChunk({ hass, entityId, chunk, formatLocalDate }))
+  );
+
+  const mergedEvents = [];
+  chunkEventLists.forEach(events => {
+    if (!events || !Array.isArray(events)) return;
+
+    events.forEach(event => {
+      const key = getEventIdentityKey(entityId, event);
+      if (seen.has(key)) return;
+      seen.add(key);
+
+      mergedEvents.push(normalizeCalendarEvent(event, { entityId, color }));
+    });
+  });
+
+  return mergedEvents;
+}
+
+export async function fetchEventsForChunk({ hass, entityId, chunk, formatLocalDate }) {
+  const chunkStartStr = chunk.startDate.toISOString();
+  const chunkEndStr = chunk.endDate.toISOString();
+
+  try {
+    return await fetchEventsViaWebSocket({ hass, entityId, chunkStartStr, chunkEndStr });
+  } catch (error) {
+    try {
+      const startDateOnly = formatLocalDate(chunk.startDate);
+      const endDateOnly = formatLocalDate(chunk.endDate);
+      return await hass.callApi('GET', `calendars/${entityId}?start=${startDateOnly}T00:00:00Z&end=${endDateOnly}T23:59:59Z`);
+    } catch (error2) {
+      console.error(`Failed to fetch events for ${entityId}:`, error2.message || error2);
+      return [];
+    }
+  }
+}
+
+export async function fetchEventsViaWebSocket({ hass, entityId, chunkStartStr, chunkEndStr }) {
+  return hass.callWS({
+    type: 'calendar/events',
+    entity_id: entityId,
+    start_date_time: chunkStartStr,
+    end_date_time: chunkEndStr
+  });
+}
+
+export function mergeEvents(existingEvents, incomingEvents, { getEventIdentityKey, getEventStartDate }) {
+  const mergedByKey = new Map();
+
+  existingEvents.forEach(event => {
+    mergedByKey.set(getEventIdentityKey(event.entityId, event), event);
+  });
+
+  incomingEvents.forEach(event => {
+    mergedByKey.set(getEventIdentityKey(event.entityId, event), event);
+  });
+
+  return sortEventsByStartDate(Array.from(mergedByKey.values()), { getEventStartDate });
+}
+
+export function sortEventsByStartDate(events, { getEventStartDate }) {
+  return [...events].sort((a, b) => getEventStartDate(a) - getEventStartDate(b));
+}
+
+export function toStableString(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(item => toStableString(item)).join(',')}]`;
+  }
+
+  if (value && typeof value === 'object') {
+    const entries = Object.keys(value)
+      .sort()
+      .map(key => `${JSON.stringify(key)}:${toStableString(value[key])}`);
+    return `{${entries.join(',')}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
+export function getCalendarDataSignature(events = []) {
+  return events
+    .map(event => {
+      const { entityId, color, ...eventData } = event;
+      return toStableString(eventData);
+    })
+    .sort()
+    .join('|');
+}
+
+export function isDateRangeCoveredByLoadedEvents(loadedEventRange, targetStartDate, targetEndDate) {
+  if (!loadedEventRange) return false;
+
+  return targetStartDate >= loadedEventRange.startDate &&
+         targetEndDate <= loadedEventRange.endDate;
+}
+
+export function shouldRefreshEvents({ lastFetch, now = Date.now(), maxAge = 60000 } = {}) {
+  return !lastFetch || (now - lastFetch > maxAge);
+}

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -168,6 +168,18 @@ import {
   shouldShowEventLocation as shouldShowEventLocationHelper,
   shouldShowEventTime as shouldShowEventTimeHelper
 } from './events/event-display.js';
+import {
+  fetchEventsByCalendarInRange as fetchEventsByCalendarInRangeHelper,
+  fetchEventsForCalendar as fetchEventsForCalendarHelper,
+  fetchEventsForChunk as fetchEventsForChunkHelper,
+  fetchEventsViaWebSocket as fetchEventsViaWebSocketHelper,
+  getCalendarDataSignature as getCalendarDataSignatureHelper,
+  isDateRangeCoveredByLoadedEvents as isDateRangeCoveredByLoadedEventsHelper,
+  mergeEvents as mergeEventsHelper,
+  shouldRefreshEvents as shouldRefreshEventsHelper,
+  sortEventsByStartDate as sortEventsByStartDateHelper,
+  toStableString as toStableStringHelper
+} from './events/event-fetcher.js';
 import { getMonthVisibleDateRange } from './views/month-view-model.js';
 import {
   getRollingDaysForView as getRollingDaysForViewModel,
@@ -1627,17 +1639,17 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   async fetchEventsByCalendarInRange(startDate, endDate) {
-    const chunks = this.getDateRangeChunks(startDate, endDate, 30);
-    const eventsByCalendar = await Promise.all(
-      this._config.entities.map((entityId, index) =>
-        this.fetchEventsForCalendar(entityId, index, chunks)
-      )
-    );
-
-    return this._config.entities.reduce((acc, entityId, index) => {
-      acc[entityId] = eventsByCalendar[index] || [];
-      return acc;
-    }, {});
+    return fetchEventsByCalendarInRangeHelper({
+      hass: this._hass,
+      entities: this._config.entities,
+      startDate,
+      endDate,
+      getDateRangeChunks: this.getDateRangeChunks.bind(this),
+      formatLocalDate: this.formatLocalDate.bind(this),
+      getCalendarColor: this.getCalendarColor.bind(this),
+      getEventIdentityKey: this.getEventIdentityKey.bind(this),
+      normalizeCalendarEvent
+    });
   }
 
   getCalendarColor(entityId, index = 0) {
@@ -1649,100 +1661,49 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   async fetchEventsForCalendar(entityId, colorIndex, chunks) {
-    const seen = new Set();
-    const color = this.getCalendarColor(entityId, colorIndex);
-
-    const chunkEventLists = await Promise.all(
-      chunks.map(chunk => this.fetchEventsForChunk(entityId, chunk))
-    );
-
-    const mergedEvents = [];
-    chunkEventLists.forEach(events => {
-      if (!events || !Array.isArray(events)) return;
-
-      events.forEach(event => {
-        const key = this.getEventIdentityKey(entityId, event);
-        if (seen.has(key)) return;
-        seen.add(key);
-
-        mergedEvents.push(normalizeCalendarEvent(event, { entityId, color }));
-      });
+    return fetchEventsForCalendarHelper({
+      hass: this._hass,
+      entityId,
+      colorIndex,
+      chunks,
+      formatLocalDate: this.formatLocalDate.bind(this),
+      getCalendarColor: this.getCalendarColor.bind(this),
+      getEventIdentityKey: this.getEventIdentityKey.bind(this),
+      normalizeCalendarEvent
     });
-
-    return mergedEvents;
   }
 
   async fetchEventsForChunk(entityId, chunk) {
-    const chunkStartStr = chunk.startDate.toISOString();
-    const chunkEndStr = chunk.endDate.toISOString();
-
-    try {
-      // Use WebSocket API to get calendar events.
-      // Home Assistant command name varies by version.
-      return await this.fetchEventsViaWebSocket(entityId, chunkStartStr, chunkEndStr);
-    } catch (error) {
-      // WebSocket API might not be available in older HA versions or for some integrations
-      // Try REST API fallback without logging (this is expected)
-      try {
-        const startDateOnly = this.formatLocalDate(chunk.startDate);
-        const endDateOnly = this.formatLocalDate(chunk.endDate);
-        return await this._hass.callApi('GET', `calendars/${entityId}?start=${startDateOnly}T00:00:00Z&end=${endDateOnly}T23:59:59Z`);
-      } catch (error2) {
-        // Both methods failed - this is a real error
-        console.error(`Failed to fetch events for ${entityId}:`, error2.message || error2);
-        return [];
-      }
-    }
+    return fetchEventsForChunkHelper({
+      hass: this._hass,
+      entityId,
+      chunk,
+      formatLocalDate: this.formatLocalDate.bind(this)
+    });
   }
 
   async fetchEventsViaWebSocket(entityId, chunkStartStr, chunkEndStr) {
-    return this._hass.callWS({
-      type: 'calendar/events',
-      entity_id: entityId,
-      start_date_time: chunkStartStr,
-      end_date_time: chunkEndStr
+    return fetchEventsViaWebSocketHelper({
+      hass: this._hass,
+      entityId,
+      chunkStartStr,
+      chunkEndStr
     });
   }
 
   mergeEvents(existingEvents, incomingEvents) {
-    const mergedByKey = new Map();
-
-    existingEvents.forEach(event => {
-      mergedByKey.set(this.getEventIdentityKey(event.entityId, event), event);
+    return mergeEventsHelper(existingEvents, incomingEvents, {
+      getEventIdentityKey: this.getEventIdentityKey.bind(this),
+      getEventStartDate: this.getEventStartDate.bind(this)
     });
-
-    incomingEvents.forEach(event => {
-      mergedByKey.set(this.getEventIdentityKey(event.entityId, event), event);
-    });
-
-    const merged = Array.from(mergedByKey.values());
-    merged.sort((a, b) => this.getEventStartDate(a) - this.getEventStartDate(b));
-    return merged;
   }
 
   toStableString(value) {
-    if (Array.isArray(value)) {
-      return `[${value.map(item => this.toStableString(item)).join(',')}]`;
-    }
-
-    if (value && typeof value === 'object') {
-      const entries = Object.keys(value)
-        .sort()
-        .map(key => `${JSON.stringify(key)}:${this.toStableString(value[key])}`);
-      return `{${entries.join(',')}}`;
-    }
-
-    return JSON.stringify(value);
+    return toStableStringHelper(value);
   }
 
   getCalendarDataSignature(events = []) {
-    return events
-      .map(event => {
-        const { entityId, color, ...eventData } = event;
-        return this.toStableString(eventData);
-      })
-      .sort()
-      .join('|');
+    return getCalendarDataSignatureHelper(events);
   }
 
   async updateEvents({ preserveScroll = false } = {}) {
@@ -1788,9 +1749,9 @@ class SkylightCalendarCard extends HTMLElement {
         this._calendarDataSignatures[entityId] = this.getCalendarDataSignature(newEventsByCalendar[entityId]);
       });
 
-      const mergedEvents = Object.values(newEventsByCalendar)
-        .flat()
-        .sort((a, b) => this.getEventStartDate(a) - this.getEventStartDate(b));
+      const mergedEvents = sortEventsByStartDateHelper(Object.values(newEventsByCalendar).flat(), {
+        getEventStartDate: this.getEventStartDate.bind(this)
+      });
 
       this._events = mergedEvents;
       this._loadedEventRange = { startDate, endDate };
@@ -1823,14 +1784,11 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   isDateRangeCoveredByLoadedEvents(targetStartDate, targetEndDate) {
-    if (!this._loadedEventRange) return false;
-
-    return targetStartDate >= this._loadedEventRange.startDate &&
-           targetEndDate <= this._loadedEventRange.endDate;
+    return isDateRangeCoveredByLoadedEventsHelper(this._loadedEventRange, targetStartDate, targetEndDate);
   }
 
   async ensureEventsForCurrentRange({ force = false, renderIfCovered = false } = {}) {
-    const shouldRefreshForAge = !this._lastFetch || (Date.now() - this._lastFetch > 60000);
+    const shouldRefreshForAge = shouldRefreshEventsHelper({ lastFetch: this._lastFetch });
     const { startDate: visibleStartDate, endDate: visibleEndDate } = this.getVisibleDateRange();
 
     // Background stale refreshes run through this path via hass updates.


### PR DESCRIPTION
### Motivation
- Continue Phase 32 of the modularization effort by removing low-level calendar event fetch and cache orchestration from the main card to improve separation of concerns.
- Move pure/service-like helpers (date chunking orchestration, per-calendar chunk fetch, WS/REST fetch, merging/sorting, stable signatures, coverage and stale-refresh checks) out of `src/skylight-calendar-card.js` while preserving runtime and visual behavior.
- Keep card-owned lifecycle, state mutation, render timing, scroll preservation, and modal/open-refresh guards in the main card so instance-level behavior remains explicit and unchanged.

### Description
- Added `src/events/event-fetcher.js` exporting: `fetchEventsByCalendarInRange`, `fetchEventsForCalendar`, `fetchEventsForChunk`, `fetchEventsViaWebSocket`, `mergeEvents`, `sortEventsByStartDate`, `toStableString`, `getCalendarDataSignature`, `isDateRangeCoveredByLoadedEvents`, and `shouldRefreshEvents`.
- Replaced the moved implementations in `src/skylight-calendar-card.js` with small delegating calls to the new helpers while binding only the explicit inputs/callbacks the helpers require (e.g., `this._hass`, `this._config.entities`, `this.getDateRangeChunks`, `this.formatLocalDate`, `this.getCalendarColor`, `this.getEventIdentityKey`, `normalizeCalendarEvent`, and `this.getEventStartDate`).
- Left card-owned state mutations and instance behavior in place, including `_fetching`, `_lastFetch`, `_loadedEventRange`, `_events`, `_calendarDataSignatures`, render and `renderPreservingAgendaScroll` calls, modal-open refresh guard, and lifecycle/DOM/service orchestration.
- Added unit tests that directly exercise the extracted pure and network helpers and updated the test file to import from the new module; also updated the build so the root shipped artifact reflects the source changes.

### Testing
- Ran dependency install and build with `npm ci --no-audit --fund=false` and `npm run build`, and regenerated the root `skylight-calendar-card.js` artifact using Rollup without altering intended output.
- Performed syntax checks `node --check src/skylight-calendar-card.js`, `node --check src/events/event-fetcher.js`, and `node --check skylight-calendar-card.js`, all of which passed.
- Ran the unit test suite with `npm test` and the visual test suite with `npm run test:visual`, and all automated tests (unit and Playwright visual tests) passed.
- Verified behavior preservation: event fetch ranges, 30-day chunking, WebSocket payload shape, REST fallback URL shape, normalization, duplicate detection/replacement, sorting, stale-refresh timing, agenda scroll preservation, modal-open refresh guards, CSS, and DOM structure were not intentionally changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d347e871c8331a3f899d5ce785784)