### PR TITLE
Extract weather forecast orchestration into WeatherForecastController

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -7573,6 +7573,175 @@ function buildWeatherForecastRequestMessage(entityId, forecastType = 'daily') {
   };
 }
 
+const DEFAULT_RETRY_DELAY_MS = 5 * 60 * 1000;
+
+class WeatherForecastController {
+  constructor({
+    getHass,
+    getWeatherEntityId,
+    onForecastUpdated = () => {},
+    now = () => Date.now(),
+    requestForecast = null,
+    subscribeForecast = null,
+    retryDelayMs = DEFAULT_RETRY_DELAY_MS
+  } = {}) {
+    this.getHass = getHass || (() => null);
+    this.getWeatherEntityId = getWeatherEntityId || (() => null);
+    this.onForecastUpdated = onForecastUpdated;
+    this.now = now;
+    this.requestForecast = requestForecast;
+    this.subscribeForecast = subscribeForecast;
+    this.retryDelayMs = retryDelayMs;
+
+    this.forecastByEntity = new Map();
+    this.subscriptionEntityId = null;
+    this.unsubscribe = null;
+    this.subscriptionInFlight = null;
+    this.subscriptionInFlightEntityId = null;
+    this.subscriptionGeneration = 0;
+    this.refreshInFlight = false;
+    this.refreshRetryAtByEntity = new Map();
+  }
+
+  getActiveWeatherEntityId() {
+    const entityId = this.getWeatherEntityId();
+    return isWeatherEntityId(entityId) ? entityId : null;
+  }
+
+  handleConfigChanged(previousEntityId, nextEntityId) {
+    if (previousEntityId !== nextEntityId) {
+      this.teardownSubscription();
+      this.clearForecasts();
+      this.clearRetryTimes();
+    }
+  }
+
+  clearForecasts() {
+    this.forecastByEntity.clear();
+  }
+
+  clearRetryTimes() {
+    this.refreshRetryAtByEntity.clear();
+  }
+
+  getForecastForEntity(entityId) {
+    return this.forecastByEntity.get(entityId);
+  }
+
+  getRenderSignature(entityId) {
+    const forecast = this.getForecastForEntity(entityId);
+    return JSON.stringify(Array.isArray(forecast) ? forecast : null);
+  }
+
+  teardownSubscription() {
+    this.subscriptionGeneration += 1;
+    if (typeof this.unsubscribe === 'function') {
+      this.unsubscribe();
+    }
+    this.unsubscribe = null;
+    this.subscriptionEntityId = null;
+    this.subscriptionInFlight = null;
+    this.subscriptionInFlightEntityId = null;
+  }
+
+  async ensureSubscription() {
+    const entityId = this.getActiveWeatherEntityId();
+    if (!entityId) {
+      this.teardownSubscription();
+      return undefined;
+    }
+
+    const hass = this.getHass();
+    const subscribeForecast = this.subscribeForecast || hass?.connection?.subscribeMessage?.bind(hass.connection);
+    if (typeof subscribeForecast !== 'function') {
+      return undefined;
+    }
+
+    if (this.subscriptionEntityId === entityId && this.unsubscribe) {
+      return undefined;
+    }
+
+    if (this.subscriptionInFlight && this.subscriptionInFlightEntityId === entityId) {
+      return this.subscriptionInFlight;
+    }
+
+    this.teardownSubscription();
+    const subscriptionGeneration = this.subscriptionGeneration;
+    this.subscriptionInFlightEntityId = entityId;
+
+    const setupPromise = subscribeForecast(
+      (message) => {
+        const nextForecast = Array.isArray(message?.forecast) ? message.forecast : [];
+        this.forecastByEntity.set(entityId, nextForecast);
+        this.onForecastUpdated(entityId, nextForecast, { source: 'subscription' });
+      },
+      buildWeatherForecastSubscriptionMessage(entityId)
+    )
+      .then((unsubscribe) => {
+        const generationMatches = subscriptionGeneration === this.subscriptionGeneration;
+        const entityMatches = entityId === this.subscriptionInFlightEntityId;
+        if (!generationMatches || !entityMatches) {
+          if (typeof unsubscribe === 'function') {
+            unsubscribe();
+          }
+          return;
+        }
+
+        this.unsubscribe = unsubscribe;
+        this.subscriptionEntityId = entityId;
+      })
+      .catch(() => {
+        if (subscriptionGeneration === this.subscriptionGeneration) {
+          this.unsubscribe = null;
+          this.subscriptionEntityId = null;
+        }
+      })
+      .finally(() => {
+        if (subscriptionGeneration === this.subscriptionGeneration) {
+          this.subscriptionInFlight = null;
+          this.subscriptionInFlightEntityId = null;
+        }
+      });
+
+    this.subscriptionInFlight = setupPromise;
+    return setupPromise;
+  }
+
+  async refreshForecastData() {
+    const entityId = this.getActiveWeatherEntityId();
+    if (!entityId) return undefined;
+    const hass = this.getHass();
+    if (!hass || this.refreshInFlight) return undefined;
+    if (this.forecastByEntity.has(entityId)) return undefined;
+    const now = this.now();
+    const retryAt = this.refreshRetryAtByEntity.get(entityId) || 0;
+    if (retryAt > now) return undefined;
+
+    const requestForecast = this.requestForecast || ((message) => hass.callWS(message));
+    if (typeof requestForecast !== 'function') return undefined;
+
+    this.refreshInFlight = true;
+    try {
+      const wsResponse = await requestForecast(buildWeatherForecastRequestMessage(entityId));
+      const dailyForecast = wsResponse?.[entityId]?.forecast;
+      if (Array.isArray(dailyForecast)) {
+        this.forecastByEntity.set(entityId, dailyForecast);
+        this.refreshRetryAtByEntity.delete(entityId);
+        this.onForecastUpdated(entityId, dailyForecast, { source: 'refresh' });
+      }
+    } catch (error) {
+      this.refreshRetryAtByEntity.set(entityId, now + this.retryDelayMs);
+    } finally {
+      this.refreshInFlight = false;
+    }
+    return undefined;
+  }
+}
+
+function createWeatherForecastController(dependencies) {
+  return new WeatherForecastController(dependencies);
+}
+
 const resolveTimedEventRange = (startValue, endValue, fallbackDurationMs = 60 * 60 * 1000) => {
   const start = parsePossiblyLocalDateTime(startValue);
   if (!(start instanceof Date) || Number.isNaN(start.getTime())) {
@@ -9699,14 +9868,17 @@ class SkylightCalendarCard extends HTMLElement {
     this._combinedEditTargets = null;
     this._combinedDeleteTargets = null;
     this._pendingHeaderSensorRender = false;
-    this._weatherForecastByEntity = new Map();
-    this._weatherForecastSubscriptionEntityId = null;
-    this._weatherForecastUnsubscribe = null;
-    this._weatherForecastSubscriptionInFlight = null;
-    this._weatherForecastSubscriptionInFlightEntityId = null;
-    this._weatherForecastSubscriptionGeneration = 0;
-    this._weatherForecastRefreshInFlight = false;
-    this._weatherForecastRefreshRetryAtByEntity = new Map();
+    this._weatherForecastController = createWeatherForecastController({
+      getHass: () => this._hass,
+      getWeatherEntityId: () => this._config?.header_weather_sensor,
+      onForecastUpdated: () => {
+        if (!this.isEventManagementDialogOpen()) {
+          this.renderPreservingAgendaScroll();
+        } else {
+          this._pendingHeaderSensorRender = true;
+        }
+      }
+    });
     this._modalVisibilityObserver = null;
     this._monthMeasureRaf = null;
     this._monthMeasureRenderRaf = null;
@@ -10189,11 +10361,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._loadedEventRange = null;
     this._calendarDataSignatures = {};
     this._lastUnchangedDataRender = null;
-    if (previousHeaderWeatherSensor !== this._config.header_weather_sensor) {
-      this.teardownWeatherForecastSubscription();
-      this._weatherForecastByEntity.clear();
-      this._weatherForecastRefreshRetryAtByEntity.clear();
-    }
+    this._weatherForecastController.handleConfigChanged(previousHeaderWeatherSensor, this._config.header_weather_sensor);
     this.ensureWeatherForecastSubscription();
     this.setWeekStart();
     this.resetAgendaWindowToToday();
@@ -15792,111 +15960,15 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   teardownWeatherForecastSubscription() {
-    this._weatherForecastSubscriptionGeneration += 1;
-    if (typeof this._weatherForecastUnsubscribe === 'function') {
-      this._weatherForecastUnsubscribe();
-    }
-    this._weatherForecastUnsubscribe = null;
-    this._weatherForecastSubscriptionEntityId = null;
-    this._weatherForecastSubscriptionInFlight = null;
-    this._weatherForecastSubscriptionInFlightEntityId = null;
+    this._weatherForecastController.teardownSubscription();
   }
 
-  async ensureWeatherForecastSubscription() {
-    const entityId = this._config?.header_weather_sensor;
-    if (!isWeatherEntityId(entityId)) {
-      this.teardownWeatherForecastSubscription();
-      return;
-    }
-
-    if (!this._hass?.connection?.subscribeMessage) {
-      return;
-    }
-
-    if (this._weatherForecastSubscriptionEntityId === entityId && this._weatherForecastUnsubscribe) {
-      return;
-    }
-
-    if (this._weatherForecastSubscriptionInFlight && this._weatherForecastSubscriptionInFlightEntityId === entityId) {
-      return this._weatherForecastSubscriptionInFlight;
-    }
-
-    this.teardownWeatherForecastSubscription();
-    const subscriptionGeneration = this._weatherForecastSubscriptionGeneration;
-    this._weatherForecastSubscriptionInFlightEntityId = entityId;
-
-    const setupPromise = this._hass.connection.subscribeMessage(
-        (message) => {
-          const nextForecast = Array.isArray(message?.forecast) ? message.forecast : [];
-          this._weatherForecastByEntity.set(entityId, nextForecast);
-          if (!this.isEventManagementDialogOpen()) {
-            this.renderPreservingAgendaScroll();
-          } else {
-            this._pendingHeaderSensorRender = true;
-          }
-        },
-        buildWeatherForecastSubscriptionMessage(entityId)
-      )
-      .then((unsubscribe) => {
-        const generationMatches = subscriptionGeneration === this._weatherForecastSubscriptionGeneration;
-        const entityMatches = entityId === this._weatherForecastSubscriptionInFlightEntityId;
-        if (!generationMatches || !entityMatches) {
-          if (typeof unsubscribe === 'function') {
-            unsubscribe();
-          }
-          return;
-        }
-
-        this._weatherForecastUnsubscribe = unsubscribe;
-        this._weatherForecastSubscriptionEntityId = entityId;
-      })
-      .catch(() => {
-        if (subscriptionGeneration === this._weatherForecastSubscriptionGeneration) {
-          this._weatherForecastUnsubscribe = null;
-          this._weatherForecastSubscriptionEntityId = null;
-        }
-      })
-      .finally(() => {
-        if (subscriptionGeneration === this._weatherForecastSubscriptionGeneration) {
-          this._weatherForecastSubscriptionInFlight = null;
-          this._weatherForecastSubscriptionInFlightEntityId = null;
-        }
-      });
-
-    this._weatherForecastSubscriptionInFlight = setupPromise;
-    return setupPromise;
+  ensureWeatherForecastSubscription() {
+    return this._weatherForecastController.ensureSubscription();
   }
 
-  async refreshWeatherForecastData() {
-    const entityId = this._config?.header_weather_sensor;
-    if (!isWeatherEntityId(entityId)) return;
-    if (!this._hass || this._weatherForecastRefreshInFlight) return;
-    if (this._weatherForecastByEntity.has(entityId)) return;
-    const now = Date.now();
-    const retryAt = this._weatherForecastRefreshRetryAtByEntity.get(entityId) || 0;
-    if (retryAt > now) return;
-
-    this._weatherForecastRefreshInFlight = true;
-    try {
-      const wsResponse = await this._hass.callWS(buildWeatherForecastRequestMessage(entityId));
-
-      const dailyForecast = wsResponse?.[entityId]?.forecast;
-      if (Array.isArray(dailyForecast)) {
-        this._weatherForecastByEntity.set(entityId, dailyForecast);
-        this._weatherForecastRefreshRetryAtByEntity.delete(entityId);
-        if (!this.isEventManagementDialogOpen()) {
-          this.renderPreservingAgendaScroll();
-        } else {
-          this._pendingHeaderSensorRender = true;
-        }
-      }
-    } catch (error) {
-      // forecast websocket may be unavailable in older HA versions; keep graceful fallback paths
-      const retryDelayMs = 5 * 60 * 1000;
-      this._weatherForecastRefreshRetryAtByEntity.set(entityId, now + retryDelayMs);
-    } finally {
-      this._weatherForecastRefreshInFlight = false;
-    }
+  refreshWeatherForecastData() {
+    return this._weatherForecastController.refreshForecastData();
   }
 
   getHeaderEntityRenderSignature(entityState) {
@@ -15938,7 +16010,7 @@ class SkylightCalendarCard extends HTMLElement {
     const sensorEntityId = this._config?.header_weather_sensor;
     if (!sensorEntityId) return null;
     const weatherEntity = this._hass?.states?.[sensorEntityId];
-    const wsForecast = this._weatherForecastByEntity.get(sensorEntityId);
+    const wsForecast = this._weatherForecastController.getForecastForEntity(sensorEntityId);
     const forecasts = getWeatherEntityForecast(weatherEntity, wsForecast);
     return normalizeForecastForDate(forecasts, date, (forecastDate) => this.getDateKey(forecastDate));
   }

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -4786,3 +4786,152 @@ test('event fetcher normalizes with calendar colors and de-duplicates chunk over
     { entityId: 'calendar.work', color: 'calendar.work:3:color' }
   ]);
 });
+
+test('weather controller ignores missing hass, missing/non-weather entities, and caches forecast by entity', async () => {
+  const { createWeatherForecastController } = await import('./src/weather/weather-controller.js');
+  let entityId = 'sensor.outdoor';
+  let requestCount = 0;
+  let subscribeCount = 0;
+  const controller = createWeatherForecastController({
+    getHass: () => null,
+    getWeatherEntityId: () => entityId,
+    requestForecast: async () => { requestCount += 1; },
+    subscribeForecast: async () => { subscribeCount += 1; return () => {}; }
+  });
+
+  await controller.ensureSubscription();
+  await controller.refreshForecastData();
+  assert.equal(subscribeCount, 0);
+  assert.equal(requestCount, 0);
+
+  entityId = null;
+  await controller.ensureSubscription();
+  await controller.refreshForecastData();
+  assert.equal(controller.getForecastForEntity('weather.home'), undefined);
+});
+
+test('weather controller subscribes with weather payload and avoids duplicate in-flight subscriptions', async () => {
+  const { createWeatherForecastController } = await import('./src/weather/weather-controller.js');
+  let resolveSubscription;
+  let callback;
+  const messages = [];
+  let updated = null;
+  const unsubscribe = () => { unsubscribe.called = true; };
+  const controller = createWeatherForecastController({
+    getHass: () => ({ connection: {} }),
+    getWeatherEntityId: () => 'weather.home',
+    subscribeForecast: (nextCallback, message) => {
+      callback = nextCallback;
+      messages.push(message);
+      return new Promise((resolve) => { resolveSubscription = () => resolve(unsubscribe); });
+    },
+    onForecastUpdated: (entityId, forecast, details) => { updated = { entityId, forecast, details }; }
+  });
+
+  const first = controller.ensureSubscription();
+  const second = controller.ensureSubscription();
+  assert.equal(messages.length, 1);
+  assert.deepEqual(messages[0], {
+    type: 'weather/subscribe_forecast',
+    entity_id: 'weather.home',
+    forecast_type: 'daily'
+  });
+
+  callback({ forecast: [{ datetime: '2026-06-25', condition: 'sunny' }] });
+  assert.deepEqual(controller.getForecastForEntity('weather.home'), [{ datetime: '2026-06-25', condition: 'sunny' }]);
+  assert.deepEqual(updated, {
+    entityId: 'weather.home',
+    forecast: [{ datetime: '2026-06-25', condition: 'sunny' }],
+    details: { source: 'subscription' }
+  });
+
+  resolveSubscription();
+  await first;
+  await controller.ensureSubscription();
+  assert.equal(messages.length, 1);
+});
+
+test('weather controller refreshes with forecast payload, prevents duplicates, and caches successes', async () => {
+  const { createWeatherForecastController } = await import('./src/weather/weather-controller.js');
+  let resolveRequest;
+  const messages = [];
+  const updates = [];
+  const controller = createWeatherForecastController({
+    getHass: () => ({}),
+    getWeatherEntityId: () => 'weather.home',
+    requestForecast: (message) => {
+      messages.push(message);
+      return new Promise((resolve) => { resolveRequest = () => resolve({ weather: {}, 'weather.home': { forecast: [{ date: '2026-06-25' }] } }); });
+    },
+    onForecastUpdated: (entityId, forecast, details) => updates.push({ entityId, forecast, details })
+  });
+
+  const first = controller.refreshForecastData();
+  const second = controller.refreshForecastData();
+  assert.equal(messages.length, 1);
+  assert.deepEqual(messages[0], {
+    type: 'weather/get_forecasts',
+    entity_ids: ['weather.home'],
+    forecast_type: 'daily'
+  });
+  resolveRequest();
+  await first;
+  await second;
+
+  assert.deepEqual(controller.getForecastForEntity('weather.home'), [{ date: '2026-06-25' }]);
+  assert.deepEqual(updates, [{
+    entityId: 'weather.home',
+    forecast: [{ date: '2026-06-25' }],
+    details: { source: 'refresh' }
+  }]);
+  await controller.refreshForecastData();
+  assert.equal(messages.length, 1);
+});
+
+test('weather controller records retry timing after failed refresh and suppresses until retry time', async () => {
+  const { createWeatherForecastController } = await import('./src/weather/weather-controller.js');
+  let now = 1000;
+  let requestCount = 0;
+  const controller = createWeatherForecastController({
+    getHass: () => ({}),
+    getWeatherEntityId: () => 'weather.home',
+    now: () => now,
+    retryDelayMs: 300000,
+    requestForecast: async () => {
+      requestCount += 1;
+      if (requestCount === 1) throw new Error('no forecasts');
+      return { 'weather.home': { forecast: [{ date: '2026-06-26' }] } };
+    }
+  });
+
+  await controller.refreshForecastData();
+  assert.equal(controller.refreshRetryAtByEntity.get('weather.home'), 301000);
+  await controller.refreshForecastData();
+  assert.equal(requestCount, 1);
+  now = 301001;
+  await controller.refreshForecastData();
+  assert.equal(requestCount, 2);
+  assert.equal(controller.refreshRetryAtByEntity.has('weather.home'), false);
+});
+
+test('weather controller config changes tear down subscription and clear forecasts and retries', async () => {
+  const { createWeatherForecastController } = await import('./src/weather/weather-controller.js');
+  let entityId = 'weather.home';
+  let unsubscribeCount = 0;
+  const controller = createWeatherForecastController({
+    getHass: () => ({ connection: {} }),
+    getWeatherEntityId: () => entityId,
+    subscribeForecast: async () => () => { unsubscribeCount += 1; }
+  });
+
+  await controller.ensureSubscription();
+  controller.forecastByEntity.set('weather.home', [{ date: '2026-06-25' }]);
+  controller.refreshRetryAtByEntity.set('weather.home', 1234);
+  entityId = 'weather.garden';
+  controller.handleConfigChanged('weather.home', 'weather.garden');
+
+  assert.equal(unsubscribeCount, 1);
+  assert.equal(controller.subscriptionEntityId, null);
+  assert.equal(controller.getForecastForEntity('weather.home'), undefined);
+  assert.equal(controller.refreshRetryAtByEntity.size, 0);
+});

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -137,11 +137,7 @@ import {
   getPersonEntityPictureUrl as getPersonEntityPictureUrlHelper,
   getPersonStateLabel as getPersonStateLabelHelper
 } from './ha/ha-state-helpers.js';
-import {
-  buildWeatherForecastRequestMessage,
-  buildWeatherForecastSubscriptionMessage,
-  isWeatherEntityId
-} from './weather/weather-service.js';
+import { createWeatherForecastController } from './weather/weather-controller.js';
 import {
   buildRRuleFromInputs as buildRRuleFromInputsHelper,
   normalizeEventFormData,
@@ -324,14 +320,17 @@ class SkylightCalendarCard extends HTMLElement {
     this._combinedEditTargets = null;
     this._combinedDeleteTargets = null;
     this._pendingHeaderSensorRender = false;
-    this._weatherForecastByEntity = new Map();
-    this._weatherForecastSubscriptionEntityId = null;
-    this._weatherForecastUnsubscribe = null;
-    this._weatherForecastSubscriptionInFlight = null;
-    this._weatherForecastSubscriptionInFlightEntityId = null;
-    this._weatherForecastSubscriptionGeneration = 0;
-    this._weatherForecastRefreshInFlight = false;
-    this._weatherForecastRefreshRetryAtByEntity = new Map();
+    this._weatherForecastController = createWeatherForecastController({
+      getHass: () => this._hass,
+      getWeatherEntityId: () => this._config?.header_weather_sensor,
+      onForecastUpdated: () => {
+        if (!this.isEventManagementDialogOpen()) {
+          this.renderPreservingAgendaScroll();
+        } else {
+          this._pendingHeaderSensorRender = true;
+        }
+      }
+    });
     this._modalVisibilityObserver = null;
     this._monthMeasureRaf = null;
     this._monthMeasureRenderRaf = null;
@@ -814,11 +813,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._loadedEventRange = null;
     this._calendarDataSignatures = {};
     this._lastUnchangedDataRender = null;
-    if (previousHeaderWeatherSensor !== this._config.header_weather_sensor) {
-      this.teardownWeatherForecastSubscription();
-      this._weatherForecastByEntity.clear();
-      this._weatherForecastRefreshRetryAtByEntity.clear();
-    }
+    this._weatherForecastController.handleConfigChanged(previousHeaderWeatherSensor, this._config.header_weather_sensor);
     this.ensureWeatherForecastSubscription();
     this.setWeekStart();
     this.resetAgendaWindowToToday();
@@ -6417,111 +6412,15 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   teardownWeatherForecastSubscription() {
-    this._weatherForecastSubscriptionGeneration += 1;
-    if (typeof this._weatherForecastUnsubscribe === 'function') {
-      this._weatherForecastUnsubscribe();
-    }
-    this._weatherForecastUnsubscribe = null;
-    this._weatherForecastSubscriptionEntityId = null;
-    this._weatherForecastSubscriptionInFlight = null;
-    this._weatherForecastSubscriptionInFlightEntityId = null;
+    this._weatherForecastController.teardownSubscription();
   }
 
-  async ensureWeatherForecastSubscription() {
-    const entityId = this._config?.header_weather_sensor;
-    if (!isWeatherEntityId(entityId)) {
-      this.teardownWeatherForecastSubscription();
-      return;
-    }
-
-    if (!this._hass?.connection?.subscribeMessage) {
-      return;
-    }
-
-    if (this._weatherForecastSubscriptionEntityId === entityId && this._weatherForecastUnsubscribe) {
-      return;
-    }
-
-    if (this._weatherForecastSubscriptionInFlight && this._weatherForecastSubscriptionInFlightEntityId === entityId) {
-      return this._weatherForecastSubscriptionInFlight;
-    }
-
-    this.teardownWeatherForecastSubscription();
-    const subscriptionGeneration = this._weatherForecastSubscriptionGeneration;
-    this._weatherForecastSubscriptionInFlightEntityId = entityId;
-
-    const setupPromise = this._hass.connection.subscribeMessage(
-        (message) => {
-          const nextForecast = Array.isArray(message?.forecast) ? message.forecast : [];
-          this._weatherForecastByEntity.set(entityId, nextForecast);
-          if (!this.isEventManagementDialogOpen()) {
-            this.renderPreservingAgendaScroll();
-          } else {
-            this._pendingHeaderSensorRender = true;
-          }
-        },
-        buildWeatherForecastSubscriptionMessage(entityId)
-      )
-      .then((unsubscribe) => {
-        const generationMatches = subscriptionGeneration === this._weatherForecastSubscriptionGeneration;
-        const entityMatches = entityId === this._weatherForecastSubscriptionInFlightEntityId;
-        if (!generationMatches || !entityMatches) {
-          if (typeof unsubscribe === 'function') {
-            unsubscribe();
-          }
-          return;
-        }
-
-        this._weatherForecastUnsubscribe = unsubscribe;
-        this._weatherForecastSubscriptionEntityId = entityId;
-      })
-      .catch(() => {
-        if (subscriptionGeneration === this._weatherForecastSubscriptionGeneration) {
-          this._weatherForecastUnsubscribe = null;
-          this._weatherForecastSubscriptionEntityId = null;
-        }
-      })
-      .finally(() => {
-        if (subscriptionGeneration === this._weatherForecastSubscriptionGeneration) {
-          this._weatherForecastSubscriptionInFlight = null;
-          this._weatherForecastSubscriptionInFlightEntityId = null;
-        }
-      });
-
-    this._weatherForecastSubscriptionInFlight = setupPromise;
-    return setupPromise;
+  ensureWeatherForecastSubscription() {
+    return this._weatherForecastController.ensureSubscription();
   }
 
-  async refreshWeatherForecastData() {
-    const entityId = this._config?.header_weather_sensor;
-    if (!isWeatherEntityId(entityId)) return;
-    if (!this._hass || this._weatherForecastRefreshInFlight) return;
-    if (this._weatherForecastByEntity.has(entityId)) return;
-    const now = Date.now();
-    const retryAt = this._weatherForecastRefreshRetryAtByEntity.get(entityId) || 0;
-    if (retryAt > now) return;
-
-    this._weatherForecastRefreshInFlight = true;
-    try {
-      const wsResponse = await this._hass.callWS(buildWeatherForecastRequestMessage(entityId));
-
-      const dailyForecast = wsResponse?.[entityId]?.forecast;
-      if (Array.isArray(dailyForecast)) {
-        this._weatherForecastByEntity.set(entityId, dailyForecast);
-        this._weatherForecastRefreshRetryAtByEntity.delete(entityId);
-        if (!this.isEventManagementDialogOpen()) {
-          this.renderPreservingAgendaScroll();
-        } else {
-          this._pendingHeaderSensorRender = true;
-        }
-      }
-    } catch (error) {
-      // forecast websocket may be unavailable in older HA versions; keep graceful fallback paths
-      const retryDelayMs = 5 * 60 * 1000;
-      this._weatherForecastRefreshRetryAtByEntity.set(entityId, now + retryDelayMs);
-    } finally {
-      this._weatherForecastRefreshInFlight = false;
-    }
+  refreshWeatherForecastData() {
+    return this._weatherForecastController.refreshForecastData();
   }
 
   getHeaderEntityRenderSignature(entityState) {
@@ -6563,7 +6462,7 @@ class SkylightCalendarCard extends HTMLElement {
     const sensorEntityId = this._config?.header_weather_sensor;
     if (!sensorEntityId) return null;
     const weatherEntity = this._hass?.states?.[sensorEntityId];
-    const wsForecast = this._weatherForecastByEntity.get(sensorEntityId);
+    const wsForecast = this._weatherForecastController.getForecastForEntity(sensorEntityId);
     const forecasts = getWeatherEntityForecast(weatherEntity, wsForecast);
     return normalizeForecastForDate(forecasts, date, (forecastDate) => this.getDateKey(forecastDate));
   }

--- a/src/weather/weather-controller.js
+++ b/src/weather/weather-controller.js
@@ -1,0 +1,174 @@
+import {
+  buildWeatherForecastRequestMessage,
+  buildWeatherForecastSubscriptionMessage,
+  isWeatherEntityId
+} from './weather-service.js';
+
+const DEFAULT_RETRY_DELAY_MS = 5 * 60 * 1000;
+
+export class WeatherForecastController {
+  constructor({
+    getHass,
+    getWeatherEntityId,
+    onForecastUpdated = () => {},
+    now = () => Date.now(),
+    requestForecast = null,
+    subscribeForecast = null,
+    retryDelayMs = DEFAULT_RETRY_DELAY_MS
+  } = {}) {
+    this.getHass = getHass || (() => null);
+    this.getWeatherEntityId = getWeatherEntityId || (() => null);
+    this.onForecastUpdated = onForecastUpdated;
+    this.now = now;
+    this.requestForecast = requestForecast;
+    this.subscribeForecast = subscribeForecast;
+    this.retryDelayMs = retryDelayMs;
+
+    this.forecastByEntity = new Map();
+    this.subscriptionEntityId = null;
+    this.unsubscribe = null;
+    this.subscriptionInFlight = null;
+    this.subscriptionInFlightEntityId = null;
+    this.subscriptionGeneration = 0;
+    this.refreshInFlight = false;
+    this.refreshRetryAtByEntity = new Map();
+  }
+
+  getActiveWeatherEntityId() {
+    const entityId = this.getWeatherEntityId();
+    return isWeatherEntityId(entityId) ? entityId : null;
+  }
+
+  handleConfigChanged(previousEntityId, nextEntityId) {
+    if (previousEntityId !== nextEntityId) {
+      this.teardownSubscription();
+      this.clearForecasts();
+      this.clearRetryTimes();
+    }
+  }
+
+  clearForecasts() {
+    this.forecastByEntity.clear();
+  }
+
+  clearRetryTimes() {
+    this.refreshRetryAtByEntity.clear();
+  }
+
+  getForecastForEntity(entityId) {
+    return this.forecastByEntity.get(entityId);
+  }
+
+  getRenderSignature(entityId) {
+    const forecast = this.getForecastForEntity(entityId);
+    return JSON.stringify(Array.isArray(forecast) ? forecast : null);
+  }
+
+  teardownSubscription() {
+    this.subscriptionGeneration += 1;
+    if (typeof this.unsubscribe === 'function') {
+      this.unsubscribe();
+    }
+    this.unsubscribe = null;
+    this.subscriptionEntityId = null;
+    this.subscriptionInFlight = null;
+    this.subscriptionInFlightEntityId = null;
+  }
+
+  async ensureSubscription() {
+    const entityId = this.getActiveWeatherEntityId();
+    if (!entityId) {
+      this.teardownSubscription();
+      return undefined;
+    }
+
+    const hass = this.getHass();
+    const subscribeForecast = this.subscribeForecast || hass?.connection?.subscribeMessage?.bind(hass.connection);
+    if (typeof subscribeForecast !== 'function') {
+      return undefined;
+    }
+
+    if (this.subscriptionEntityId === entityId && this.unsubscribe) {
+      return undefined;
+    }
+
+    if (this.subscriptionInFlight && this.subscriptionInFlightEntityId === entityId) {
+      return this.subscriptionInFlight;
+    }
+
+    this.teardownSubscription();
+    const subscriptionGeneration = this.subscriptionGeneration;
+    this.subscriptionInFlightEntityId = entityId;
+
+    const setupPromise = subscribeForecast(
+      (message) => {
+        const nextForecast = Array.isArray(message?.forecast) ? message.forecast : [];
+        this.forecastByEntity.set(entityId, nextForecast);
+        this.onForecastUpdated(entityId, nextForecast, { source: 'subscription' });
+      },
+      buildWeatherForecastSubscriptionMessage(entityId)
+    )
+      .then((unsubscribe) => {
+        const generationMatches = subscriptionGeneration === this.subscriptionGeneration;
+        const entityMatches = entityId === this.subscriptionInFlightEntityId;
+        if (!generationMatches || !entityMatches) {
+          if (typeof unsubscribe === 'function') {
+            unsubscribe();
+          }
+          return;
+        }
+
+        this.unsubscribe = unsubscribe;
+        this.subscriptionEntityId = entityId;
+      })
+      .catch(() => {
+        if (subscriptionGeneration === this.subscriptionGeneration) {
+          this.unsubscribe = null;
+          this.subscriptionEntityId = null;
+        }
+      })
+      .finally(() => {
+        if (subscriptionGeneration === this.subscriptionGeneration) {
+          this.subscriptionInFlight = null;
+          this.subscriptionInFlightEntityId = null;
+        }
+      });
+
+    this.subscriptionInFlight = setupPromise;
+    return setupPromise;
+  }
+
+  async refreshForecastData() {
+    const entityId = this.getActiveWeatherEntityId();
+    if (!entityId) return undefined;
+    const hass = this.getHass();
+    if (!hass || this.refreshInFlight) return undefined;
+    if (this.forecastByEntity.has(entityId)) return undefined;
+    const now = this.now();
+    const retryAt = this.refreshRetryAtByEntity.get(entityId) || 0;
+    if (retryAt > now) return undefined;
+
+    const requestForecast = this.requestForecast || ((message) => hass.callWS(message));
+    if (typeof requestForecast !== 'function') return undefined;
+
+    this.refreshInFlight = true;
+    try {
+      const wsResponse = await requestForecast(buildWeatherForecastRequestMessage(entityId));
+      const dailyForecast = wsResponse?.[entityId]?.forecast;
+      if (Array.isArray(dailyForecast)) {
+        this.forecastByEntity.set(entityId, dailyForecast);
+        this.refreshRetryAtByEntity.delete(entityId);
+        this.onForecastUpdated(entityId, dailyForecast, { source: 'refresh' });
+      }
+    } catch (error) {
+      this.refreshRetryAtByEntity.set(entityId, now + this.retryDelayMs);
+    } finally {
+      this.refreshInFlight = false;
+    }
+    return undefined;
+  }
+}
+
+export function createWeatherForecastController(dependencies) {
+  return new WeatherForecastController(dependencies);
+}


### PR DESCRIPTION
### Motivation
- Reduce card instance surface area by moving weather forecast subscription, refresh, retry, and cache orchestration into a focused controller while preserving runtime and visual behavior.
- Improve testability and module boundaries by keeping only card lifecycle, rendering, DOM, and user-facing decisions inside `src/skylight-calendar-card.js`.
- Reuse existing `weather-service` and `weather-utils` helpers and avoid changing public behavior, payload shapes, or timing guarantees.

### Description
- Added a new controller `src/weather/weather-controller.js` (factory `createWeatherForecastController`) that owns forecast cache, active weather entity validation, subscription setup/teardown, in-flight/subscription-generation tracking, refresh-in-flight protection, retry timing, and one-shot refresh orchestration while delegating payload construction to `weather-service` helpers via injected dependencies.
- Updated `src/skylight-calendar-card.js` to construct the controller with narrow dependencies (`getHass`, `getWeatherEntityId`, `onForecastUpdated`, etc.) and replaced the card-local weather orchestration state/methods with small delegation wrappers: `teardownWeatherForecastSubscription()`, `ensureWeatherForecastSubscription()`, `refreshWeatherForecastData()`, and `getForecastForDate()` now read from the controller.
- Kept card-owned responsibilities in place: the `hass` setter, `setConfig()`, lifecycle, final `render()` and `renderPreservingAgendaScroll()` decisions, modal-open header render gating, header sensor render signatures, DOM measurements, event fetching, modal behavior, and all renderer/DOM structure remain unchanged.
- Added focused unit tests in `skylight-calendar-card.test.js` covering controller behavior for missing `hass`, missing/non-weather entities, subscription request payload usage, refresh request payload usage, duplicate/in-flight subscription prevention, refresh-in-flight suppression, retry timing behavior on failure, successful cache updates, teardown/unsubscribe behavior, and forecast getter cache lookup.

### Testing
- Ran `npm ci --no-audit --fund=false` successfully to install dependencies.
- Built the bundle with `npm run build` successfully and verified the root artifact `skylight-calendar-card.js` was regenerated and included with the source changes in this PR.
- Performed syntax checks with `node --check src/skylight-calendar-card.js`, `node --check src/weather/weather-controller.js`, and `node --check skylight-calendar-card.js`, all of which passed.
- Ran unit tests with `npm test`; all tests (including the new weather controller tests) passed.
- Ran visual tests with `npm run test:visual`; all Playwright visual tests passed and no intentional visual snapshot differences were observed.

Notes: Forecast request and subscription payload shapes, retry timing, forecast cache keys/normalization, render timing, header weather display output, CSS, DOM structure, classes, IDs, data attributes, translations, and public config names were not intentionally changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d52f05c9c8331afb7acce3cf5cf2f)