### PR TITLE
Document Phase-33 modularization and align main entry imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,34 +29,44 @@ The project was formerly named Skylight Calendar Card. The public name is now Da
 
 ## Module boundaries
 
-Current modules are organized around these boundaries. Future modules may be added, but new modules should preserve the same separation principles and keep card-instance orchestration separate from pure/data-only helpers.
+The broad modularization refactor is complete through the post-Phase-33 cleanup checkpoint. Current modules are organized around these boundaries. Future modules may be added, but new extractions should be tied to real feature or bug work and should preserve the same separation principles: keep card-instance orchestration in the main custom element, and keep extracted modules explicit, focused, and independent from card instance state.
 
-* `src/skylight-calendar-card.js`: main custom element, lifecycle, Home Assistant orchestration, view composition, renderer callback wiring, DOM measurement, scroll restoration, modal/editor DOM behavior, preference persistence, service behavior, and event handlers.
+* `src/skylight-calendar-card.js`: Rollup entry point and main custom element. It intentionally owns custom element registration and lifecycle; config orchestration; preference persistence; Home Assistant `hass` setter behavior; capability checks; final event/weather refresh decisions; final render timing; view composition; renderer callback wiring; DOM reads/writes; ResizeObserver behavior; compact-height measurement; scroll restoration; modal behavior; event listeners; service behavior; and Daylight/legacy Skylight compatibility wrappers.
+* `src/version.js`: card version lookup helper. Do not update release/version behavior unless explicitly preparing a release.
 * `src/translations.js`: translation data.
 * `src/constants.js`: shared static constants.
 * `src/defaults.js`: default config values, option lists, aliases, and stub config creation.
-* `src/utils/`: pure utility helpers for dates, normalization, and strings.
+* `src/config/config-normalizers.js`: config normalization helpers for modes, colors, opacities, hidden calendars, and related public option values.
+* `src/utils/date-utils.js`: date parsing, local date formatting, range chunking, and ISO week helpers.
+* `src/utils/normalization-utils.js`: normalization helpers for enums, booleans, dashboard paths, and entity maps.
+* `src/utils/string-utils.js`: string and HTML-attribute escaping helpers.
+* `src/utils/color-utils.js`: color parsing, named-color handling, alpha blending, contrast, and color map normalization helpers.
+* `src/ha/ha-state-helpers.js`: Home Assistant entity state display helpers, render signatures, person labels/pictures, and header weather display data.
 * `src/events/event-normalizer.js`: Home Assistant calendar event normalization and combined-event data shaping.
-* `src/events/event-form.js`: event form validation and create/update data normalization.
-* `src/events/event-service.js`: Home Assistant calendar event service and WebSocket payload helpers.
 * `src/events/event-display.js`: non-rendering event display decisions and display metadata.
+* `src/events/event-fetcher.js`: calendar fetch/cache helpers, range coverage checks, stable signatures, merge/sort helpers, and WebSocket fetch orchestration helpers.
+* `src/events/event-form.js`: event form validation, recurrence helpers, and create/update data normalization.
+* `src/events/event-service.js`: Home Assistant calendar event service and WebSocket payload helpers.
 * `src/rules/condition-matcher.js`: condition and value matching helpers.
 * `src/rules/style-rules.js`: style rule normalization and matching helpers.
-* `src/badges/day-badges.js`: day badge normalization, matching, and display data helpers.
+* `src/badges/day-badges.js`: day badge normalization, matching, template resolution, and display data helpers.
 * `src/weather/weather-utils.js`: weather formatting, icon, temperature, and forecast utility helpers.
 * `src/weather/weather-service.js`: weather entity discovery and Home Assistant weather service payload helpers.
-* `src/editor/editor-schema.js`: editor default values, option metadata, and config normalization helpers.
+* `src/weather/weather-controller.js`: weather forecast controller helper for forecast cache/refresh state. The main card still owns final weather refresh decisions and render timing.
+* `src/editor/daylight-calendar-card-editor.js`: Daylight Calendar Card editor custom element registration and editor implementation.
+* `src/editor/editor-schema.js`: editor default values, option metadata, and config normalization schema helpers.
 * `src/views/month-view-model.js`: month-grid date and visible-range view-model helpers.
 * `src/views/week-view-model.js`: week and rolling-days view-model helpers.
-* `src/views/agenda-view-model.js`: agenda visible-range and rolling-days view-model helpers.
+* `src/views/agenda-view-model.js`: agenda window, visible-range, and rolling-days view-model helpers.
 * `src/calendars/calendar-entities.js`: calendar entity metadata, colors, names, virtual calendar badges, writable calendars, and person mappings.
 * `src/renderers/`: extracted markup renderers for header, month, day cells, week compact, week standard, agenda, shared events, modals/forms, editor controls, calendar badges, and day/weather helpers. Renderers receive explicit data and callbacks from the card.
 * `src/styles/card-styles.js`: static card CSS used by the main custom element.
 
 ## Modularization guardrails
 
+* The broad modularization refactor is complete; future extractions should be opportunistic and tied to real feature or bug work rather than extraction-only cleanup.
 * Prefer extracting pure/data-only logic before rendering or DOM logic.
-* Keep lifecycle methods, card-instance view composition, renderer callback wiring, DOM querying, modal behavior, editor behavior, preference persistence, ResizeObserver/compact-height behavior, and Home Assistant service orchestration in `src/skylight-calendar-card.js` unless a prompt explicitly asks to move that area.
+* Keep lifecycle methods, card-instance view composition, renderer callback wiring, DOM querying, modal behavior, event listener behavior, preference persistence, ResizeObserver/compact-height behavior, final render timing, final event/weather refresh decisions, capability checks, `hass` setter behavior, and Home Assistant service orchestration in `src/skylight-calendar-card.js` unless a prompt explicitly asks to move that area.
 * New modules should receive explicit inputs/helpers rather than importing or depending on card instance state.
 * Do not pass the whole card instance into helper modules unless explicitly justified.
 * Preserve public config option names, custom element names, CSS class names, DOM structure, and visual behavior.
@@ -65,7 +75,7 @@ Current modules are organized around these boundaries. Future modules may be add
 
 ## Working in `src/`
 
-Most source work should start in `src/`. `src/skylight-calendar-card.js` remains large and tightly coupled because it owns lifecycle, view composition, renderer callback wiring, DOM behavior, and orchestration. Before editing:
+Most source work should start in `src/`. `src/skylight-calendar-card.js` remains large and tightly coupled because it owns lifecycle, config orchestration, Home Assistant integration, final render timing, view composition, renderer callback wiring, DOM behavior, event listeners, preference persistence, modal behavior, and orchestration. Before editing:
 
 1. Find the existing feature area and existing module boundary.
 2. Reuse existing modules/helpers before adding new ones.

--- a/src/README.md
+++ b/src/README.md
@@ -4,30 +4,43 @@
 
 ## Main custom element
 
-`src/skylight-calendar-card.js` remains the Rollup entry point and main custom element source. After the renderer extractions through Phase 27, it still intentionally owns card-instance responsibilities that depend on live Home Assistant state, DOM state, browser APIs, or custom-element lifecycle:
+`src/skylight-calendar-card.js` remains the Rollup entry point and main card custom element source after the modularization work through Phase 33. It intentionally owns card-instance responsibilities that depend on live Home Assistant state, DOM state, browser APIs, render timing, or custom-element lifecycle:
 
-- custom element lifecycle and registration compatibility
-- config normalization orchestration and preference persistence
-- Home Assistant integration, service calls, capability checks, and event fetching
-- view composition and renderer callback wiring
-- DOM reads/writes, ResizeObserver handling, compact-height measurement, and scroll restoration
-- modal behavior and editor/card event handlers
-- compatibility wrapper methods that keep extracted renderers isolated from card internals
+- custom element registration and lifecycle, including Daylight and legacy Skylight compatibility;
+- config orchestration and compatibility with public config option names;
+- preference persistence;
+- Home Assistant `hass` setter behavior;
+- capability checks;
+- final event and weather refresh decisions;
+- final render timing;
+- DOM reads/writes;
+- ResizeObserver behavior;
+- compact-height measurement;
+- scroll restoration;
+- modal behavior;
+- event listeners;
+- renderer callback wiring.
 
-Do not move lifecycle, service orchestration, DOM structure, modal behavior, event handlers, or compatibility aliases unless a change is explicitly scoped to do that work.
+Do not move lifecycle, service orchestration, DOM structure, modal behavior, event listeners, renderer callback wiring, preference persistence, DOM measurement, or compatibility aliases unless a change is explicitly scoped to do that work. Further refactors should be opportunistic and tied to real feature or bug work, especially around modal flows, DOM measurement, event listeners, and preference persistence.
 
 ## Extracted module areas
 
-The current post-Phase 27 module layout keeps pure/data helpers and renderer markup helpers outside the main custom element while leaving card-instance orchestration in `src/skylight-calendar-card.js`:
+The current post-Phase 33 module layout keeps pure/data helpers, service helpers, controller-style helpers, renderer markup helpers, and static styles outside the main custom element while leaving card-instance orchestration in `src/skylight-calendar-card.js`.
 
-### Core data, defaults, and translations
+### Core data, defaults, version, and translations
 
 - `constants.js`: shared static constants used across source modules and the card.
 - `defaults.js`: default config values, option lists, config aliases, and stub config creation.
 - `translations.js`: translation strings and locale data.
+- `version.js`: version lookup helper used by the card without moving release/version ownership.
 
-### Utilities and view models
+### Config, editor, utilities, Home Assistant state, and view models
 
+- `config/config-normalizers.js`: config normalization helpers for modes, colors, opacities, hidden calendars, and related public option values.
+- `editor/daylight-calendar-card-editor.js`: Daylight Calendar Card editor custom element registration and editor element implementation.
+- `editor/editor-schema.js`: editor default values, option metadata, and config normalization schema helpers for the editor.
+- `ha/ha-state-helpers.js`: Home Assistant entity state display helpers, render signatures, person labels/pictures, and header weather display data.
+- `utils/color-utils.js`: color parsing, named-color handling, alpha blending, contrast, and color map normalization helpers.
 - `utils/date-utils.js`: date parsing, local date formatting, range chunking, and ISO week helpers.
 - `utils/normalization-utils.js`: small normalization helpers for enums, booleans, dashboard paths, and entity maps.
 - `utils/string-utils.js`: string and HTML-attribute escaping helpers.
@@ -39,15 +52,16 @@ The current post-Phase 27 module layout keeps pure/data helpers and renderer mar
 
 - `calendars/calendar-entities.js`: calendar entity metadata, colors, names, virtual calendar badges, writable calendars, and person mappings.
 - `events/event-normalizer.js`: Home Assistant calendar event normalization and combined-event data shaping.
+- `events/event-display.js`: non-rendering event display decisions, including time/location visibility, badge data, and schedule visual metadata.
+- `events/event-fetcher.js`: calendar fetch/cache helpers, range coverage checks, stable signatures, merge/sort helpers, and WebSocket fetch orchestration helpers.
 - `events/event-form.js`: event form validation, recurrence helpers, and create/update data normalization.
 - `events/event-service.js`: Home Assistant calendar event service and WebSocket payload helpers.
-- `events/event-display.js`: non-rendering event display decisions, including time/location visibility, badge data, and schedule visual metadata.
 - `rules/condition-matcher.js`: condition and value matching helpers for rule evaluation.
 - `rules/style-rules.js`: style rule normalization and matching helpers.
 - `badges/day-badges.js`: day badge normalization, matching, template resolution, and display data helpers.
+- `weather/weather-controller.js`: weather forecast controller helper that encapsulates forecast cache/refresh state while the card keeps final refresh decisions and render timing.
 - `weather/weather-utils.js`: weather formatting, icon, temperature, and forecast utility helpers.
 - `weather/weather-service.js`: weather entity discovery and Home Assistant weather service payload helpers.
-- `editor/editor-schema.js`: editor default values, option metadata, and config normalization helpers for the editor.
 
 ### Renderers and styles
 
@@ -62,26 +76,28 @@ Renderer modules return existing markup for specific card regions. They receive 
 - `renderers/event-renderer.js`: shared event bubble/icon/title/corner-bubble markup helpers.
 - `renderers/event-modal-renderer.js`: event detail modal markup.
 - `renderers/event-form-renderer.js`: create/edit event form modal markup.
-- `renderers/editor-renderer.js`: reusable editor section, color input, and weekday checkbox markup.
+- `renderers/editor-renderer.js`: reusable editor section, color input, and weekday checkbox markup used by the editor custom element.
 - `renderers/calendar-badge-renderer.js`: calendar badge containers, labels, and icons.
 - `renderers/day-weather-renderer.js`: day badge and day forecast markup.
 - `styles/card-styles.js`: static card CSS string used by the main custom element.
 
-## Renderer wrapper checkpoint
+## Wrapper and ownership checkpoint
 
-Phase 28 reviewed the remaining render-related methods in `src/skylight-calendar-card.js` as a conservative checkpoint. The remaining wrappers are intentionally kept when they do at least one of the following:
+The remaining card-facing wrapper methods in `src/skylight-calendar-card.js` are intentionally kept when they do at least one of the following:
 
-- compose card-instance state before calling an extracted renderer;
-- provide callback bridges so renderers do not depend on the card instance;
+- compose card-instance state before calling an extracted helper or renderer;
+- provide callback bridges so renderers and helper modules do not depend on the card instance;
 - preserve compatibility with existing tests or legacy method call sites;
-- perform DOM, Home Assistant, modal, preference, or service orchestration that belongs in the main custom element.
+- keep extracted modules independent from card-instance state;
+- perform DOM, Home Assistant, modal, preference, render-timing, capability, event-listener, or service orchestration that belongs in the main custom element.
 
-Only obviously unused wrappers should be removed in future phases, and only after confirming they are not referenced by `src/`, tests, renderer callbacks, or compatibility paths.
+Only objectively unused wrappers should be removed, and only after confirming they are not referenced by `src/`, tests, renderer callbacks, compatibility paths, or the generated artifact process. If there is doubt, keep the wrapper and document the reason in the relevant cleanup work.
 
-## Guardrails for future phases
+## Guardrails for future work
 
 - Prefer direct module tests for extracted pure/data helpers before moving any additional behavior.
 - Keep helpers explicit: pass inputs and callbacks instead of importing or depending on the card instance.
-- Preserve public config option names, custom element names, CSS class names, DOM structure, translations, and visual behavior unless a prompt explicitly requests a behavior change.
+- Preserve public config option names, custom element names, CSS class names, DOM structure, data attributes, IDs, translations, and visual behavior unless a prompt explicitly requests a behavior change.
 - Preserve both `daylight-calendar-card` and legacy `skylight-calendar-card` compatibility.
 - Treat visual/layout changes as potentially breaking for dashboard users.
+- Keep future refactors small, opportunistic, and tied to real feature or bug work rather than extraction-only churn.

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -3,49 +3,18 @@ import { registerDaylightCalendarCardEditor } from './editor/daylight-calendar-c
 import { getDaylightCalendarCardVersion } from './version.js';
 import { getCardStyles } from './styles/card-styles.js';
 import {
-  COMBINE_BACKGROUND_MODE_OPTIONS,
-  COMBINE_STYLE_OPTIONS,
   createDefaultStubConfig,
-  DAY_BADGE_LAYOUT_WEEK_OPTIONS,
-  DEFAULT_BACKGROUND_IMAGE_POSITION,
-  DEFAULT_BACKGROUND_IMAGE_REPEAT,
-  DEFAULT_BACKGROUND_IMAGE_SIZE,
   DEFAULT_COMBINE_BACKGROUND,
   DEFAULT_CONFIG_VALUES,
-  DEFAULT_COMBINE_STYLE,
-  DEFAULT_DAY_BADGE_LAYOUT_WEEK,
   DEFAULT_EVENT_COLOR_BAR_WIDTH,
-  DEFAULT_EVENT_COLOR_MODE,
-  DEFAULT_EVENT_MODAL_SIZE,
   DEFAULT_EVENT_NEUTRAL_BACKGROUND,
   DEFAULT_EVENT_TINT_OPACITY,
-  DEFAULT_EVENT_TITLE_PREFIX,
   DEFAULT_LANGUAGE,
-  DEFAULT_PAST_EVENT_MODE,
   DEFAULT_THEME_MODE,
-  DEFAULT_VIEW,
-  EVENT_COLOR_MODE_OPTIONS,
-  EVENT_MODAL_SIZE_OPTIONS,
-  EVENT_TITLE_PREFIX_ALIASES,
-  EVENT_TITLE_PREFIX_OPTIONS,
-  HIDDEN_CALENDAR_VISIBILITY_VALUES,
-  PAST_EVENT_MODE_OPTIONS,
-  THEME_MODE_OPTIONS,
-  VISIBLE_CALENDAR_VISIBILITY_VALUES
+  DEFAULT_VIEW
 } from './defaults.js';
 import { TRANSLATIONS } from './translations.js';
-import {
-  createConfigNormalizationSchema,
-  getEditorDefaultValue as getEditorDefaultValueFromSchema,
-  getEventCalendarBubbleMode as getEventCalendarBubbleModeFromConfig,
-  normalizeDefaultViewForEditor as normalizeDefaultViewForEditorValue
-} from './editor/editor-schema.js';
-import {
-  renderEditorColorInputControl,
-  renderEditorSection,
-  renderEditorSubSection,
-  renderEditorWeekdayCheckboxes
-} from './renderers/editor-renderer.js';
+import { createConfigNormalizationSchema } from './editor/editor-schema.js';
 import {
   renderDayBadges as renderDayBadgesHtml,
   renderDayForecast as renderDayForecastHtml
@@ -129,7 +98,6 @@ import {
   normalizeWeatherTemperature as normalizeWeatherTemperatureHelper
 } from './weather/weather-utils.js';
 import {
-  getEntityFriendlyName as getEntityFriendlyNameHelper,
   getEntityRenderSignature as getEntityRenderSignatureHelper,
   getFormattedHeaderSensorTime as getFormattedHeaderSensorTimeHelper,
   getHeaderEntityRenderSignatureFromState,


### PR DESCRIPTION
### Motivation

- Finalize and document the modularization work through the Phase-33 checkpoint and provide clearer boundaries and guardrails for future extractions. 
- Ensure the repository docs and internal guidance reflect new module responsibilities and preserve backwards compatibility and the shipped artifact ownership. 
- Align the `src/skylight-calendar-card.js` entry point imports with the newly extracted and renamed modules so the main custom element keeps card-instance orchestration. 

### Description

- Update `AGENTS.md` to describe the completed post-Phase-33 modularization, add new module ownership notes, and tighten guardrails about when to extract code. 
- Update `src/README.md` to reflect the new module map, introduce `version.js`, `weather-controller.js`, and reorganized `config/`, `ha/`, `utils/`, `editor/`, `events/`, and renderer module responsibilities. 
- Change `src/skylight-calendar-card.js` imports to match the refactor by removing/renaming dozens of imports and keeping the entry point focused on lifecycle, orchestration, and compatibility wrappers. 
- Preserve public API, custom element names, and the generated root artifact ownership while documenting which behaviors must remain in the main card file. 

### Testing

- Ran dependency install with `npm ci --no-audit --fund=false` and the build via `npm run build`, both of which completed successfully. 
- Executed the Node unit tests (the `skylight-calendar-card.test.js` suite using `node:test`) and they passed. 
- Ran the Playwright visual/spec checks (`playwright/visual.spec.js`) and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d997e05f4833192addaf040712f9f)