### PR TITLE
docs: explain stale HACS frontend resources

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -80,7 +80,7 @@ The Daylight Calendar Card is a custom Lovelace card for Home Assistant that bri
     2. Go to **Frontend**.
     3. Find **Daylight Calendar Card** in the list.
     4. If an update is available, click the card entry and then click **Update**.
-    5. After HACS finishes downloading, hard-refresh your browser with **Ctrl\+Shift\+R** (Windows/Linux) or **Cmd\+Shift\+R** (Mac) to ensure the browser loads the new JavaScript file and not a cached version.
+    5. After HACS finishes downloading, hard-refresh your browser with `Ctrl+Shift+R` (Windows/Linux) or `Cmd+Shift+R` (Mac) to ensure the browser loads the new JavaScript file and not a cached version.
 
     <Tip>
       If the card still shows the old version number after updating, clear your browser cache or open the dashboard in a private/incognito window to confirm the update took effect.

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -87,6 +87,16 @@ The Daylight Calendar Card is a custom Lovelace card for Home Assistant that bri
     </Tip>
   </Accordion>
 
+  <Accordion title="I updated through HACS, but I do not see the latest features. Why?">
+    HACS showing the latest version confirms that the current files are installed on disk. It does not prove that your browser or dashboard is loading the current frontend resource.
+
+    This is especially common if you installed the card before the Skylight → Daylight rename. Home Assistant may still have an old resource entry or cached file that points to the previous `skylight-calendar-card` folder, even though the JavaScript filename is still `skylight-calendar-card.js`.
+
+    Check **Settings → Dashboards → Resources**, remove duplicate or old Skylight resources, and make sure the active HACS resource uses `/hacsfiles/daylight-calendar-card/skylight-calendar-card.js`. Then hard-refresh the browser or try a private/incognito window.
+
+    See [Updated to the latest version, but still seeing old behavior](/troubleshooting#updated-to-the-latest-version-but-still-seeing-old-behavior) for the full checklist.
+  </Accordion>
+
   <Accordion title="Can I use the card without writing YAML?">
     Yes. The card ships with a visual configuration editor that is accessible directly from the Home Assistant dashboard card editor. Click **Edit Dashboard**, add or edit a Daylight Calendar Card, and the graphical editor appears automatically. It covers all the common options including calendars, view modes, colors, and weather.
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -51,7 +51,10 @@ The Daylight Calendar Card is designed to work out of the box with any Home Assi
     </Tip>
   </Accordion>
 
-  <Accordion title="Updated to the latest version, but still seeing old behavior">
+  <Accordion
+    title="Updated to the latest version, but still seeing old behavior"
+    id="updated-to-the-latest-version-but-still-seeing-old-behavior"
+  >
     If HACS shows the latest version but new frontend behavior is missing, the most common cause is a stale dashboard resource or browser cache. HACS confirms that the files are installed. It does not confirm that Home Assistant or your browser is loading the current file.
 
     This is especially likely if you installed the card before the Skylight → Daylight rename. The filename is still `skylight-calendar-card.js` for compatibility, but the HACS folder path should now be the Daylight folder.

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -15,7 +15,7 @@ The Daylight Calendar Card is designed to work out of the box with any Home Assi
     1. In Home Assistant, go to **Settings → Dashboards → Resources** (you may need to enable Advanced Mode in your profile first).
     2. Check that `skylight-calendar-card.js` is listed and its type is set to **JavaScript Module**.
     3. If the entry is missing, add it manually. The URL should match your installation path, for example `/hacsfiles/daylight-calendar-card/skylight-calendar-card.js` (HACS) or `/local/skylight-calendar-card.js` (manual).
-    4. Hard-refresh your browser with **Ctrl\+Shift\+R** (Windows/Linux) or **Cmd\+Shift\+R** (Mac) to force the browser to reload the resource.
+    4. Hard-refresh your browser with `Ctrl+Shift+R` (Windows/Linux) or `Cmd+Shift+R` (Mac) to force the browser to reload the resource.
 
     <Note>
       If you installed via HACS, the resource entry is usually added automatically. If it's missing, try removing and re-downloading the card in HACS, then check Resources again.
@@ -95,7 +95,7 @@ The Daylight Calendar Card is designed to work out of the box with any Home Assi
 
     5. **Refresh or restart**
 
-       Hard-refresh your browser with **Ctrl\+Shift\+R** (Windows/Linux) or **Cmd\+Shift\+R** (Mac). If the old UI still appears, try a private/incognito window, clear your browser cache, or restart Home Assistant.
+       Hard-refresh your browser with `Ctrl+Shift+R` (Windows/Linux) or `Cmd+Shift+R` (Mac). If the old UI still appears, try a private/incognito window, clear your browser cache, or restart Home Assistant.
 
     6. **Verify the current editor loads**
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -51,6 +51,69 @@ The Daylight Calendar Card is designed to work out of the box with any Home Assi
     </Tip>
   </Accordion>
 
+  <Accordion title="Updated to the latest version, but still seeing old behavior">
+    If HACS shows the latest version but new frontend behavior is missing, the most common cause is a stale dashboard resource or browser cache. HACS confirms that the files are installed. It does not confirm that Home Assistant or your browser is loading the current file.
+
+    This is especially likely if you installed the card before the Skylight → Daylight rename. The filename is still `skylight-calendar-card.js` for compatibility, but the HACS folder path should now be the Daylight folder.
+
+    **Symptoms:**
+
+    - New options or features are missing
+    - Documented options have no effect
+    - The card editor looks outdated
+    - The card editor is missing the **About / Diagnostics** section
+
+    **Steps to fix:**
+
+    1. **Confirm HACS version**
+
+       Open **HACS → Frontend → Daylight Calendar Card** and confirm it shows the version you expect. This only confirms installation, so continue with the resource checks below if the dashboard still looks old.
+
+    2. **Check Dashboard Resources**
+
+       In Home Assistant, go to **Settings → Dashboards → Resources**. Look for every resource entry that points to `skylight-calendar-card.js`.
+
+    3. **Remove old Skylight resources**
+
+       Delete duplicate or old entries that point to the pre-rename folder, such as:
+
+       ```text
+       /hacsfiles/skylight-calendar-card/skylight-calendar-card.js
+       ```
+
+    4. **Keep only the current Daylight resource**
+
+       For a HACS install, the resource should use the Daylight folder:
+
+       ```text
+       /hacsfiles/daylight-calendar-card/skylight-calendar-card.js
+       ```
+
+       <Note>
+         The filename is intentionally still `skylight-calendar-card.js`. The important part is the folder path: `daylight-calendar-card`, not `skylight-calendar-card`.
+       </Note>
+
+    5. **Refresh or restart**
+
+       Hard-refresh your browser with **Ctrl\+Shift\+R** (Windows/Linux) or **Cmd\+Shift\+R** (Mac). If the old UI still appears, try a private/incognito window, clear your browser cache, or restart Home Assistant.
+
+    6. **Verify the current editor loads**
+
+       Edit the card in your dashboard and scroll to the bottom of the card editor. Seeing the **About / Diagnostics** section is a good sign that the current frontend/editor is loading. If that section is missing, an old frontend resource is probably still being loaded.
+
+    7. **Include details when opening an issue**
+
+       If you still need help, include screenshots of:
+
+       - The HACS version shown for Daylight Calendar Card
+       - **Settings → Dashboards → Resources**
+       - The bottom of the card editor, especially whether **About / Diagnostics** appears
+
+    <Tip>
+      This checklist is most useful when HACS shows the latest version but new options or editor sections are missing. Other bugs can have different causes.
+    </Tip>
+  </Accordion>
+
   <Accordion title='"Add Event" button is missing'>
     The **Add Event** button is hidden when event management is disabled or no writable calendar is available.
 


### PR DESCRIPTION
### Motivation
- Users reported installing the latest release via HACS but still seeing missing features because Home Assistant or the browser was loading an older cached frontend resource from before the Skylight → Daylight rename. 
- The intent is to give a short FAQ pointer and a practical troubleshooting checklist that helps users confirm the active resource path and clear stale caches so the dashboard loads the up-to-date frontend.

### Description
- Added a concise FAQ entry to `docs/faq.mdx` titled “I updated through HACS, but I do not see the latest features. Why?” that explains HACS only confirms files are installed and links to the troubleshooting checklist. 
- Added a new troubleshooting accordion to `docs/troubleshooting.mdx` titled “Updated to the latest version, but still seeing old behavior” that lists symptoms, explains the Daylight vs Skylight folder distinction, and provides a step-by-step checklist. 
- The checklist instructs users to confirm the HACS version, check **Settings → Dashboards → Resources**, remove old `skylight-calendar-card` folder resources, keep the HACS Daylight resource path `/hacsfiles/daylight-calendar-card/skylight-calendar-card.js`, hard-refresh/clear cache/use private window or restart HA, and verify the editor shows the About / Diagnostics section. 
- The troubleshooting entry also tells users what screenshots to include if they still need help and keeps the same style, tone, and component usage as the existing docs.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and it completed without errors. 
- No build or visual tests (`npm run build`, `npm test`, or `npm run test:visual`) were run because these are documentation-only changes and do not affect the shipped artifact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3de63521ec8331beff156627a61b7d)