### PR TITLE
Add dismissible stale Skylight resource warning banner

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -9935,6 +9935,19 @@ const showStaleResourceWarningBanner = (staleUrl) => {
   if (staleUrl) {
     message.title = staleUrl;
   }
+  const docsLink = document.createElement('a');
+  docsLink.href = STALE_RESOURCE_TROUBLESHOOTING_URL;
+  docsLink.target = '_blank';
+  docsLink.rel = 'noreferrer';
+  docsLink.textContent = 'Help';
+  docsLink.style.cssText = [
+    'color: #bbdefb',
+    'font-size: 12px',
+    'font-weight: 500',
+    'text-decoration: none',
+    'white-space: nowrap'
+  ].join(';');
+
   const dismissButton = document.createElement('button');
   dismissButton.type = 'button';
   dismissButton.textContent = 'Dismiss';
@@ -9951,7 +9964,7 @@ const showStaleResourceWarningBanner = (staleUrl) => {
   ].join(';');
   dismissButton.addEventListener('click', () => dismissStaleResourceWarning(banner));
 
-  banner.append(message, dismissButton);
+  banner.append(message, docsLink, dismissButton);
   document.body?.appendChild?.(banner);
 };
 

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -616,6 +616,61 @@ function normalizeBooleanStyleValue(value) {
   return null;
 }
 
+const STALE_RESOURCE_WARNING_STORAGE_KEY = 'daylight-calendar-card:stale-resource-warning-dismissed';
+const STALE_RESOURCE_TROUBLESHOOTING_URL = 'https://docs.daylightcalendar.com/troubleshooting#updated-to-the-latest-version-but-still-seeing-old-behavior';
+
+const STALE_RESOURCE_SEGMENT = '/skylight-calendar-card/';
+const CURRENT_HACS_RESOURCE_PATH = '/hacsfiles/daylight-calendar-card/skylight-calendar-card.js';
+
+const normalizeResourceUrl = (value) => {
+  if (typeof value !== 'string') return '';
+  return value.trim();
+};
+
+const isStaleResourceUrl = (url) => {
+  const normalized = normalizeResourceUrl(url).toLowerCase();
+  if (!normalized) return false;
+  return normalized.includes(STALE_RESOURCE_SEGMENT) && !normalized.includes(CURRENT_HACS_RESOURCE_PATH);
+};
+
+const collectResourceUrls = (documentLike) => {
+  const urls = [];
+  if (!documentLike) return urls;
+
+  const addUrl = (value) => {
+    const normalized = normalizeResourceUrl(value);
+    if (normalized) urls.push(normalized);
+  };
+
+  try {
+    for (const script of Array.from(documentLike.scripts || [])) {
+      addUrl(script?.src);
+    }
+  } catch (_error) {
+    // Ignore unavailable document APIs.
+  }
+
+  try {
+    for (const link of Array.from(documentLike.querySelectorAll?.('link[href]') || [])) {
+      addUrl(link?.href);
+    }
+  } catch (_error) {
+    // Ignore unavailable document APIs.
+  }
+
+  return urls;
+};
+
+const detectStaleSkylightResource = (documentLike = globalThis.document) => {
+  const urls = collectResourceUrls(documentLike);
+  const staleUrl = urls.find(isStaleResourceUrl) || null;
+  return {
+    detected: !!staleUrl,
+    staleUrl,
+    urls
+  };
+};
+
 function normalizeDefaultDarkMode(value) {
   if (value === true) return 'dark';
   if (value === false || value === undefined || value === null || value === '') return DEFAULT_THEME_MODE;
@@ -1810,11 +1865,19 @@ class SkylightCalendarCardEditor extends HTMLElement {
       </div>
     `);
 
+    const staleResourceDetection = detectStaleSkylightResource();
+    const staleResourceDiagnostics = staleResourceDetection.detected ? `
+      <p class="helper"><strong>Old Skylight resource detected:</strong> ${this.escapeHtml(staleResourceDetection.staleUrl)}</p>
+      <p class="helper">Remove the old resource from Settings → Dashboards → Resources and keep /hacsfiles/daylight-calendar-card/skylight-calendar-card.js. HACS showing the latest version confirms the file is installed, but not that this dashboard loaded the current frontend resource.</p>
+      <p class="helper"><a href="${STALE_RESOURCE_TROUBLESHOOTING_URL}" target="_blank" rel="noreferrer">Troubleshooting guide</a></p>
+    ` : '';
+
     const diagnosticsSection = this.renderSection('About / Diagnostics', `
       <p class="helper">Daylight Calendar Card</p>
       <p class="helper">Loaded version: ${this.escapeHtml(getDaylightCalendarCardVersion())}</p>
       <p class="helper">Resource file: skylight-calendar-card.js</p>
       <p class="helper">If this version does not match the version shown in HACS, Home Assistant may be loading a cached or stale resource.</p>
+      ${staleResourceDiagnostics}
     `);
 
     this.innerHTML = `
@@ -9810,12 +9873,115 @@ const translate = (language, key, params = {}) => {
   return interpolate(strings[key] || fallback, params);
 };
 
+
+const STALE_RESOURCE_BANNER_ID = 'daylight-calendar-card-stale-resource-warning';
+let staleResourceWarningHandled = false;
+
+const logStaleResourceWarning = (staleUrl) => {
+  console.warn(
+    `Daylight Calendar Card: old Skylight resource detected${staleUrl ? ` (${staleUrl})` : ''}. ` +
+    'Remove it from Settings → Dashboards → Resources and keep /hacsfiles/daylight-calendar-card/skylight-calendar-card.js. ' +
+    'The filename may still be skylight-calendar-card.js; the important part is the daylight-calendar-card folder.'
+  );
+};
+
+const isStaleResourceWarningDismissed = () => {
+  try {
+    return window.localStorage?.getItem(STALE_RESOURCE_WARNING_STORAGE_KEY) === 'true';
+  } catch (_error) {
+    return false;
+  }
+};
+
+const dismissStaleResourceWarning = (banner) => {
+  try {
+    window.localStorage?.setItem(STALE_RESOURCE_WARNING_STORAGE_KEY, 'true');
+  } catch (_error) {
+    // Ignore storage failures; the banner can still be dismissed for this page view.
+  }
+  banner?.remove?.();
+};
+
+const showStaleResourceWarningBanner = (staleUrl) => {
+  if (isStaleResourceWarningDismissed() || document.getElementById?.(STALE_RESOURCE_BANNER_ID)) return;
+
+  const banner = document.createElement('div');
+  banner.id = STALE_RESOURCE_BANNER_ID;
+  banner.setAttribute('role', 'status');
+  banner.style.cssText = [
+    'position: fixed',
+    'left: 50%',
+    'bottom: 24px',
+    'transform: translateX(-50%)',
+    'z-index: 2147483647',
+    'box-sizing: border-box',
+    'max-width: min(560px, calc(100vw - 32px))',
+    'display: flex',
+    'align-items: center',
+    'gap: 12px',
+    'padding: 12px 16px',
+    'border-radius: 4px',
+    'background: #323232',
+    'color: #fff',
+    'box-shadow: 0 3px 8px rgba(0, 0, 0, 0.32)',
+    'font-family: var(--primary-font-family, Roboto, Arial, sans-serif)',
+    'font-size: 14px',
+    'line-height: 1.35',
+    'pointer-events: auto'
+  ].join(';');
+
+  const message = document.createElement('span');
+  message.textContent = 'Old Skylight Calendar Card resource detected. Remove the old resource from Settings → Dashboards → Resources.';
+  message.style.cssText = 'min-width: 0; flex: 1 1 auto;';
+  if (staleUrl) {
+    message.title = staleUrl;
+  }
+
+  const docsLink = document.createElement('a');
+  docsLink.href = STALE_RESOURCE_TROUBLESHOOTING_URL;
+  docsLink.target = '_blank';
+  docsLink.rel = 'noreferrer';
+  docsLink.textContent = 'Troubleshooting';
+  docsLink.style.cssText = 'color: #bbdefb; text-decoration: none; font-weight: 500; white-space: nowrap;';
+
+  const dismissButton = document.createElement('button');
+  dismissButton.type = 'button';
+  dismissButton.textContent = 'Dismiss';
+  dismissButton.style.cssText = [
+    'border: 0',
+    'background: transparent',
+    'color: #90caf9',
+    'font: inherit',
+    'font-weight: 500',
+    'text-transform: uppercase',
+    'cursor: pointer',
+    'padding: 4px',
+    'white-space: nowrap'
+  ].join(';');
+  dismissButton.addEventListener('click', () => dismissStaleResourceWarning(banner));
+
+  banner.append(message, docsLink, dismissButton);
+  document.body?.appendChild?.(banner);
+};
+
+const checkAndShowStaleResourceWarning = () => {
+  if (staleResourceWarningHandled) return;
+  staleResourceWarningHandled = true;
+
+  const detection = detectStaleSkylightResource();
+  if (!detection.detected) return;
+
+  logStaleResourceWarning(detection.staleUrl);
+  showStaleResourceWarningBanner(detection.staleUrl);
+};
+
 // ============================================================================
 // MAIN CALENDAR CARD CLASS
 // ============================================================================
 
 class SkylightCalendarCard extends HTMLElement {
   static COMMON_NAMED_COLORS = COMMON_NAMED_COLORS;
+  static detectStaleSkylightResource = detectStaleSkylightResource;
 
   constructor() {
     super();
@@ -11530,6 +11696,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   connectedCallback() {
+    checkAndShowStaleResourceWarning();
     window.addEventListener('resize', this._handleViewportResize);
     window.visualViewport?.addEventListener('resize', this._handleViewportResize);
     this.attachSystemThemeListener();

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -9910,17 +9910,16 @@ const showStaleResourceWarningBanner = (staleUrl) => {
   banner.setAttribute('role', 'status');
   banner.style.cssText = [
     'position: fixed',
-    'left: 50%',
-    'bottom: 24px',
-    'transform: translateX(-50%)',
+    'left: 0',
+    'right: 0',
+    'bottom: 0',
     'z-index: 2147483647',
     'box-sizing: border-box',
-    'max-width: min(560px, calc(100vw - 32px))',
+    'width: 100%',
     'display: flex',
     'align-items: center',
     'gap: 12px',
     'padding: 12px 16px',
-    'border-radius: 4px',
     'background: #323232',
     'color: #fff',
     'box-shadow: 0 3px 8px rgba(0, 0, 0, 0.32)',
@@ -9931,19 +9930,11 @@ const showStaleResourceWarningBanner = (staleUrl) => {
   ].join(';');
 
   const message = document.createElement('span');
-  message.textContent = 'Old Skylight Calendar Card resource detected. Remove the old resource from Settings → Dashboards → Resources.';
+  message.textContent = 'Old Skylight Calendar Card resource detected. Remove it from Settings → Dashboards → Resources.';
   message.style.cssText = 'min-width: 0; flex: 1 1 auto;';
   if (staleUrl) {
     message.title = staleUrl;
   }
-
-  const docsLink = document.createElement('a');
-  docsLink.href = STALE_RESOURCE_TROUBLESHOOTING_URL;
-  docsLink.target = '_blank';
-  docsLink.rel = 'noreferrer';
-  docsLink.textContent = 'Troubleshooting';
-  docsLink.style.cssText = 'color: #bbdefb; text-decoration: none; font-weight: 500; white-space: nowrap;';
-
   const dismissButton = document.createElement('button');
   dismissButton.type = 'button';
   dismissButton.textContent = 'Dismiss';
@@ -9960,7 +9951,7 @@ const showStaleResourceWarningBanner = (staleUrl) => {
   ].join(';');
   dismissButton.addEventListener('click', () => dismissStaleResourceWarning(banner));
 
-  banner.append(message, docsLink, dismissButton);
+  banner.append(message, dismissButton);
   document.body?.appendChild?.(banner);
 };
 

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -4935,3 +4935,39 @@ test('weather controller config changes tear down subscription and clear forecas
   assert.equal(controller.getForecastForEntity('weather.home'), undefined);
   assert.equal(controller.refreshRetryAtByEntity.size, 0);
 });
+
+test('detectStaleSkylightResource detects old HACS skylight resource path', () => {
+  const result = Card.detectStaleSkylightResource({
+    scripts: [{ src: '/hacsfiles/skylight-calendar-card/skylight-calendar-card.js' }],
+    querySelectorAll: () => []
+  });
+
+  assert.equal(result.detected, true);
+  assert.equal(result.staleUrl, '/hacsfiles/skylight-calendar-card/skylight-calendar-card.js');
+});
+
+test('detectStaleSkylightResource does not warn for current Daylight HACS resource path', () => {
+  const result = Card.detectStaleSkylightResource({
+    scripts: [{ src: '/hacsfiles/daylight-calendar-card/skylight-calendar-card.js' }],
+    querySelectorAll: () => []
+  });
+
+  assert.equal(result.detected, false);
+  assert.equal(result.staleUrl, null);
+});
+
+test('detectStaleSkylightResource handles missing and empty document resources safely', () => {
+  assert.equal(Card.detectStaleSkylightResource(null).detected, false);
+  assert.equal(Card.detectStaleSkylightResource({}).detected, false);
+  assert.equal(Card.detectStaleSkylightResource({ scripts: [], querySelectorAll: () => [] }).detected, false);
+});
+
+test('detectStaleSkylightResource ignores unrelated scripts and links', () => {
+  const result = Card.detectStaleSkylightResource({
+    scripts: [{ src: '/hacsfiles/other-card/other-card.js' }],
+    querySelectorAll: () => [{ href: '/local/daylight-calendar-card.js' }]
+  });
+
+  assert.equal(result.detected, false);
+  assert.equal(result.staleUrl, null);
+});

--- a/src/editor/daylight-calendar-card-editor.js
+++ b/src/editor/daylight-calendar-card-editor.js
@@ -39,6 +39,7 @@ import {
 import { getEntityFriendlyName as getEntityFriendlyNameHelper } from '../ha/ha-state-helpers.js';
 import { getDaylightCalendarCardVersion } from '../version.js';
 import { normalizeDashboardPath, normalizeEnumValue } from '../utils/normalization-utils.js';
+import { detectStaleSkylightResource, STALE_RESOURCE_TROUBLESHOOTING_URL } from '../utils/stale-resource-utils.js';
 
 function normalizeDefaultDarkMode(value) {
   if (value === true) return 'dark';
@@ -1234,11 +1235,19 @@ export class SkylightCalendarCardEditor extends HTMLElement {
       </div>
     `);
 
+    const staleResourceDetection = detectStaleSkylightResource();
+    const staleResourceDiagnostics = staleResourceDetection.detected ? `
+      <p class="helper"><strong>Old Skylight resource detected:</strong> ${this.escapeHtml(staleResourceDetection.staleUrl)}</p>
+      <p class="helper">Remove the old resource from Settings → Dashboards → Resources and keep /hacsfiles/daylight-calendar-card/skylight-calendar-card.js. HACS showing the latest version confirms the file is installed, but not that this dashboard loaded the current frontend resource.</p>
+      <p class="helper"><a href="${STALE_RESOURCE_TROUBLESHOOTING_URL}" target="_blank" rel="noreferrer">Troubleshooting guide</a></p>
+    ` : '';
+
     const diagnosticsSection = this.renderSection('About / Diagnostics', `
       <p class="helper">Daylight Calendar Card</p>
       <p class="helper">Loaded version: ${this.escapeHtml(getDaylightCalendarCardVersion())}</p>
       <p class="helper">Resource file: skylight-calendar-card.js</p>
       <p class="helper">If this version does not match the version shown in HACS, Home Assistant may be loading a cached or stale resource.</p>
+      ${staleResourceDiagnostics}
     `);
 
     this.innerHTML = `

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -69,7 +69,6 @@ import {
 import { escapeHtmlAttribute, normalizeEventTextValue } from './utils/string-utils.js';
 import {
   detectStaleSkylightResource,
-  STALE_RESOURCE_TROUBLESHOOTING_URL,
   STALE_RESOURCE_WARNING_STORAGE_KEY
 } from './utils/stale-resource-utils.js';
 import {
@@ -272,17 +271,16 @@ const showStaleResourceWarningBanner = (staleUrl) => {
   banner.setAttribute('role', 'status');
   banner.style.cssText = [
     'position: fixed',
-    'left: 50%',
-    'bottom: 24px',
-    'transform: translateX(-50%)',
+    'left: 0',
+    'right: 0',
+    'bottom: 0',
     'z-index: 2147483647',
     'box-sizing: border-box',
-    'max-width: min(560px, calc(100vw - 32px))',
+    'width: 100%',
     'display: flex',
     'align-items: center',
     'gap: 12px',
     'padding: 12px 16px',
-    'border-radius: 4px',
     'background: #323232',
     'color: #fff',
     'box-shadow: 0 3px 8px rgba(0, 0, 0, 0.32)',
@@ -293,19 +291,11 @@ const showStaleResourceWarningBanner = (staleUrl) => {
   ].join(';');
 
   const message = document.createElement('span');
-  message.textContent = 'Old Skylight Calendar Card resource detected. Remove the old resource from Settings → Dashboards → Resources.';
+  message.textContent = 'Old Skylight Calendar Card resource detected. Remove it from Settings → Dashboards → Resources.';
   message.style.cssText = 'min-width: 0; flex: 1 1 auto;';
   if (staleUrl) {
     message.title = staleUrl;
   }
-
-  const docsLink = document.createElement('a');
-  docsLink.href = STALE_RESOURCE_TROUBLESHOOTING_URL;
-  docsLink.target = '_blank';
-  docsLink.rel = 'noreferrer';
-  docsLink.textContent = 'Troubleshooting';
-  docsLink.style.cssText = 'color: #bbdefb; text-decoration: none; font-weight: 500; white-space: nowrap;';
-
   const dismissButton = document.createElement('button');
   dismissButton.type = 'button';
   dismissButton.textContent = 'Dismiss';
@@ -322,7 +312,7 @@ const showStaleResourceWarningBanner = (staleUrl) => {
   ].join(';');
   dismissButton.addEventListener('click', () => dismissStaleResourceWarning(banner));
 
-  banner.append(message, docsLink, dismissButton);
+  banner.append(message, dismissButton);
   document.body?.appendChild?.(banner);
 };
 

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -69,6 +69,7 @@ import {
 import { escapeHtmlAttribute, normalizeEventTextValue } from './utils/string-utils.js';
 import {
   detectStaleSkylightResource,
+  STALE_RESOURCE_TROUBLESHOOTING_URL,
   STALE_RESOURCE_WARNING_STORAGE_KEY
 } from './utils/stale-resource-utils.js';
 import {
@@ -296,6 +297,19 @@ const showStaleResourceWarningBanner = (staleUrl) => {
   if (staleUrl) {
     message.title = staleUrl;
   }
+  const docsLink = document.createElement('a');
+  docsLink.href = STALE_RESOURCE_TROUBLESHOOTING_URL;
+  docsLink.target = '_blank';
+  docsLink.rel = 'noreferrer';
+  docsLink.textContent = 'Help';
+  docsLink.style.cssText = [
+    'color: #bbdefb',
+    'font-size: 12px',
+    'font-weight: 500',
+    'text-decoration: none',
+    'white-space: nowrap'
+  ].join(';');
+
   const dismissButton = document.createElement('button');
   dismissButton.type = 'button';
   dismissButton.textContent = 'Dismiss';
@@ -312,7 +326,7 @@ const showStaleResourceWarningBanner = (staleUrl) => {
   ].join(';');
   dismissButton.addEventListener('click', () => dismissStaleResourceWarning(banner));
 
-  banner.append(message, dismissButton);
+  banner.append(message, docsLink, dismissButton);
   document.body?.appendChild?.(banner);
 };
 

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -68,6 +68,11 @@ import {
 } from './config/config-normalizers.js';
 import { escapeHtmlAttribute, normalizeEventTextValue } from './utils/string-utils.js';
 import {
+  detectStaleSkylightResource,
+  STALE_RESOURCE_TROUBLESHOOTING_URL,
+  STALE_RESOURCE_WARNING_STORAGE_KEY
+} from './utils/stale-resource-utils.js';
+import {
   getEventDateTimeInfo as getNormalizedEventDateTimeInfo,
   getEventIdentityKey as getNormalizedEventIdentityKey,
   getEventStartDate as getNormalizedEventStartDate,
@@ -230,12 +235,115 @@ const translate = (language, key, params = {}) => {
   return interpolate(strings[key] || fallback, params);
 };
 
+
+const STALE_RESOURCE_BANNER_ID = 'daylight-calendar-card-stale-resource-warning';
+let staleResourceWarningHandled = false;
+
+const logStaleResourceWarning = (staleUrl) => {
+  console.warn(
+    `Daylight Calendar Card: old Skylight resource detected${staleUrl ? ` (${staleUrl})` : ''}. ` +
+    'Remove it from Settings → Dashboards → Resources and keep /hacsfiles/daylight-calendar-card/skylight-calendar-card.js. ' +
+    'The filename may still be skylight-calendar-card.js; the important part is the daylight-calendar-card folder.'
+  );
+};
+
+const isStaleResourceWarningDismissed = () => {
+  try {
+    return window.localStorage?.getItem(STALE_RESOURCE_WARNING_STORAGE_KEY) === 'true';
+  } catch (_error) {
+    return false;
+  }
+};
+
+const dismissStaleResourceWarning = (banner) => {
+  try {
+    window.localStorage?.setItem(STALE_RESOURCE_WARNING_STORAGE_KEY, 'true');
+  } catch (_error) {
+    // Ignore storage failures; the banner can still be dismissed for this page view.
+  }
+  banner?.remove?.();
+};
+
+const showStaleResourceWarningBanner = (staleUrl) => {
+  if (isStaleResourceWarningDismissed() || document.getElementById?.(STALE_RESOURCE_BANNER_ID)) return;
+
+  const banner = document.createElement('div');
+  banner.id = STALE_RESOURCE_BANNER_ID;
+  banner.setAttribute('role', 'status');
+  banner.style.cssText = [
+    'position: fixed',
+    'left: 50%',
+    'bottom: 24px',
+    'transform: translateX(-50%)',
+    'z-index: 2147483647',
+    'box-sizing: border-box',
+    'max-width: min(560px, calc(100vw - 32px))',
+    'display: flex',
+    'align-items: center',
+    'gap: 12px',
+    'padding: 12px 16px',
+    'border-radius: 4px',
+    'background: #323232',
+    'color: #fff',
+    'box-shadow: 0 3px 8px rgba(0, 0, 0, 0.32)',
+    'font-family: var(--primary-font-family, Roboto, Arial, sans-serif)',
+    'font-size: 14px',
+    'line-height: 1.35',
+    'pointer-events: auto'
+  ].join(';');
+
+  const message = document.createElement('span');
+  message.textContent = 'Old Skylight Calendar Card resource detected. Remove the old resource from Settings → Dashboards → Resources.';
+  message.style.cssText = 'min-width: 0; flex: 1 1 auto;';
+  if (staleUrl) {
+    message.title = staleUrl;
+  }
+
+  const docsLink = document.createElement('a');
+  docsLink.href = STALE_RESOURCE_TROUBLESHOOTING_URL;
+  docsLink.target = '_blank';
+  docsLink.rel = 'noreferrer';
+  docsLink.textContent = 'Troubleshooting';
+  docsLink.style.cssText = 'color: #bbdefb; text-decoration: none; font-weight: 500; white-space: nowrap;';
+
+  const dismissButton = document.createElement('button');
+  dismissButton.type = 'button';
+  dismissButton.textContent = 'Dismiss';
+  dismissButton.style.cssText = [
+    'border: 0',
+    'background: transparent',
+    'color: #90caf9',
+    'font: inherit',
+    'font-weight: 500',
+    'text-transform: uppercase',
+    'cursor: pointer',
+    'padding: 4px',
+    'white-space: nowrap'
+  ].join(';');
+  dismissButton.addEventListener('click', () => dismissStaleResourceWarning(banner));
+
+  banner.append(message, docsLink, dismissButton);
+  document.body?.appendChild?.(banner);
+};
+
+const checkAndShowStaleResourceWarning = () => {
+  if (staleResourceWarningHandled) return;
+  staleResourceWarningHandled = true;
+
+  const detection = detectStaleSkylightResource();
+  if (!detection.detected) return;
+
+  logStaleResourceWarning(detection.staleUrl);
+  showStaleResourceWarningBanner(detection.staleUrl);
+};
+
 // ============================================================================
 // MAIN CALENDAR CARD CLASS
 // ============================================================================
 
 class SkylightCalendarCard extends HTMLElement {
   static COMMON_NAMED_COLORS = COMMON_NAMED_COLORS;
+  static detectStaleSkylightResource = detectStaleSkylightResource;
 
   constructor() {
     super();
@@ -1950,6 +2058,7 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   connectedCallback() {
+    checkAndShowStaleResourceWarning();
     window.addEventListener('resize', this._handleViewportResize);
     window.visualViewport?.addEventListener('resize', this._handleViewportResize);
     this.attachSystemThemeListener();

--- a/src/utils/stale-resource-utils.js
+++ b/src/utils/stale-resource-utils.js
@@ -1,0 +1,54 @@
+export const STALE_RESOURCE_WARNING_STORAGE_KEY = 'daylight-calendar-card:stale-resource-warning-dismissed';
+export const STALE_RESOURCE_TROUBLESHOOTING_URL = 'https://docs.daylightcalendar.com/troubleshooting#updated-to-the-latest-version-but-still-seeing-old-behavior';
+
+const STALE_RESOURCE_SEGMENT = '/skylight-calendar-card/';
+const CURRENT_HACS_RESOURCE_PATH = '/hacsfiles/daylight-calendar-card/skylight-calendar-card.js';
+
+const normalizeResourceUrl = (value) => {
+  if (typeof value !== 'string') return '';
+  return value.trim();
+};
+
+const isStaleResourceUrl = (url) => {
+  const normalized = normalizeResourceUrl(url).toLowerCase();
+  if (!normalized) return false;
+  return normalized.includes(STALE_RESOURCE_SEGMENT) && !normalized.includes(CURRENT_HACS_RESOURCE_PATH);
+};
+
+const collectResourceUrls = (documentLike) => {
+  const urls = [];
+  if (!documentLike) return urls;
+
+  const addUrl = (value) => {
+    const normalized = normalizeResourceUrl(value);
+    if (normalized) urls.push(normalized);
+  };
+
+  try {
+    for (const script of Array.from(documentLike.scripts || [])) {
+      addUrl(script?.src);
+    }
+  } catch (_error) {
+    // Ignore unavailable document APIs.
+  }
+
+  try {
+    for (const link of Array.from(documentLike.querySelectorAll?.('link[href]') || [])) {
+      addUrl(link?.href);
+    }
+  } catch (_error) {
+    // Ignore unavailable document APIs.
+  }
+
+  return urls;
+};
+
+export const detectStaleSkylightResource = (documentLike = globalThis.document) => {
+  const urls = collectResourceUrls(documentLike);
+  const staleUrl = urls.find(isStaleResourceUrl) || null;
+  return {
+    detected: !!staleUrl,
+    staleUrl,
+    urls
+  };
+};


### PR DESCRIPTION
## Summary
- Added a conservative stale-resource detection helper at `src/utils/stale-resource-utils.js` that inspects loaded `script.src` and `link[href]` URLs and flags visible URLs containing `/skylight-calendar-card/` while excluding the valid `/hacsfiles/daylight-calendar-card/skylight-calendar-card.js` path.
- Added a one-time bottom snackbar-style warning in `src/skylight-calendar-card.js` that logs a clear `console.warn`, shows a small fixed-position dismissible banner with a troubleshooting link, and persists dismissal to `localStorage` under `daylight-calendar-card:stale-resource-warning-dismissed`.
- Surface stale-resource diagnostics in the editor About / Diagnostics area via `src/editor/daylight-calendar-card-editor.js`, including the detected stale URL and guidance that HACS showing the latest version does not guarantee the browser loaded the latest frontend resource.
- Added unit tests appended to `skylight-calendar-card.test.js` covering detection of the old HACS skylight path, suppression for the current Daylight HACS path, safe handling of missing/empty document resources, and ignoring unrelated scripts and links.

## Tests
- Ran `npm run build` and regenerated the shipped artifact `skylight-calendar-card.js` successfully with no build errors.
- Ran `node --check` on `src/skylight-calendar-card.js`, `src/editor/daylight-calendar-card-editor.js`, `src/utils/stale-resource-utils.js`, and the generated `skylight-calendar-card.js` with no syntax errors.
- Ran `npm test` and all tests passed, including the new stale-resource detection tests.

## Generated artifact
- Regenerated and committed the root `skylight-calendar-card.js` artifact from `src/`.

## Notes / risks
- Detection is intentionally conservative to avoid false positives and may produce false negatives in corner cases involving dynamic resource loading or atypical document environments.
- The banner uses `localStorage` for per-browser dismissal and continues to emit `console.warn` even after dismissal; it is non-blocking and styled to match a snackbar feel but does add a small global DOM element with a high `z-index` to ensure visibility.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3dfd578f208331af92c52ab3d98309)