### PR TITLE
Fix compact header resize oscillation

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -10059,6 +10059,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._hostResizeObserver = null;
     this._hostResizeRaf = null;
     this._pendingHostResizeRender = false;
+    this._pendingWidthDependentLayoutRefresh = false;
     this._observedResizeParent = null;
     this._lastObservedHostSize = null;
     this._monthCompactMeasurementDirty = true;
@@ -12111,10 +12112,20 @@ class SkylightCalendarCard extends HTMLElement {
         return;
       }
 
+      if (this.isEventManagementDialogOpen() && this.hasWidthDependentMeasuredLayoutState()) {
+        this._pendingWidthDependentLayoutRefresh = true;
+        return;
+      }
+
       this.updateCompactHeaderWrapState();
       this.updateCalendarBadgesScrollState();
       this.refreshWidthDependentLayoutMeasurements();
     });
+  }
+
+  hasWidthDependentMeasuredLayoutState() {
+    return this._config?.day_badge_layout_week === 'stacked'
+      && (this._viewMode === 'week-standard' || this._viewMode === 'week-compact');
   }
 
   refreshWidthDependentLayoutMeasurements() {
@@ -12126,9 +12137,18 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   flushPendingHostResizeRender() {
-    if (!this._pendingHostResizeRender) return;
+    const shouldRender = this._pendingHostResizeRender;
+    const shouldRefreshWidthMeasurements = this._pendingWidthDependentLayoutRefresh;
     this._pendingHostResizeRender = false;
-    this.render();
+    this._pendingWidthDependentLayoutRefresh = false;
+
+    if (shouldRefreshWidthMeasurements) {
+      this.refreshWidthDependentLayoutMeasurements();
+    }
+
+    if (shouldRender) {
+      this.render();
+    }
   }
 
   observeHeaderResize() {

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -10350,6 +10350,12 @@ class SkylightCalendarCard extends HTMLElement {
     return requiredWidth > (availableWidth + tolerance);
   }
 
+  setClassStateIfChanged(element, className, shouldHaveClass) {
+    if (!element?.classList) return;
+    if (element.classList.contains(className) === shouldHaveClass) return;
+    element.classList.toggle(className, shouldHaveClass);
+  }
+
   measureAndApplyHeaderWrapState() {
     if (!this._root) return;
 
@@ -10357,14 +10363,7 @@ class SkylightCalendarCard extends HTMLElement {
     const controlsSelector = this._config.compact_header ? '.compact-header-controls' : '.header-controls';
     const header = this._root.querySelector(headerSelector);
     const controls = this._root.querySelector(controlsSelector);
-    const compactControls = this._root.querySelector('.compact-header-controls');
-    const standardControls = this._root.querySelector('.header-controls');
     const badges = this._root.querySelector('.calendar-badges-inline');
-
-    header?.classList.remove('is-wrapped');
-    standardControls?.classList.remove('is-wrapped');
-    compactControls?.classList.remove('is-wrapped');
-    badges?.classList.remove('is-wrapped');
 
     if (header) {
       const leftGroup = this._config.compact_header
@@ -10373,15 +10372,18 @@ class SkylightCalendarCard extends HTMLElement {
       const controlsGroup = this._config.compact_header
         ? header.querySelector('.compact-header-controls')
         : header.querySelector('.header-controls');
-      header.classList.toggle('is-wrapped', this.shouldMarkHeaderWrappedFromWidth(header, leftGroup, controlsGroup));
+      const shouldWrapHeader = this.shouldMarkHeaderWrappedFromWidth(header, leftGroup, controlsGroup);
+      this.setClassStateIfChanged(header, 'is-wrapped', shouldWrapHeader);
     }
 
     if (controls) {
-      controls.classList.toggle('is-wrapped', this.shouldMarkGroupWrappedFromWidth(controls));
+      const shouldWrapControls = this.shouldMarkGroupWrappedFromWidth(controls);
+      this.setClassStateIfChanged(controls, 'is-wrapped', shouldWrapControls);
     }
 
     if (this._config.compact_header && badges) {
-      badges.classList.toggle('is-wrapped', this.shouldMarkWrappedFromChildren(Array.from(badges.children)));
+      const shouldWrapBadges = this.shouldMarkWrappedFromChildren(Array.from(badges.children));
+      this.setClassStateIfChanged(badges, 'is-wrapped', shouldWrapBadges);
     }
   }
 
@@ -12030,16 +12032,23 @@ class SkylightCalendarCard extends HTMLElement {
       if (!this.hasObservedHostSizeChanged(nextSize)) return;
 
       this._lastObservedHostSize = nextSize;
+      const needsCompactHeightRender = !!this._config.compact_height;
       if (this._config.compact_height && this._viewMode === 'month' && !this.shouldShowAllEventsInMonth()) {
         this._monthCompactMeasurementDirty = true;
       }
 
-      if (this.isEventManagementDialogOpen()) {
-        this._pendingHostResizeRender = true;
+      if (needsCompactHeightRender) {
+        if (this.isEventManagementDialogOpen()) {
+          this._pendingHostResizeRender = true;
+          return;
+        }
+
+        this.render();
         return;
       }
 
-      this.render();
+      this.updateCompactHeaderWrapState();
+      this.updateCalendarBadgesScrollState();
     });
   }
 

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -10081,6 +10081,7 @@ class SkylightCalendarCard extends HTMLElement {
 
       this.updateCompactHeaderWrapState();
       this.updateCalendarBadgesScrollState();
+      this.refreshWidthDependentLayoutMeasurements();
     };
   }
 
@@ -10339,6 +10340,45 @@ class SkylightCalendarCard extends HTMLElement {
     return requiredWidth > (availableWidth + tolerance);
   }
 
+  getUnwrappedHeaderMeasurementElements(header) {
+    if (!header || typeof header.cloneNode !== 'function') return null;
+
+    const parent = header.parentNode || this._root;
+    if (typeof parent?.appendChild !== 'function') return null;
+
+    const clone = header.cloneNode(true);
+    if (!clone) return null;
+
+    clone.classList?.remove?.('is-wrapped');
+    clone.querySelector?.('.header-controls')?.classList?.remove?.('is-wrapped');
+    clone.querySelector?.('.compact-header-controls')?.classList?.remove?.('is-wrapped');
+    clone.querySelector?.('.calendar-badges-inline')?.classList?.remove?.('is-wrapped');
+
+    if (clone.style) {
+      const width = header.getBoundingClientRect?.().width || header.clientWidth || 0;
+      clone.style.position = 'absolute';
+      clone.style.visibility = 'hidden';
+      clone.style.pointerEvents = 'none';
+      clone.style.left = '-10000px';
+      clone.style.top = '0';
+      clone.style.height = 'auto';
+      clone.style.maxHeight = 'none';
+      clone.style.overflow = 'visible';
+      if (width > 0) clone.style.width = `${width}px`;
+    }
+
+    parent.appendChild(clone);
+    return {
+      clone,
+      leftGroup: this._config.compact_header
+        ? clone.querySelector?.('.compact-header-left')
+        : clone.querySelector?.('.header-left'),
+      controlsGroup: this._config.compact_header
+        ? clone.querySelector?.('.compact-header-controls')
+        : clone.querySelector?.('.header-controls')
+    };
+  }
+
 
   shouldMarkGroupWrappedFromWidth(group) {
     if (!group) return false;
@@ -10366,17 +10406,29 @@ class SkylightCalendarCard extends HTMLElement {
     const badges = this._root.querySelector('.calendar-badges-inline');
 
     if (header) {
-      const leftGroup = this._config.compact_header
+      const liveLeftGroup = this._config.compact_header
         ? header.querySelector('.compact-header-left')
         : header.querySelector('.header-left');
-      const controlsGroup = this._config.compact_header
+      const liveControlsGroup = this._config.compact_header
         ? header.querySelector('.compact-header-controls')
         : header.querySelector('.header-controls');
-      const shouldWrapHeader = this.shouldMarkHeaderWrappedFromWidth(header, leftGroup, controlsGroup);
-      this.setClassStateIfChanged(header, 'is-wrapped', shouldWrapHeader);
-    }
+      const probe = this.getUnwrappedHeaderMeasurementElements(header);
+      let shouldWrapHeader = false;
+      let shouldWrapControls = false;
+      try {
+        const leftGroup = probe?.leftGroup || liveLeftGroup;
+        const controlsGroup = probe?.controlsGroup || liveControlsGroup;
+        shouldWrapHeader = this.shouldMarkHeaderWrappedFromWidth(header, leftGroup, controlsGroup);
+        shouldWrapControls = controls ? this.shouldMarkGroupWrappedFromWidth(probe?.controlsGroup || controls) : false;
+      } finally {
+        probe?.clone?.remove?.();
+      }
 
-    if (controls) {
+      this.setClassStateIfChanged(header, 'is-wrapped', shouldWrapHeader);
+      if (controls) {
+        this.setClassStateIfChanged(controls, 'is-wrapped', shouldWrapControls);
+      }
+    } else if (controls) {
       const shouldWrapControls = this.shouldMarkGroupWrappedFromWidth(controls);
       this.setClassStateIfChanged(controls, 'is-wrapped', shouldWrapControls);
     }
@@ -11853,7 +11905,7 @@ class SkylightCalendarCard extends HTMLElement {
     });
   }
 
-  updateWeekStandardFixedOffsetHeightFromDom() {
+  updateWeekStandardFixedOffsetHeightFromDom({ renderOnChange = true } = {}) {
     if (this._viewMode !== 'week-standard' || !this._root) return;
     if (this.isEventManagementDialogOpen()) return;
 
@@ -11877,7 +11929,9 @@ class SkylightCalendarCard extends HTMLElement {
         this._weekStandardExtraHeaderHeight = 0;
         this._weekStandardHeaderHeight = null;
         this._weekStandardContainerTopInViewport = measuredContainerTop;
-        this.render();
+        container.style.removeProperty('--week-standard-day-header-height');
+        container.style.removeProperty('--week-standard-time-header-spacer-height');
+        if (renderOnChange) this.render();
       }
       return;
     }
@@ -11910,11 +11964,19 @@ class SkylightCalendarCard extends HTMLElement {
       this._weekStandardExtraHeaderHeight = effectiveExtraHeaderHeight;
       this._weekStandardHeaderHeight = effectiveSharedHeaderHeight;
       this._weekStandardContainerTopInViewport = measuredContainerTop;
-      this.render();
+      if (effectiveSharedHeaderHeight === null) {
+        container.style.removeProperty('--week-standard-day-header-height');
+        container.style.removeProperty('--week-standard-time-header-spacer-height');
+      } else {
+        const timeHeaderSpacerHeight = Math.max(60, effectiveSharedHeaderHeight - 35);
+        container.style.setProperty('--week-standard-day-header-height', `${effectiveSharedHeaderHeight}px`);
+        container.style.setProperty('--week-standard-time-header-spacer-height', `${timeHeaderSpacerHeight}px`);
+      }
+      if (renderOnChange) this.render();
     }
   }
 
-  updateWeekCompactStackedHeaderHeightFromDom() {
+  updateWeekCompactStackedHeaderHeightFromDom({ renderOnChange = true } = {}) {
     if (this._viewMode !== 'week-compact' || !this._root) return;
     if (this.isEventManagementDialogOpen()) return;
 
@@ -11928,7 +11990,8 @@ class SkylightCalendarCard extends HTMLElement {
     if (!hasRenderedStackedDayBadges) {
       if (this._weekCompactHeaderHeight !== null) {
         this._weekCompactHeaderHeight = null;
-        this.render();
+        container.style.removeProperty('--week-compact-header-height');
+        if (renderOnChange) this.render();
       }
       return;
     }
@@ -11952,7 +12015,8 @@ class SkylightCalendarCard extends HTMLElement {
     const headerHeightChanged = this._weekCompactHeaderHeight === null || Math.abs(this._weekCompactHeaderHeight - measuredHeaderHeight) > 1;
     if (headerHeightChanged) {
       this._weekCompactHeaderHeight = measuredHeaderHeight;
-      this.render();
+      container.style.setProperty('--week-compact-header-height', `${measuredHeaderHeight}px`);
+      if (renderOnChange) this.render();
     }
   }
 
@@ -12049,7 +12113,16 @@ class SkylightCalendarCard extends HTMLElement {
 
       this.updateCompactHeaderWrapState();
       this.updateCalendarBadgesScrollState();
+      this.refreshWidthDependentLayoutMeasurements();
     });
+  }
+
+  refreshWidthDependentLayoutMeasurements() {
+    if (this._viewMode === 'week-standard') {
+      this.updateWeekStandardFixedOffsetHeightFromDom({ renderOnChange: false });
+    } else if (this._viewMode === 'week-compact') {
+      this.updateWeekCompactStackedHeaderHeightFromDom({ renderOnChange: false });
+    }
   }
 
   flushPendingHostResizeRender() {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -3092,6 +3092,99 @@ test('scheduleHostAndParentResizeHandling renders for compact-height size change
   }
 });
 
+
+test('scheduleHostAndParentResizeHandling refreshes stacked week-compact header height without rendering', () => {
+  const card = makeCard({ entities: ['calendar.a'], default_view: 'week-compact', day_badge_layout_week: 'stacked' });
+  let renderCount = 0;
+  let hostSize = { width: 300, height: 400 };
+  const styleValues = new Map([['--week-compact-header-height', '120px']]);
+  const container = {
+    style: {
+      getPropertyValue: (name) => styleValues.get(name) || '',
+      removeProperty: (name) => styleValues.delete(name),
+      setProperty: (name, value) => styleValues.set(name, value)
+    }
+  };
+  const header = makeMeasuredDayHeader({ headerHeight: 84, badgeHeight: 20 });
+  const originalRequestAnimationFrame = window.requestAnimationFrame;
+
+  try {
+    window.requestAnimationFrame = (callback) => { callback(); return 1; };
+    card.render = () => { renderCount += 1; };
+    card.updateCompactHeaderWrapState = () => {};
+    card.updateCalendarBadgesScrollState = () => {};
+    card.isEventManagementDialogOpen = () => false;
+    card._viewMode = 'week-compact';
+    card._weekCompactHeaderHeight = 120;
+    card._root = {
+      querySelector: (selector) => selector === '.week-compact-container' ? container : null,
+      querySelectorAll: (selector) => selector === '.week-day-header' ? [header] : []
+    };
+    card.getBoundingClientRect = () => ({ width: hostSize.width, height: hostSize.height });
+    card.parentElement = { getBoundingClientRect: () => ({ width: 320, height: 480 }) };
+    card._lastObservedHostSize = card.measureHostAndParentSize();
+
+    hostSize = { width: 360, height: 400 };
+    card.scheduleHostAndParentResizeHandling();
+
+    assert.equal(renderCount, 0);
+    assert.equal(card._weekCompactHeaderHeight, 84);
+    assert.equal(styleValues.get('--week-compact-header-height'), '84px');
+  } finally {
+    window.requestAnimationFrame = originalRequestAnimationFrame;
+  }
+});
+
+test('scheduleHostAndParentResizeHandling refreshes stacked week-standard header height without rendering', () => {
+  const card = makeCard({ entities: ['calendar.a'], default_view: 'week-standard', day_badge_layout_week: 'stacked' });
+  let renderCount = 0;
+  let hostSize = { width: 300, height: 400 };
+  const styleValues = new Map([
+    ['--week-standard-day-header-height', '120px'],
+    ['--week-standard-time-header-spacer-height', '85px']
+  ]);
+  const container = {
+    style: {
+      getPropertyValue: (name) => styleValues.get(name) || '',
+      removeProperty: (name) => styleValues.delete(name),
+      setProperty: (name, value) => styleValues.set(name, value)
+    },
+    getBoundingClientRect: () => ({ top: 24 })
+  };
+  const header = makeMeasuredDayHeader({ headerHeight: 90, badgeHeight: 20 });
+  const originalRequestAnimationFrame = window.requestAnimationFrame;
+
+  try {
+    window.requestAnimationFrame = (callback) => { callback(); return 1; };
+    card.render = () => { renderCount += 1; };
+    card.updateCompactHeaderWrapState = () => {};
+    card.updateCalendarBadgesScrollState = () => {};
+    card.isEventManagementDialogOpen = () => false;
+    card._viewMode = 'week-standard';
+    card._weekStandardHeaderHeight = 120;
+    card._weekStandardExtraHeaderHeight = 60;
+    card._weekStandardContainerTopInViewport = 24;
+    card._root = {
+      querySelector: (selector) => selector === '.week-standard-container' ? container : null,
+      querySelectorAll: (selector) => selector === '.week-standard-day-header' ? [header] : []
+    };
+    card.getBoundingClientRect = () => ({ width: hostSize.width, height: hostSize.height });
+    card.parentElement = { getBoundingClientRect: () => ({ width: 320, height: 480 }) };
+    card._lastObservedHostSize = card.measureHostAndParentSize();
+
+    hostSize = { width: 360, height: 400 };
+    card.scheduleHostAndParentResizeHandling();
+
+    assert.equal(renderCount, 0);
+    assert.equal(card._weekStandardHeaderHeight, 90);
+    assert.equal(card._weekStandardExtraHeaderHeight, 30);
+    assert.equal(styleValues.get('--week-standard-day-header-height'), '90px');
+    assert.equal(styleValues.get('--week-standard-time-header-spacer-height'), '60px');
+  } finally {
+    window.requestAnimationFrame = originalRequestAnimationFrame;
+  }
+});
+
 test('disconnectedCallback disconnects host ResizeObserver', () => {
   const card = makeCard({ entities: ['calendar.a'] });
   let disconnectCount = 0;
@@ -3549,6 +3642,79 @@ test('measureAndApplyHeaderWrapState does not mutate classes when measured state
   assert.deepEqual(header.classList.toggles, []);
   assert.deepEqual(controls.classList.toggles, []);
   assert.deepEqual(badges.classList.toggles, []);
+});
+
+
+test('measureAndApplyHeaderWrapState uses unwrapped probe to remove stale compact wrapping when width grows', () => {
+  const card = makeCard({ entities: ['calendar.a'], compact_header: true });
+  const makeClassList = (initial = []) => ({
+    _set: new Set(initial),
+    contains(name) { return this._set.has(name); },
+    add(name) { this._set.add(name); },
+    remove(name) { this._set.delete(name); },
+    toggle(name, force) { if (force) this._set.add(name); else this._set.delete(name); }
+  });
+  const makeGroup = (naturalWidth, wrappedWidth, classes = []) => ({
+    naturalWidth,
+    wrappedWidth,
+    classList: makeClassList(classes),
+    children: []
+  });
+  const liveLeft = makeGroup(300, 300);
+  const liveControls = makeGroup(300, 500, ['is-wrapped']);
+  const cloneLeft = makeGroup(300, 300);
+  const cloneControls = makeGroup(300, 300, ['is-wrapped']);
+  const badges = { classList: makeClassList(['is-wrapped']), children: [] };
+  let appendedClone = null;
+  const clone = {
+    style: {},
+    classList: makeClassList(['is-wrapped']),
+    querySelector(selector) {
+      if (selector === '.compact-header-left') return cloneLeft;
+      if (selector === '.compact-header-controls') return cloneControls;
+      return null;
+    },
+    remove() { appendedClone = null; }
+  };
+  const header = {
+    clientWidth: 700,
+    style: {},
+    classList: makeClassList(['is-wrapped']),
+    parentNode: { appendChild(node) { appendedClone = node; } },
+    getBoundingClientRect: () => ({ width: 700 }),
+    cloneNode: () => clone,
+    querySelector(selector) {
+      if (selector === '.compact-header-left') return liveLeft;
+      if (selector === '.compact-header-controls') return liveControls;
+      return null;
+    }
+  };
+  card._root = {
+    querySelector(selector) {
+      if (selector === '.header-compact') return header;
+      if (selector === '.compact-header-controls') return liveControls;
+      if (selector === '.calendar-badges-inline') return badges;
+      return null;
+    }
+  };
+
+  const originalMeasure = card.measureNaturalGroupWidth;
+  const originalGetComputedStyle = window.getComputedStyle;
+  try {
+    card.measureNaturalGroupWidth = (group) => group.naturalWidth;
+    window.getComputedStyle = () => ({ columnGap: '16px', gap: '16px', paddingLeft: '0px', paddingRight: '0px' });
+
+    card.measureAndApplyHeaderWrapState();
+
+    assert.equal(header.classList.contains('is-wrapped'), false);
+    assert.equal(liveControls.classList.contains('is-wrapped'), false);
+    assert.equal(appendedClone, null);
+    assert.equal(clone.classList.contains('is-wrapped'), false);
+    assert.equal(cloneControls.classList.contains('is-wrapped'), false);
+  } finally {
+    card.measureNaturalGroupWidth = originalMeasure;
+    window.getComputedStyle = originalGetComputedStyle;
+  }
 });
 
 test('measureAndApplyHeaderWrapState reaches stable compact wrapped and unwrapped states', () => {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -3185,6 +3185,63 @@ test('scheduleHostAndParentResizeHandling refreshes stacked week-standard header
   }
 });
 
+
+test('scheduleHostAndParentResizeHandling defers stacked week header refresh while modal is open', () => {
+  const card = makeCard({ entities: ['calendar.a'], default_view: 'week-compact', day_badge_layout_week: 'stacked' });
+  let renderCount = 0;
+  let hostSize = { width: 300, height: 400 };
+  const modalClasses = new Set(['show']);
+  const modal = { classList: { contains: (name) => modalClasses.has(name) } };
+  const styleValues = new Map([['--week-compact-header-height', '120px']]);
+  const container = {
+    style: {
+      getPropertyValue: (name) => styleValues.get(name) || '',
+      removeProperty: (name) => styleValues.delete(name),
+      setProperty: (name, value) => styleValues.set(name, value)
+    }
+  };
+  const header = makeMeasuredDayHeader({ headerHeight: 84, badgeHeight: 20 });
+  const originalRequestAnimationFrame = window.requestAnimationFrame;
+
+  try {
+    window.requestAnimationFrame = (callback) => { callback(); return 1; };
+    card.render = () => { renderCount += 1; };
+    card.updateCompactHeaderWrapState = () => {};
+    card.updateCalendarBadgesScrollState = () => {};
+    card._viewMode = 'week-compact';
+    card._weekCompactHeaderHeight = 120;
+    card._root = {
+      querySelector(selector) {
+        if (selector === '#event-modal') return modal;
+        if (selector === '.week-compact-container') return container;
+        return null;
+      },
+      querySelectorAll: (selector) => selector === '.week-day-header' ? [header] : []
+    };
+    card.getBoundingClientRect = () => ({ width: hostSize.width, height: hostSize.height });
+    card.parentElement = { getBoundingClientRect: () => ({ width: 320, height: 480 }) };
+    card._lastObservedHostSize = card.measureHostAndParentSize();
+
+    hostSize = { width: 360, height: 400 };
+    card.scheduleHostAndParentResizeHandling();
+
+    assert.equal(renderCount, 0);
+    assert.equal(card._pendingWidthDependentLayoutRefresh, true);
+    assert.equal(card._weekCompactHeaderHeight, 120);
+    assert.equal(styleValues.get('--week-compact-header-height'), '120px');
+
+    modalClasses.delete('show');
+    card.updateEventModalOpenState(modal);
+
+    assert.equal(renderCount, 0);
+    assert.equal(card._pendingWidthDependentLayoutRefresh, false);
+    assert.equal(card._weekCompactHeaderHeight, 84);
+    assert.equal(styleValues.get('--week-compact-header-height'), '84px');
+  } finally {
+    window.requestAnimationFrame = originalRequestAnimationFrame;
+  }
+});
+
 test('disconnectedCallback disconnects host ResizeObserver', () => {
   const card = makeCard({ entities: ['calendar.a'] });
   let disconnectCount = 0;

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -3032,8 +3032,41 @@ test('scheduleHostAndParentResizeHandling defers host resize render while event 
   }
 });
 
-test('scheduleHostAndParentResizeHandling renders immediately when event modal is closed', () => {
+test('scheduleHostAndParentResizeHandling updates header state without rendering for ordinary size changes', () => {
   const card = makeCard({ entities: ['calendar.a'] });
+  let renderCount = 0;
+  let hostSize = { width: 300, height: 400 };
+  const originalRequestAnimationFrame = window.requestAnimationFrame;
+
+  try {
+    window.requestAnimationFrame = (callback) => {
+      callback();
+      return 1;
+    };
+    let wrapUpdateCount = 0;
+    let badgeUpdateCount = 0;
+    card.render = () => { renderCount += 1; };
+    card.updateCompactHeaderWrapState = () => { wrapUpdateCount += 1; };
+    card.updateCalendarBadgesScrollState = () => { badgeUpdateCount += 1; };
+    card.isEventManagementDialogOpen = () => false;
+    card.getBoundingClientRect = () => ({ width: hostSize.width, height: hostSize.height });
+    card.parentElement = { getBoundingClientRect: () => ({ width: 320, height: 480 }) };
+    card._lastObservedHostSize = card.measureHostAndParentSize();
+
+    hostSize = { width: 340, height: 400 };
+    card.scheduleHostAndParentResizeHandling();
+
+    assert.equal(renderCount, 0);
+    assert.equal(wrapUpdateCount, 1);
+    assert.equal(badgeUpdateCount, 1);
+    assert.equal(card._pendingHostResizeRender, false);
+  } finally {
+    window.requestAnimationFrame = originalRequestAnimationFrame;
+  }
+});
+
+test('scheduleHostAndParentResizeHandling renders for compact-height size changes', () => {
+  const card = makeCard({ entities: ['calendar.a'], compact_height: true });
   let renderCount = 0;
   let hostSize = { width: 300, height: 400 };
   const originalRequestAnimationFrame = window.requestAnimationFrame;
@@ -3428,11 +3461,11 @@ test('updateCompactHeaderWrapState keeps header single-row after delayed updates
   const controls = {
     scrollWidth: 400,
     children: [{ offsetParent: {}, offsetTop: 20 }, { offsetParent: {}, offsetTop: 20 }],
-    classList: { remove() {}, toggle() {} }
+    classList: { remove() {}, toggle() {}, contains() { return false; } }
   };
   Object.defineProperty(header, 'clientWidth', { configurable: true, value: 1000 });
 
-  const badges = { children: [], classList: { remove() {}, toggle() {} } };
+  const badges = { children: [], classList: { remove() {}, toggle() {}, contains() { return false; } } };
   card._root = {
     querySelector(sel) {
       if (sel === '.header-compact') return header;
@@ -3472,6 +3505,97 @@ test('updateCompactHeaderWrapState keeps header single-row after delayed updates
     window.getComputedStyle = originalGetComputedStyle;
     card.measureNaturalGroupWidth = originalMeasure;
   }
+});
+
+
+test('measureAndApplyHeaderWrapState does not mutate classes when measured state is unchanged', () => {
+  const card = makeCard({ entities: ['calendar.a'], compact_header: true });
+  const makeClassList = (initial = []) => ({
+    _set: new Set(initial),
+    toggles: [],
+    removes: [],
+    contains(name) { return this._set.has(name); },
+    toggle(name, force) { this.toggles.push([name, force]); if (force) this._set.add(name); else this._set.delete(name); },
+    remove(name) { this.removes.push(name); this._set.delete(name); }
+  });
+  const left = { classList: makeClassList(), children: [] };
+  const controls = { classList: makeClassList(['is-wrapped']), children: [] };
+  const badges = { classList: makeClassList(['is-wrapped']), children: [{ offsetParent: {}, offsetTop: 0 }, { offsetParent: {}, offsetTop: 3 }] };
+  const header = {
+    classList: makeClassList(['is-wrapped']),
+    querySelector(selector) {
+      if (selector === '.compact-header-left') return left;
+      if (selector === '.compact-header-controls') return controls;
+      return null;
+    }
+  };
+  card._root = {
+    querySelector(selector) {
+      if (selector === '.header-compact') return header;
+      if (selector === '.compact-header-controls') return controls;
+      if (selector === '.calendar-badges-inline') return badges;
+      return null;
+    }
+  };
+  card.shouldMarkHeaderWrappedFromWidth = () => true;
+  card.shouldMarkGroupWrappedFromWidth = () => true;
+
+  card.measureAndApplyHeaderWrapState();
+  card.measureAndApplyHeaderWrapState();
+
+  assert.deepEqual(header.classList.removes, []);
+  assert.deepEqual(controls.classList.removes, []);
+  assert.deepEqual(badges.classList.removes, []);
+  assert.deepEqual(header.classList.toggles, []);
+  assert.deepEqual(controls.classList.toggles, []);
+  assert.deepEqual(badges.classList.toggles, []);
+});
+
+test('measureAndApplyHeaderWrapState reaches stable compact wrapped and unwrapped states', () => {
+  const card = makeCard({ entities: ['calendar.a'], compact_header: true });
+  const makeClassList = () => ({
+    _set: new Set(),
+    toggleCount: 0,
+    contains(name) { return this._set.has(name); },
+    toggle(name, force) { this.toggleCount += 1; if (force) this._set.add(name); else this._set.delete(name); }
+  });
+  const left = {};
+  const controls = { classList: makeClassList(), children: [] };
+  const badges = { classList: makeClassList(), children: [] };
+  const header = {
+    classList: makeClassList(),
+    querySelector(selector) {
+      if (selector === '.compact-header-left') return left;
+      if (selector === '.compact-header-controls') return controls;
+      return null;
+    }
+  };
+  let shouldWrap = true;
+  card._root = {
+    querySelector(selector) {
+      if (selector === '.header-compact') return header;
+      if (selector === '.compact-header-controls') return controls;
+      if (selector === '.calendar-badges-inline') return badges;
+      return null;
+    }
+  };
+  card.shouldMarkHeaderWrappedFromWidth = () => shouldWrap;
+  card.shouldMarkGroupWrappedFromWidth = () => shouldWrap;
+
+  card.measureAndApplyHeaderWrapState();
+  card.measureAndApplyHeaderWrapState();
+  assert.equal(header.classList.contains('is-wrapped'), true);
+  assert.equal(controls.classList.contains('is-wrapped'), true);
+  assert.equal(header.classList.toggleCount, 1);
+  assert.equal(controls.classList.toggleCount, 1);
+
+  shouldWrap = false;
+  card.measureAndApplyHeaderWrapState();
+  card.measureAndApplyHeaderWrapState();
+  assert.equal(header.classList.contains('is-wrapped'), false);
+  assert.equal(controls.classList.contains('is-wrapped'), false);
+  assert.equal(header.classList.toggleCount, 2);
+  assert.equal(controls.classList.toggleCount, 2);
 });
 
 test('repeated updateCompactHeaderWrapState calls cancel previous pending RAFs', () => {

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -443,6 +443,7 @@ class SkylightCalendarCard extends HTMLElement {
 
       this.updateCompactHeaderWrapState();
       this.updateCalendarBadgesScrollState();
+      this.refreshWidthDependentLayoutMeasurements();
     };
   }
 
@@ -701,6 +702,45 @@ class SkylightCalendarCard extends HTMLElement {
     return requiredWidth > (availableWidth + tolerance);
   }
 
+  getUnwrappedHeaderMeasurementElements(header) {
+    if (!header || typeof header.cloneNode !== 'function') return null;
+
+    const parent = header.parentNode || this._root;
+    if (typeof parent?.appendChild !== 'function') return null;
+
+    const clone = header.cloneNode(true);
+    if (!clone) return null;
+
+    clone.classList?.remove?.('is-wrapped');
+    clone.querySelector?.('.header-controls')?.classList?.remove?.('is-wrapped');
+    clone.querySelector?.('.compact-header-controls')?.classList?.remove?.('is-wrapped');
+    clone.querySelector?.('.calendar-badges-inline')?.classList?.remove?.('is-wrapped');
+
+    if (clone.style) {
+      const width = header.getBoundingClientRect?.().width || header.clientWidth || 0;
+      clone.style.position = 'absolute';
+      clone.style.visibility = 'hidden';
+      clone.style.pointerEvents = 'none';
+      clone.style.left = '-10000px';
+      clone.style.top = '0';
+      clone.style.height = 'auto';
+      clone.style.maxHeight = 'none';
+      clone.style.overflow = 'visible';
+      if (width > 0) clone.style.width = `${width}px`;
+    }
+
+    parent.appendChild(clone);
+    return {
+      clone,
+      leftGroup: this._config.compact_header
+        ? clone.querySelector?.('.compact-header-left')
+        : clone.querySelector?.('.header-left'),
+      controlsGroup: this._config.compact_header
+        ? clone.querySelector?.('.compact-header-controls')
+        : clone.querySelector?.('.header-controls')
+    };
+  }
+
 
   shouldMarkGroupWrappedFromWidth(group) {
     if (!group) return false;
@@ -728,17 +768,29 @@ class SkylightCalendarCard extends HTMLElement {
     const badges = this._root.querySelector('.calendar-badges-inline');
 
     if (header) {
-      const leftGroup = this._config.compact_header
+      const liveLeftGroup = this._config.compact_header
         ? header.querySelector('.compact-header-left')
         : header.querySelector('.header-left');
-      const controlsGroup = this._config.compact_header
+      const liveControlsGroup = this._config.compact_header
         ? header.querySelector('.compact-header-controls')
         : header.querySelector('.header-controls');
-      const shouldWrapHeader = this.shouldMarkHeaderWrappedFromWidth(header, leftGroup, controlsGroup);
-      this.setClassStateIfChanged(header, 'is-wrapped', shouldWrapHeader);
-    }
+      const probe = this.getUnwrappedHeaderMeasurementElements(header);
+      let shouldWrapHeader = false;
+      let shouldWrapControls = false;
+      try {
+        const leftGroup = probe?.leftGroup || liveLeftGroup;
+        const controlsGroup = probe?.controlsGroup || liveControlsGroup;
+        shouldWrapHeader = this.shouldMarkHeaderWrappedFromWidth(header, leftGroup, controlsGroup);
+        shouldWrapControls = controls ? this.shouldMarkGroupWrappedFromWidth(probe?.controlsGroup || controls) : false;
+      } finally {
+        probe?.clone?.remove?.();
+      }
 
-    if (controls) {
+      this.setClassStateIfChanged(header, 'is-wrapped', shouldWrapHeader);
+      if (controls) {
+        this.setClassStateIfChanged(controls, 'is-wrapped', shouldWrapControls);
+      }
+    } else if (controls) {
       const shouldWrapControls = this.shouldMarkGroupWrappedFromWidth(controls);
       this.setClassStateIfChanged(controls, 'is-wrapped', shouldWrapControls);
     }
@@ -2215,7 +2267,7 @@ class SkylightCalendarCard extends HTMLElement {
     });
   }
 
-  updateWeekStandardFixedOffsetHeightFromDom() {
+  updateWeekStandardFixedOffsetHeightFromDom({ renderOnChange = true } = {}) {
     if (this._viewMode !== 'week-standard' || !this._root) return;
     if (this.isEventManagementDialogOpen()) return;
 
@@ -2239,7 +2291,9 @@ class SkylightCalendarCard extends HTMLElement {
         this._weekStandardExtraHeaderHeight = 0;
         this._weekStandardHeaderHeight = null;
         this._weekStandardContainerTopInViewport = measuredContainerTop;
-        this.render();
+        container.style.removeProperty('--week-standard-day-header-height');
+        container.style.removeProperty('--week-standard-time-header-spacer-height');
+        if (renderOnChange) this.render();
       }
       return;
     }
@@ -2272,11 +2326,19 @@ class SkylightCalendarCard extends HTMLElement {
       this._weekStandardExtraHeaderHeight = effectiveExtraHeaderHeight;
       this._weekStandardHeaderHeight = effectiveSharedHeaderHeight;
       this._weekStandardContainerTopInViewport = measuredContainerTop;
-      this.render();
+      if (effectiveSharedHeaderHeight === null) {
+        container.style.removeProperty('--week-standard-day-header-height');
+        container.style.removeProperty('--week-standard-time-header-spacer-height');
+      } else {
+        const timeHeaderSpacerHeight = Math.max(60, effectiveSharedHeaderHeight - 35);
+        container.style.setProperty('--week-standard-day-header-height', `${effectiveSharedHeaderHeight}px`);
+        container.style.setProperty('--week-standard-time-header-spacer-height', `${timeHeaderSpacerHeight}px`);
+      }
+      if (renderOnChange) this.render();
     }
   }
 
-  updateWeekCompactStackedHeaderHeightFromDom() {
+  updateWeekCompactStackedHeaderHeightFromDom({ renderOnChange = true } = {}) {
     if (this._viewMode !== 'week-compact' || !this._root) return;
     if (this.isEventManagementDialogOpen()) return;
 
@@ -2290,7 +2352,8 @@ class SkylightCalendarCard extends HTMLElement {
     if (!hasRenderedStackedDayBadges) {
       if (this._weekCompactHeaderHeight !== null) {
         this._weekCompactHeaderHeight = null;
-        this.render();
+        container.style.removeProperty('--week-compact-header-height');
+        if (renderOnChange) this.render();
       }
       return;
     }
@@ -2314,7 +2377,8 @@ class SkylightCalendarCard extends HTMLElement {
     const headerHeightChanged = this._weekCompactHeaderHeight === null || Math.abs(this._weekCompactHeaderHeight - measuredHeaderHeight) > 1;
     if (headerHeightChanged) {
       this._weekCompactHeaderHeight = measuredHeaderHeight;
-      this.render();
+      container.style.setProperty('--week-compact-header-height', `${measuredHeaderHeight}px`);
+      if (renderOnChange) this.render();
     }
   }
 
@@ -2411,7 +2475,16 @@ class SkylightCalendarCard extends HTMLElement {
 
       this.updateCompactHeaderWrapState();
       this.updateCalendarBadgesScrollState();
+      this.refreshWidthDependentLayoutMeasurements();
     });
+  }
+
+  refreshWidthDependentLayoutMeasurements() {
+    if (this._viewMode === 'week-standard') {
+      this.updateWeekStandardFixedOffsetHeightFromDom({ renderOnChange: false });
+    } else if (this._viewMode === 'week-compact') {
+      this.updateWeekCompactStackedHeaderHeightFromDom({ renderOnChange: false });
+    }
   }
 
   flushPendingHostResizeRender() {

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -712,6 +712,12 @@ class SkylightCalendarCard extends HTMLElement {
     return requiredWidth > (availableWidth + tolerance);
   }
 
+  setClassStateIfChanged(element, className, shouldHaveClass) {
+    if (!element?.classList) return;
+    if (element.classList.contains(className) === shouldHaveClass) return;
+    element.classList.toggle(className, shouldHaveClass);
+  }
+
   measureAndApplyHeaderWrapState() {
     if (!this._root) return;
 
@@ -719,14 +725,7 @@ class SkylightCalendarCard extends HTMLElement {
     const controlsSelector = this._config.compact_header ? '.compact-header-controls' : '.header-controls';
     const header = this._root.querySelector(headerSelector);
     const controls = this._root.querySelector(controlsSelector);
-    const compactControls = this._root.querySelector('.compact-header-controls');
-    const standardControls = this._root.querySelector('.header-controls');
     const badges = this._root.querySelector('.calendar-badges-inline');
-
-    header?.classList.remove('is-wrapped');
-    standardControls?.classList.remove('is-wrapped');
-    compactControls?.classList.remove('is-wrapped');
-    badges?.classList.remove('is-wrapped');
 
     if (header) {
       const leftGroup = this._config.compact_header
@@ -735,15 +734,18 @@ class SkylightCalendarCard extends HTMLElement {
       const controlsGroup = this._config.compact_header
         ? header.querySelector('.compact-header-controls')
         : header.querySelector('.header-controls');
-      header.classList.toggle('is-wrapped', this.shouldMarkHeaderWrappedFromWidth(header, leftGroup, controlsGroup));
+      const shouldWrapHeader = this.shouldMarkHeaderWrappedFromWidth(header, leftGroup, controlsGroup);
+      this.setClassStateIfChanged(header, 'is-wrapped', shouldWrapHeader);
     }
 
     if (controls) {
-      controls.classList.toggle('is-wrapped', this.shouldMarkGroupWrappedFromWidth(controls));
+      const shouldWrapControls = this.shouldMarkGroupWrappedFromWidth(controls);
+      this.setClassStateIfChanged(controls, 'is-wrapped', shouldWrapControls);
     }
 
     if (this._config.compact_header && badges) {
-      badges.classList.toggle('is-wrapped', this.shouldMarkWrappedFromChildren(Array.from(badges.children)));
+      const shouldWrapBadges = this.shouldMarkWrappedFromChildren(Array.from(badges.children));
+      this.setClassStateIfChanged(badges, 'is-wrapped', shouldWrapBadges);
     }
   }
 
@@ -2392,16 +2394,23 @@ class SkylightCalendarCard extends HTMLElement {
       if (!this.hasObservedHostSizeChanged(nextSize)) return;
 
       this._lastObservedHostSize = nextSize;
+      const needsCompactHeightRender = !!this._config.compact_height;
       if (this._config.compact_height && this._viewMode === 'month' && !this.shouldShowAllEventsInMonth()) {
         this._monthCompactMeasurementDirty = true;
       }
 
-      if (this.isEventManagementDialogOpen()) {
-        this._pendingHostResizeRender = true;
+      if (needsCompactHeightRender) {
+        if (this.isEventManagementDialogOpen()) {
+          this._pendingHostResizeRender = true;
+          return;
+        }
+
+        this.render();
         return;
       }
 
-      this.render();
+      this.updateCompactHeaderWrapState();
+      this.updateCalendarBadgesScrollState();
     });
   }
 

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -421,6 +421,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._hostResizeObserver = null;
     this._hostResizeRaf = null;
     this._pendingHostResizeRender = false;
+    this._pendingWidthDependentLayoutRefresh = false;
     this._observedResizeParent = null;
     this._lastObservedHostSize = null;
     this._monthCompactMeasurementDirty = true;
@@ -2473,10 +2474,20 @@ class SkylightCalendarCard extends HTMLElement {
         return;
       }
 
+      if (this.isEventManagementDialogOpen() && this.hasWidthDependentMeasuredLayoutState()) {
+        this._pendingWidthDependentLayoutRefresh = true;
+        return;
+      }
+
       this.updateCompactHeaderWrapState();
       this.updateCalendarBadgesScrollState();
       this.refreshWidthDependentLayoutMeasurements();
     });
+  }
+
+  hasWidthDependentMeasuredLayoutState() {
+    return this._config?.day_badge_layout_week === 'stacked'
+      && (this._viewMode === 'week-standard' || this._viewMode === 'week-compact');
   }
 
   refreshWidthDependentLayoutMeasurements() {
@@ -2488,9 +2499,18 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   flushPendingHostResizeRender() {
-    if (!this._pendingHostResizeRender) return;
+    const shouldRender = this._pendingHostResizeRender;
+    const shouldRefreshWidthMeasurements = this._pendingWidthDependentLayoutRefresh;
     this._pendingHostResizeRender = false;
-    this.render();
+    this._pendingWidthDependentLayoutRefresh = false;
+
+    if (shouldRefreshWidthMeasurements) {
+      this.refreshWidthDependentLayoutMeasurements();
+    }
+
+    if (shouldRender) {
+      this.render();
+    }
   }
 
   observeHeaderResize() {


### PR DESCRIPTION
### Motivation
- Prevent a layout recalculation/render loop that caused the card to vibrate at narrow/mobile widths while preserving measurement-based header wrapping and `compact_header` behavior. 
- Avoid mutating the live DOM during width measurements so ResizeObserver/RAF callbacks do not trigger repeated full renders.

### Description
- Refactored `measureAndApplyHeaderWrapState()` so it computes desired `is-wrapped` states first and only mutates `classList` when the current state differs, adding a small helper `setClassStateIfChanged()` to centralize that logic. 
- Removed the previous unconditional `is-wrapped` removals that temporarily unwrapped the live header/controls/badges during measurement and replaced them with idempotent class updates based on measured widths and child positions. 
- Changed `scheduleHostAndParentResizeHandling()` to avoid calling `render()` for ordinary host/parent width changes; it now calls `updateCompactHeaderWrapState()` and `updateCalendarBadgesScrollState()` in-place and only performs a full `render()` when `compact_height` layout actually requires a height-dependent recalculation. 
- Added unit tests that assert idempotent wrap behavior, stable wrapped/unwrapped transitions, and that ordinary non-compact-height resizes update header/badge state without forcing a full render, and regenerated the shipped artifact.

### Testing
- Ran `npm run build` and regenerated `skylight-calendar-card.js` successfully. 
- Ran `node --check` on `src/skylight-calendar-card.js`, `skylight-calendar-card.js`, and test files, and all checks passed. 
- Ran the full test suite with `npm test`, including the new regression tests, and all tests passed. 
- Verified the added unit tests specifically cover: measurement-based wrap decision, repeated-call idempotence, stable wrap/unwrap transitions, and resize-path behavior that avoids unnecessary `render()` calls.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f3e648b048331bde7210dd1c07b11)