### PR TITLE
Bump card version to v4.6.0

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -570,7 +570,7 @@ function getEntityRenderSignature(hass, entityIds = []) {
   }));
 }
 
-const DAYLIGHT_CALENDAR_CARD_VERSION = 'v4.5.0';
+const DAYLIGHT_CALENDAR_CARD_VERSION = 'v4.6.0';
 
 function getDaylightCalendarCardVersion() {
   return DAYLIGHT_CALENDAR_CARD_VERSION.includes('__')

--- a/src/version.js
+++ b/src/version.js
@@ -1,4 +1,4 @@
-export const DAYLIGHT_CALENDAR_CARD_VERSION = 'v4.5.0';
+export const DAYLIGHT_CALENDAR_CARD_VERSION = 'v4.6.0';
 
 export function getDaylightCalendarCardVersion() {
   return DAYLIGHT_CALENDAR_CARD_VERSION.includes('__')


### PR DESCRIPTION
## Summary
- Update the Daylight Calendar Card version constant from `v4.5.0` to `v4.6.0` in `src/version.js` and regenerate the shipped artifact so `skylight-calendar-card.js` also reports `v4.6.0`.
- Commit the regenerated artifact alongside the source change.

## Tests
- Ran `npm run build` which regenerated `skylight-calendar-card.js` and completed successfully.
- Ran `node --check src/version.js` and `node --check skylight-calendar-card.js`, both succeeded.
- Ran `npm test`, all automated tests passed (269 tests, 0 failures).

## Generated artifact
- `skylight-calendar-card.js` was rebuilt from `src/` and now contains `DAYLIGHT_CALENDAR_CARD_VERSION = 'v4.6.0'`.

## Notes / risks
- This change only updates the version string and the built artifact; no runtime or visual behavior was modified.
- The regenerated `skylight-calendar-card.js` was committed with the source change to keep the shipped artifact in sync.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f66e2aeb08331b8fc9fefc5a6f1c3)