### PR TITLE
Render continuous multi-day all-day event spans in schedule view with styles and tests

### DIFF
--- a/playwright/visual.spec.js
+++ b/playwright/visual.spec.js
@@ -103,6 +103,20 @@ const stackedDayBadgeEvents = {
   ]
 };
 
+const scheduleSpanEvents = {
+  'calendar.family': [
+    { summary: 'Classic Span', start: '2026-03-15', end: '2026-03-18' },
+    { summary: 'Tint Span', start: '2026-03-16', end: '2026-03-19' },
+    { summary: 'Neutral Span', start: '2026-03-17', end: '2026-03-20' },
+    { summary: 'Combined Stripes Span', start: '2026-03-18', end: '2026-03-21' },
+    { summary: 'Combined Bars Span', start: '2026-03-19', end: '2026-03-22' }
+  ],
+  'calendar.work': [
+    { summary: 'Combined Stripes Span', start: '2026-03-18', end: '2026-03-21' },
+    { summary: 'Combined Bars Span', start: '2026-03-19', end: '2026-03-22' }
+  ]
+};
+
 const stackedDayBadgeConfig = {
   day_badge_layout_week: 'stacked',
   day_badges: [
@@ -212,6 +226,32 @@ const cases = [
     }
   },
   { name: 'event-left-tint-schedule', config: { default_view: 'schedule', event_color_mode: 'left-tint', event_tint_opacity: 100, event_color_bar_width: 18, colors: defaultColors }, darkMode: false, events: baseEvents, viewLabel: 'Schedule' },
+  {
+    name: 'schedule-all-day-continuous-spans',
+    config: {
+      default_view: 'schedule',
+      combine_calendars: true,
+      combine_style: 'stripes',
+      combine_background: '#d7ebff',
+      colors: defaultColors,
+      event_styles: [
+        { match: { title: 'Tint Span' }, style: { background_color: '#e0f2fe', event_font_color: '#075985', icon: 'mdi:water' } },
+        { match: { title: 'Neutral Span' }, style: { background_color: '#f8f3e9', event_font_color: '#7c2d12', icon: 'mdi:minus' } },
+        { match: { title: 'Combined Bars Span' }, style: { background_color: '#fef3c7', event_font_color: '#78350f', icon: 'mdi:format-list-bulleted' } }
+      ]
+    },
+    darkMode: false,
+    events: scheduleSpanEvents,
+    viewLabel: 'Schedule',
+    assert: async (card) => {
+      await expect(card.locator('.all-day-event').filter({ hasText: 'Classic Span' })).toHaveCount(1);
+      await expect(card.locator('.all-day-event').filter({ hasText: 'Tint Span' })).toHaveCount(1);
+      await expect(card.locator('.all-day-event').filter({ hasText: 'Neutral Span' })).toHaveCount(1);
+      await expect(card.locator('.all-day-event').filter({ hasText: 'Combined Stripes Span' })).toHaveCount(1);
+      await expect(card.locator('.all-day-event').filter({ hasText: 'Combined Bars Span' })).toHaveCount(1);
+      expect(await card.locator('.all-day-event-span-placeholder').count()).toBeGreaterThan(5);
+    }
+  },
   { name: 'virtual-calendars', config: { default_view: 'schedule', virtual_calendars: [{ name: 'home+work', icon: 'mdi:calendar', entities: ['calendar.family', 'calendar.work'] }] }, darkMode: false, events: baseEvents, viewLabel: 'Schedule' },
   {
     name: 'styled-events-days',

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -4358,6 +4358,12 @@ function getCardStyles() {
         z-index: 2;
       }
 
+      .all-day-event[data-all-day-span-days] {
+        width: calc((100% * var(--all-day-visible-span, 1)) + ((var(--week-standard-column-gap) + var(--week-standard-bridge-overlap)) * var(--all-day-title-gap-count, 0)));
+        max-width: none;
+        z-index: 2;
+      }
+
       .all-day-event-title {
         font-weight: 600;
         overflow: hidden;
@@ -4371,12 +4377,10 @@ function getCardStyles() {
       }
 
       .all-day-event-title.spans-multiple-days {
-        position: absolute;
-        top: 50%;
-        left: calc(8px + var(--combine-left-offset, 0px));
-        transform: translateY(-50%);
-        width: calc(((100% * var(--all-day-title-span-days, 1)) + ((var(--week-standard-column-gap) + var(--week-standard-bridge-overlap)) * var(--all-day-title-gap-count, 0))) - (24px + var(--combine-left-offset, 0px)));
-        max-width: calc(((100% * var(--all-day-title-span-days, 1)) + ((var(--week-standard-column-gap) + var(--week-standard-bridge-overlap)) * var(--all-day-title-gap-count, 0))) - (24px + var(--combine-left-offset, 0px)));
+        position: static;
+        transform: none;
+        width: auto;
+        max-width: 100%;
         overflow: hidden;
         text-overflow: ellipsis;
         z-index: 1;
@@ -13063,10 +13067,17 @@ class SkylightCalendarCard extends HTMLElement {
         lanes[span.laneIndex] = {
           event: span.event,
           displayTitle: span.displayTitle,
+          spanStartIndex: span.startIndex,
+          spanEndIndex: span.endIndex,
+          dayIndex,
+          segmentIndexWithinVisibleSpan: dayIndex - span.startIndex,
           continuesFromPreviousDay: dayIndex > span.startIndex || !span.startsOnDayAtStartIndex,
           continuesToNextDay: dayIndex < span.endIndex || !span.endsOnDayAtEndIndex,
+          startsBeforeVisibleSegment: !span.startsOnDayAtStartIndex,
           bridgeFromPreviousDay: dayIndex > span.startIndex,
           bridgeToNextDay: dayIndex < span.endIndex,
+          isFirstVisibleSegment: dayIndex === span.startIndex,
+          isLastVisibleSegment: dayIndex === span.endIndex,
           showTitle: dayIndex === span.startIndex,
           visibleDaySpan: span.endIndex - span.startIndex + 1
         };
@@ -13117,10 +13128,18 @@ class SkylightCalendarCard extends HTMLElement {
             displayTitle,
             visibleDaySpan
           } = lane;
+          if (!lane.isFirstVisibleSegment) {
+            return '<div class="all-day-event-spacer all-day-event-span-placeholder"></div>';
+          }
+
           const eventStyle = this.getEventStyle(event, { withBorderAccent: false });
+          const spanStyle = visibleDaySpan > 1
+            ? ` --all-day-title-span-days: ${visibleDaySpan}; --all-day-title-gap-count: ${Math.max(visibleDaySpan - 1, 0)}; --all-day-visible-span: ${visibleDaySpan};`
+            : '';
+          const spanDataAttribute = visibleDaySpan > 1 ? ` data-all-day-span-days="${visibleDaySpan}"` : '';
           return `
             <div class="all-day-event ${continuesFromPreviousDay ? 'continues-prev' : ''} ${continuesToNextDay ? 'continues-next' : ''} ${bridgeFromPreviousDay ? 'bridge-prev' : ''} ${bridgeToNextDay ? 'bridge-next' : ''} ${showTitle && visibleDaySpan > 1 ? 'leading-span-title' : ''}"
-                 style="${eventStyle} --event-bubble-font-size: ${this.getEventBubbleFontSize(event)}; --event-time-font-size: ${this.getEventTimeFontSize(event)}; --event-bubble-text-color: ${this.getEventBubbleFontColor(event)}; --all-day-title-span-days: ${visibleDaySpan}; --all-day-title-gap-count: ${Math.max(visibleDaySpan - 1, 0)};"
+                 style="${eventStyle} --event-bubble-font-size: ${this.getEventBubbleFontSize(event)}; --event-time-font-size: ${this.getEventTimeFontSize(event)}; --event-bubble-text-color: ${this.getEventBubbleFontColor(event)};${spanStyle}"${spanDataAttribute}
                  data-event='${JSON.stringify(event).replace(/'/g, "&#39;")}'>
               <div class="all-day-event-title ${showTitle && visibleDaySpan > 1 ? 'spans-multiple-days' : ''}">${showTitle ? this.renderEventTitleWithPrefix(event, displayTitle || event.summary || this.t('untitledEvent')) : ''}</div>
               ${this.renderEventStyleCornerIcon(event)}

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -1470,6 +1470,130 @@ test('event color modes normalize widths and tint opacity endpoints', () => {
   assert.match(widthFallback.getEventStyle(event), /--combine-left-offset: 22px/);
 });
 
+function makeAllDayEvent(summary, startDate, endDate, entityId = 'calendar.family', extra = {}) {
+  return {
+    entityId,
+    color: extra.color || '#3366ff',
+    summary,
+    start: { date: startDate },
+    end: { date: endDate },
+    ...extra
+  };
+}
+
+function renderScheduleAllDayHtml(card, weekStartDateKey = '2026-05-03') {
+  const weekStart = new Date(`${weekStartDateKey}T00:00:00`);
+  const weekDays = Array.from({ length: 7 }, (_, offset) => new Date(weekStart.getFullYear(), weekStart.getMonth(), weekStart.getDate() + offset));
+  const layout = card.buildAllDayLayoutForSchedule(weekDays);
+  return weekDays.map((date) => card.renderAllDayEventsForDay(layout.dayLanesByDateKey.get(card.getDateKey(date)) || [], 28)).join('\n');
+}
+
+function countRenderedAllDayBodies(html) {
+  return (html.match(/class="all-day-event /g) || []).length;
+}
+
+function countAllDayPlaceholders(html) {
+  return (html.match(/all-day-event-span-placeholder/g) || []).length;
+}
+
+test('schedule all-day multi-day events render once as a continuous span across styling modes', () => {
+  for (const event_color_mode of ['classic', 'left-tint', 'left-neutral']) {
+    const card = makeCard({ entities: ['calendar.family'], event_color_mode });
+    card._events = [makeAllDayEvent(`${event_color_mode} trip`, '2026-05-04', '2026-05-07')];
+    const html = renderScheduleAllDayHtml(card);
+
+    assert.equal(countRenderedAllDayBodies(html), 1, `${event_color_mode} should render one visible event body`);
+    assert.equal(countAllDayPlaceholders(html), 2, `${event_color_mode} should reserve continuation lanes`);
+    assert.match(html, /data-all-day-span-days="3"/);
+    assert.match(html, /--all-day-visible-span: 3/);
+    if (event_color_mode === 'classic') {
+      assert.match(html, /background-image: none/);
+    } else {
+      assert.equal((html.match(/background-image: linear-gradient\(to right/g) || []).length, 1);
+    }
+  }
+});
+
+test('schedule all-day single-day events keep their leading bar in left color modes', () => {
+  for (const event_color_mode of ['left-tint', 'left-neutral']) {
+    const card = makeCard({ entities: ['calendar.family'], event_color_mode });
+    card._events = [makeAllDayEvent('single', '2026-05-04', '2026-05-05')];
+    const html = renderScheduleAllDayHtml(card);
+
+    assert.equal(countRenderedAllDayBodies(html), 1);
+    assert.equal(countAllDayPlaceholders(html), 0);
+    assert.doesNotMatch(html, /data-all-day-span-days=/);
+    assert.equal((html.match(/background-image: linear-gradient\(to right/g) || []).length, 1);
+  }
+});
+
+test('schedule all-day combined multi-day events render one indicator decoration for bars dots and stripes', () => {
+  for (const combine_style of ['bars', 'dots', 'stripes']) {
+    const card = makeCard({
+      entities: ['calendar.a', 'calendar.b'],
+      combine_calendars: true,
+      combine_style,
+      combine_background: 'neutral',
+      colors: { 'calendar.a': '#ff0000', 'calendar.b': '#00ff00' }
+    });
+    card._events = card.combineDuplicateCalendarEvents([
+      makeAllDayEvent('combined', '2026-05-04', '2026-05-07', 'calendar.a', { color: '#ff0000' }),
+      makeAllDayEvent('combined', '2026-05-04', '2026-05-07', 'calendar.b', { color: '#00ff00' })
+    ]);
+    const html = renderScheduleAllDayHtml(card);
+
+    assert.equal(countRenderedAllDayBodies(html), 1, `${combine_style} should render one visible event body`);
+    assert.equal(countAllDayPlaceholders(html), 2, `${combine_style} should reserve continuation lanes`);
+    assert.match(html, /data-all-day-span-days="3"/);
+    assert.equal((html.match(/background-image:/g) || []).length, 1);
+    assert.match(html, combine_style === 'stripes' ? /linear-gradient\(135deg/ : /background-repeat: no-repeat/);
+  }
+});
+
+test('schedule all-day styled multi-day events keep overrides on the continuous span', () => {
+  const card = makeCard({
+    entities: ['calendar.family'],
+    event_styles: [{
+      match: { title_contains: 'styled' },
+      style: {
+        background_color: '#112233',
+        event_font_color: '#ffeecc',
+        opacity: 0.7,
+        filter: 'grayscale(20%)',
+        icon: 'mdi:star',
+        icon_color: '#abcdef',
+        title_prefix: 'emoji'
+      }
+    }]
+  });
+  card._events = [makeAllDayEvent('styled retreat', '2026-05-04', '2026-05-07')];
+  const html = renderScheduleAllDayHtml(card);
+
+  assert.equal(countRenderedAllDayBodies(html), 1);
+  assert.equal(countAllDayPlaceholders(html), 2);
+  assert.match(html, /background-color: #112233/);
+  assert.match(html, /opacity: 0.7/);
+  assert.match(html, /filter: grayscale\(20%\)/);
+  assert.match(html, /mdi:star/);
+});
+
+test('schedule all-day visible range edges and overlapping lanes preserve continuous placeholders', () => {
+  const card = makeCard({ entities: ['calendar.family'] });
+  card._events = [
+    makeAllDayEvent('started before', '2026-05-01', '2026-05-05'),
+    makeAllDayEvent('continues after', '2026-05-08', '2026-05-12'),
+    makeAllDayEvent('full visible week', '2026-05-03', '2026-05-10'),
+    makeAllDayEvent('overlap', '2026-05-04', '2026-05-06')
+  ];
+  const html = renderScheduleAllDayHtml(card);
+
+  assert.equal(countRenderedAllDayBodies(html), 4);
+  assert.equal(countAllDayPlaceholders(html), 9);
+  assert.match(html, /continues-prev[\s\S]*started before/);
+  assert.match(html, /continues-next[\s\S]*continues after/);
+  assert.match(html, /data-all-day-span-days="7"/);
+});
+
 test('checkAllCalendarCapabilities marks google, caldav, and local capabilities correctly', async () => {
   const card = makeCard({
     entities: ['calendar.google_home', 'calendar.caldav_work', 'calendar.local_family'],

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -3425,10 +3425,17 @@ class SkylightCalendarCard extends HTMLElement {
         lanes[span.laneIndex] = {
           event: span.event,
           displayTitle: span.displayTitle,
+          spanStartIndex: span.startIndex,
+          spanEndIndex: span.endIndex,
+          dayIndex,
+          segmentIndexWithinVisibleSpan: dayIndex - span.startIndex,
           continuesFromPreviousDay: dayIndex > span.startIndex || !span.startsOnDayAtStartIndex,
           continuesToNextDay: dayIndex < span.endIndex || !span.endsOnDayAtEndIndex,
+          startsBeforeVisibleSegment: !span.startsOnDayAtStartIndex,
           bridgeFromPreviousDay: dayIndex > span.startIndex,
           bridgeToNextDay: dayIndex < span.endIndex,
+          isFirstVisibleSegment: dayIndex === span.startIndex,
+          isLastVisibleSegment: dayIndex === span.endIndex,
           showTitle: dayIndex === span.startIndex,
           visibleDaySpan: span.endIndex - span.startIndex + 1
         };
@@ -3479,10 +3486,18 @@ class SkylightCalendarCard extends HTMLElement {
             displayTitle,
             visibleDaySpan
           } = lane;
+          if (!lane.isFirstVisibleSegment) {
+            return '<div class="all-day-event-spacer all-day-event-span-placeholder"></div>';
+          }
+
           const eventStyle = this.getEventStyle(event, { withBorderAccent: false });
+          const spanStyle = visibleDaySpan > 1
+            ? ` --all-day-title-span-days: ${visibleDaySpan}; --all-day-title-gap-count: ${Math.max(visibleDaySpan - 1, 0)}; --all-day-visible-span: ${visibleDaySpan};`
+            : '';
+          const spanDataAttribute = visibleDaySpan > 1 ? ` data-all-day-span-days="${visibleDaySpan}"` : '';
           return `
             <div class="all-day-event ${continuesFromPreviousDay ? 'continues-prev' : ''} ${continuesToNextDay ? 'continues-next' : ''} ${bridgeFromPreviousDay ? 'bridge-prev' : ''} ${bridgeToNextDay ? 'bridge-next' : ''} ${showTitle && visibleDaySpan > 1 ? 'leading-span-title' : ''}"
-                 style="${eventStyle} --event-bubble-font-size: ${this.getEventBubbleFontSize(event)}; --event-time-font-size: ${this.getEventTimeFontSize(event)}; --event-bubble-text-color: ${this.getEventBubbleFontColor(event)}; --all-day-title-span-days: ${visibleDaySpan}; --all-day-title-gap-count: ${Math.max(visibleDaySpan - 1, 0)};"
+                 style="${eventStyle} --event-bubble-font-size: ${this.getEventBubbleFontSize(event)}; --event-time-font-size: ${this.getEventTimeFontSize(event)}; --event-bubble-text-color: ${this.getEventBubbleFontColor(event)};${spanStyle}"${spanDataAttribute}
                  data-event='${JSON.stringify(event).replace(/'/g, "&#39;")}'>
               <div class="all-day-event-title ${showTitle && visibleDaySpan > 1 ? 'spans-multiple-days' : ''}">${showTitle ? this.renderEventTitleWithPrefix(event, displayTitle || event.summary || this.t('untitledEvent')) : ''}</div>
               ${this.renderEventStyleCornerIcon(event)}

--- a/src/styles/card-styles.js
+++ b/src/styles/card-styles.js
@@ -1559,6 +1559,12 @@ export function getCardStyles() {
         z-index: 2;
       }
 
+      .all-day-event[data-all-day-span-days] {
+        width: calc((100% * var(--all-day-visible-span, 1)) + ((var(--week-standard-column-gap) + var(--week-standard-bridge-overlap)) * var(--all-day-title-gap-count, 0)));
+        max-width: none;
+        z-index: 2;
+      }
+
       .all-day-event-title {
         font-weight: 600;
         overflow: hidden;
@@ -1572,12 +1578,10 @@ export function getCardStyles() {
       }
 
       .all-day-event-title.spans-multiple-days {
-        position: absolute;
-        top: 50%;
-        left: calc(8px + var(--combine-left-offset, 0px));
-        transform: translateY(-50%);
-        width: calc(((100% * var(--all-day-title-span-days, 1)) + ((var(--week-standard-column-gap) + var(--week-standard-bridge-overlap)) * var(--all-day-title-gap-count, 0))) - (24px + var(--combine-left-offset, 0px)));
-        max-width: calc(((100% * var(--all-day-title-span-days, 1)) + ((var(--week-standard-column-gap) + var(--week-standard-bridge-overlap)) * var(--all-day-title-gap-count, 0))) - (24px + var(--combine-left-offset, 0px)));
+        position: static;
+        transform: none;
+        width: auto;
+        max-width: 100%;
         overflow: hidden;
         text-overflow: ellipsis;
         z-index: 1;


### PR DESCRIPTION
### Motivation
- Improve schedule view rendering so multi-day all-day events appear as a single continuous span across visible days rather than repeated segmented bodies.
- Ensure the visual styling, width calculations, and placeholders for continuation lanes work across combine styles and event color modes.
- Add tests and visual cases to prevent regressions for combined calendars, styling overrides, and visible-range edge cases.

### Description
- Update rendering to emit a single visible event body for the first visible segment and inject spacer placeholders for subsequent segments by adding `isFirstVisibleSegment` handling and `all-day-event-span-placeholder` output in `renderAllDayEventsForDay` (in `src/skylight-calendar-card.js` and built `skylight-calendar-card.js`).
- Add span metadata attributes and CSS custom-properties (`data-all-day-span-days`, `--all-day-visible-span`, and gap-count properties) so multi-day widths can be computed and styled (CSS updates in `src/styles/card-styles.js` and built `skylight-calendar-card.js`).
- Simplify title layout for spanning events by making `.all-day-event-title.spans-multiple-days` static and constrain overflow, and add `.all-day-event[data-all-day-span-days]` rules to size continuous spans correctly.
- Add unit tests covering schedule all-day multi-day rendering, combined calendar decorations, styling overrides, edge-of-visible-range behavior, and single-day preservation for left color modes in `skylight-calendar-card.test.js`.
- Add a Playwright visual case `schedule-all-day-continuous-spans` and supporting `scheduleSpanEvents` in `playwright/visual.spec.js` to exercise schedule continuous spans visually.

### Testing
- Ran the unit test suite including the new `skylight-calendar-card.test.js` cases via the project test runner, and the tests completed successfully.
- Executed the Playwright visual spec suite with the added `schedule-all-day-continuous-spans` case, and the visual test run succeeded against the baseline.
- Verified the built `skylight-calendar-card.js` and style changes are exercised by the tests and did not introduce regressions in related calendar rendering tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41516f083483319655c4eb74d90d05)