### PR TITLE
Add YAML day_badges tap_action (fire-dom-event) support

### DIFF
--- a/docs/advanced/day-badges.mdx
+++ b/docs/advanced/day-badges.mdx
@@ -199,7 +199,33 @@ Dynamic badge values are intentionally narrow in scope:
 - Missing fields are ignored safely.
 - Values that resolve to objects or arrays are ignored for display fields.
 - Dynamic `background_color` and `color` values must resolve to supported CSS color formats, such as hex, `rgb()`/`rgba()`, `hsl()`/`hsla()`, or a recognized named color. Invalid color values are ignored.
-- Dynamic resolution currently applies only to `day_badges` display fields, not matching, priority, hidden calendar rules, or actions.
+- Dynamic resolution applies only to `day_badges` display fields and `tap_action.event_data`, not matching, priority, or hidden calendar rules.
+
+### Fire a DOM event when tapping a badge
+
+You can make an individual day badge clickable by adding `tap_action`. Currently, day badges support only `action: fire-dom-event`. Other Home Assistant actions such as `navigate`, `url`, `call-service`, `more-info`, `hold_action`, and `double_tap_action` are not supported for day badges.
+
+`tap_action.event_data` supports the same safe full-value templates as dynamic badge text, icon, and color. Values can resolve from `date`, `calendar`, `title`, `event`, and `event.description_json`. Only scalar string, number, and boolean values are included in the dispatched event detail.
+
+```yaml
+day_badges:
+  - conditions:
+      calendar: calendar.helper_day_types
+      all_day: true
+      title: Schoolday
+    icon: "{{ event.description_json.icon }}"
+    text: "{{ event.description_json.badge_text }}"
+    background_color: "{{ event.description_json.badge_color }}"
+    tap_action:
+      action: fire-dom-event
+      event_type: open-day-detail
+      event_data:
+        date: "{{ date }}"
+        calendar: "{{ calendar }}"
+        title: "{{ title }}"
+```
+
+When tapped, the card dispatches a bubbling, composed `CustomEvent` named `open-day-detail`. The event `detail` contains the resolved `event_data` values.
 
 ### Mark all-day event days with an indicator
 

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3469,6 +3469,13 @@ function getCardStyles() {
         box-sizing: border-box;
       }
 
+      .day-badge-action {
+        border: 0;
+        font: inherit;
+        appearance: none;
+        cursor: pointer;
+      }
+
       .day-badge.has-text {
         width: auto;
         gap: 4px;
@@ -6570,7 +6577,7 @@ const TRANSLATIONS = {
   }
 };
 
-function renderDayBadge(badge, { escapeHtml }) {
+function renderDayBadge(badge, { escapeHtml, registerDayBadgeAction } = {}) {
   const style = [
     badge.background_color ? `--dcc-day-badge-background: ${badge.background_color};` : '',
     badge.color ? `--dcc-day-badge-color: ${badge.color};` : '',
@@ -6583,15 +6590,21 @@ function renderDayBadge(badge, { escapeHtml }) {
     hasIcon ? `<ha-icon icon="${escapeHtml(badge.icon)}"></ha-icon>` : '',
     hasText ? `<span class="day-badge-text">${escapeHtml(badge.text)}</span>` : ''
   ].join('');
-  const classes = ['day-badge', hasIcon ? 'has-icon' : '', hasText ? 'has-text' : ''].filter(Boolean).join(' ');
+  const actionId = badge.tap_action && typeof registerDayBadgeAction === 'function'
+    ? registerDayBadgeAction(badge.tap_action)
+    : null;
+  const classes = ['day-badge', actionId ? 'day-badge-action' : '', hasIcon ? 'has-icon' : '', hasText ? 'has-text' : ''].filter(Boolean).join(' ');
+  if (actionId) {
+    return `<button type="button" class="${classes}" style="${style}" data-day-badge-action-id="${escapeHtml(actionId)}">${content}</button>`;
+  }
   return `<span class="${classes}" style="${style}">${content}</span>`;
 }
 
-function renderDayBadges(date, dayEvents, { escapeHtml, getDayBadges }) {
+function renderDayBadges(date, dayEvents, { escapeHtml, getDayBadges, registerDayBadgeAction }) {
   const badges = getDayBadges(date, dayEvents);
   if (!badges.length) return '';
 
-  const badgesHtml = badges.map((badge) => renderDayBadge(badge, { escapeHtml })).join('');
+  const badgesHtml = badges.map((badge) => renderDayBadge(badge, { escapeHtml, registerDayBadgeAction })).join('');
 
   return `<div class="day-badges">${badgesHtml}</div>`;
 }
@@ -6653,6 +6666,31 @@ function normalizeDayBadgeBlock(rule = {}, {
 
   const fontSize = normalizeStyleSizeValue(rule.font_size);
   if (fontSize) normalized.font_size = fontSize;
+
+  const tapAction = normalizeDayBadgeTapAction(rule.tap_action);
+  if (tapAction) normalized.tap_action = tapAction;
+  return normalized;
+}
+
+function isPlainObject(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeDayBadgeTapAction(tapAction) {
+  if (!isPlainObject(tapAction)) return undefined;
+  if (tapAction.action !== 'fire-dom-event') return undefined;
+  const eventType = typeof tapAction.event_type === 'string' ? tapAction.event_type.trim() : '';
+  if (!eventType) return undefined;
+
+  const normalized = {
+    action: 'fire-dom-event',
+    event_type: eventType
+  };
+
+  if (isPlainObject(tapAction.event_data)) {
+    normalized.event_data = { ...tapAction.event_data };
+  }
+
   return normalized;
 }
 
@@ -6736,6 +6774,27 @@ function resolveDayBadgeDisplayValue(value, context) {
   return resolveSafePath(match[1], context);
 }
 
+function resolveDayBadgeTapAction(tapAction, context) {
+  const normalized = normalizeDayBadgeTapAction(tapAction);
+  if (!normalized) return undefined;
+
+  const eventData = {};
+  if (isPlainObject(normalized.event_data)) {
+    Object.entries(normalized.event_data).forEach(([key, value]) => {
+      if (!['string', 'number', 'boolean'].includes(typeof value)) return;
+      const resolvedValue = resolveDayBadgeDisplayValue(value, context);
+      if (!['string', 'number', 'boolean'].includes(typeof resolvedValue)) return;
+      eventData[key] = resolvedValue;
+    });
+  }
+
+  return {
+    action: 'fire-dom-event',
+    event_type: normalized.event_type,
+    event_data: eventData
+  };
+}
+
 function resolveDayBadgeForRender(rule, date, matchedEvent, {
   formatLocalDate,
   normalizeResolvedDayBadgeDisplayColor
@@ -6761,6 +6820,12 @@ function resolveDayBadgeForRender(rule, date, matchedEvent, {
 
     resolved[field] = String(value).trim();
   });
+  const tapAction = resolveDayBadgeTapAction(rule.tap_action, context);
+  if (tapAction) {
+    resolved.tap_action = tapAction;
+  } else {
+    delete resolved.tap_action;
+  }
   return resolved;
 }
 
@@ -10292,6 +10357,8 @@ class SkylightCalendarCard extends HTMLElement {
     this._swipeStartY = null;
     this._swipeTracking = false;
     this._swipeStartedOnInteractive = false;
+    this._dayBadgeActions = new Map();
+    this._dayBadgeActionSequence = 0;
     this._activeModalBackHandler = null;
     this._combinedEditTargets = null;
     this._combinedDeleteTargets = null;
@@ -12698,6 +12765,8 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   render() {
+    this._dayBadgeActions = new Map();
+    this._dayBadgeActionSequence = 0;
     const shouldRestoreAgendaScrollPosition = this._viewMode === 'agenda' && Number.isFinite(this._agendaPendingScrollTop);
     const agendaScrollTopToRestore = shouldRestoreAgendaScrollPosition ? this._agendaPendingScrollTop : null;
     const today = new Date();
@@ -13929,8 +13998,39 @@ class SkylightCalendarCard extends HTMLElement {
   renderDayBadges(date, dayEvents) {
     return renderDayBadges(date, dayEvents, {
       escapeHtml: this.escapeHtml.bind(this),
-      getDayBadges: this.getDayBadges.bind(this)
+      getDayBadges: this.getDayBadges.bind(this),
+      registerDayBadgeAction: this.registerDayBadgeAction.bind(this)
     });
+  }
+
+  registerDayBadgeAction(tapAction) {
+    if (!tapAction || tapAction.action !== 'fire-dom-event' || typeof tapAction.event_type !== 'string' || !tapAction.event_type.trim()) {
+      return null;
+    }
+    if (!this._dayBadgeActions) this._dayBadgeActions = new Map();
+    this._dayBadgeActionSequence = (this._dayBadgeActionSequence || 0) + 1;
+    const actionId = `day-badge-action-${this._dayBadgeActionSequence}`;
+    this._dayBadgeActions.set(actionId, {
+      event_type: tapAction.event_type.trim(),
+      event_data: tapAction.event_data && typeof tapAction.event_data === 'object' && !Array.isArray(tapAction.event_data)
+        ? { ...tapAction.event_data }
+        : {}
+    });
+    return actionId;
+  }
+
+  handleDayBadgeActionClick(event, actionEl) {
+    event.preventDefault();
+    event.stopPropagation();
+    const actionId = actionEl?.getAttribute?.('data-day-badge-action-id');
+    const action = actionId ? this._dayBadgeActions?.get(actionId) : null;
+    if (!action?.event_type) return;
+
+    this.dispatchEvent(new CustomEvent(action.event_type, {
+      detail: action.event_data || {},
+      bubbles: true,
+      composed: true
+    }));
   }
 
   trimTrailingNullMonthSpanLanes(monthSpanLanes = []) {
@@ -14716,6 +14816,10 @@ class SkylightCalendarCard extends HTMLElement {
 
     this.attachSwipeControls();
 
+    this._root.querySelectorAll('.day-badge-action').forEach(actionEl => {
+      actionEl.addEventListener('click', (e) => this.handleDayBadgeActionClick(e, actionEl));
+    });
+
     // Event click handlers for all view modes
     this._root.querySelectorAll('.event, .week-compact-event, .week-standard-event, .all-day-event, .agenda-event').forEach(eventEl => {
       eventEl.addEventListener('click', (e) => {
@@ -14745,7 +14849,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._root.querySelectorAll('.day-cell').forEach(dayEl => {
       dayEl.addEventListener('click', (e) => {
         // Don't open if clicking on an event
-        if (e.target.classList.contains('event') || e.target.closest('.event')) {
+        if (e.target.classList.contains('event') || e.target.closest('.event') || e.target.closest('.day-badge-action')) {
           return;
         }
 
@@ -14768,11 +14872,11 @@ class SkylightCalendarCard extends HTMLElement {
     this._root.querySelectorAll('.agenda-day-row').forEach(rowEl => {
       rowEl.addEventListener('click', (e) => {
         // Don't open if clicking on an event
-        if (e.target.classList.contains('agenda-event') || e.target.closest('.agenda-event')) {
+        if (e.target.classList.contains('agenda-event') || e.target.closest('.agenda-event') || e.target.closest('.day-badge-action')) {
           return;
         }
 
-        if (!this._config.enable_event_management || this.getWritableCalendars().length === 0) {
+        if (e.target.closest('.day-badge-action') || !this._config.enable_event_management || this.getWritableCalendars().length === 0) {
           return;
         }
 
@@ -15016,7 +15120,7 @@ class SkylightCalendarCard extends HTMLElement {
       this._swipeStartY = touch.clientY;
       this._swipeTracking = true;
       const eventTarget = event.target instanceof Element ? event.target : null;
-      this._swipeStartedOnInteractive = !!eventTarget?.closest('button, select, input, textarea, .event, .week-compact-event, .week-standard-event, .all-day-event');
+      this._swipeStartedOnInteractive = !!eventTarget?.closest('button, select, input, textarea, .event, .week-compact-event, .week-standard-event, .all-day-event, .day-badge-action, [data-day-badge-action-id]');
     }, { passive: true });
 
     container.addEventListener('touchend', (event) => {

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3471,7 +3471,7 @@ function getCardStyles() {
 
       .day-badge-action {
         border: 0;
-        font: inherit;
+        font-family: inherit;
         appearance: none;
         cursor: pointer;
       }

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3471,6 +3471,7 @@ function getCardStyles() {
 
       .day-badge-action {
         border: 0;
+        padding: 0;
         font-family: inherit;
         appearance: none;
         cursor: pointer;

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -3045,6 +3045,136 @@ test('hidden events do not contribute to month overflow counts', () => {
 
 
 
+
+
+test('day badge tap_action fire-dom-event renders clickable badge and dispatches resolved detail', () => {
+  const card = makeCard({
+    entities: ['calendar.helper_day_types'],
+    day_badges: [{
+      conditions: { calendar: 'calendar.helper_day_types', all_day: true, title: 'Schoolday' },
+      text: '{{ event.description_json.badge_text }}',
+      icon: '{{ event.description_json.icon }}',
+      background_color: '{{ event.description_json.badge_color }}',
+      tap_action: {
+        action: 'fire-dom-event',
+        event_type: 'open-day-detail',
+        event_data: {
+          date: '{{ date }}',
+          calendar: '{{ calendar }}',
+          title: '{{ title }}',
+          icon: '{{ event.description_json.icon }}',
+          count: 2,
+          active: true,
+          unsafe: '{{ event.__proto__.polluted }}',
+          object_value: { skip: true }
+        }
+      }
+    }]
+  });
+  const event = {
+    entityId: 'calendar.helper_day_types',
+    summary: 'Schoolday',
+    description: '{"badge_text":"School","icon":"mdi:school","badge_color":"#EDE7F6"}',
+    start: { date: '2026-05-01' },
+    end: { date: '2026-05-02' }
+  };
+  card._events = [event];
+
+  const html = card.renderDayBadges(new Date('2026-05-01T00:00:00Z'), [event]);
+  assert.match(html, /<button type="button" class="day-badge day-badge-action has-icon has-text"/);
+  assert.match(html, /data-day-badge-action-id="day-badge-action-1"/);
+  assert.match(html, /day-badge-text">School</);
+
+  let dispatched;
+  card.dispatchEvent = (customEvent) => { dispatched = customEvent; return true; };
+  const actionEl = { getAttribute: (name) => name === 'data-day-badge-action-id' ? 'day-badge-action-1' : null };
+  let prevented = false;
+  let stopped = false;
+  card.handleDayBadgeActionClick({ preventDefault: () => { prevented = true; }, stopPropagation: () => { stopped = true; } }, actionEl);
+
+  assert.equal(prevented, true);
+  assert.equal(stopped, true);
+  assert.equal(dispatched.type, 'open-day-detail');
+  assert.equal(dispatched.bubbles, true);
+  assert.equal(dispatched.composed, true);
+  assert.deepEqual(dispatched.detail, {
+    date: '2026-05-01',
+    calendar: 'calendar.helper_day_types',
+    title: 'Schoolday',
+    icon: 'mdi:school',
+    count: 2,
+    active: true
+  });
+});
+
+test('day badge without valid tap_action renders normally and unsupported actions are ignored', () => {
+  const baseEvent = {
+    entityId: 'calendar.helper_day_types',
+    summary: 'Schoolday',
+    start: { date: '2026-05-01' },
+    end: { date: '2026-05-02' }
+  };
+  const noActionCard = makeCard({
+    entities: ['calendar.helper_day_types'],
+    day_badges: [{ conditions: { title: 'Schoolday' }, text: 'School' }]
+  });
+  assert.match(noActionCard.renderDayBadges(new Date('2026-05-01T00:00:00Z'), [baseEvent]), /<span class="day-badge has-text"/);
+
+  const unsupportedActionCard = makeCard({
+    entities: ['calendar.helper_day_types'],
+    day_badges: [{
+      conditions: { title: 'Schoolday' },
+      text: 'School',
+      tap_action: { action: 'navigate', navigation_path: '/lovelace' }
+    }]
+  });
+  const html = unsupportedActionCard.renderDayBadges(new Date('2026-05-01T00:00:00Z'), [baseEvent]);
+  assert.match(html, /<span class="day-badge has-text"/);
+  assert.doesNotMatch(html, /day-badge-action/);
+  assert.doesNotMatch(html, /data-day-badge-action-id/);
+});
+
+test('day badge action click listener prevents day modal and create modal conflicts', () => {
+  const card = makeCard({ entities: ['calendar.family'], enable_event_management: true });
+  const handlers = {};
+  const actionEl = {
+    addEventListener: (eventName, callback) => { handlers[`action:${eventName}`] = callback; },
+    getAttribute: (name) => name === 'data-day-badge-action-id' ? 'badge-action' : null
+  };
+  const dayEl = {
+    addEventListener: (eventName, callback) => { handlers[`day:${eventName}`] = callback; },
+    getAttribute: () => '2026-05-01'
+  };
+  card._dayBadgeActions = new Map([['badge-action', { event_type: 'open-day-detail', event_data: { title: 'Schoolday' } }]]);
+  card.getRootElementById = () => null;
+  card.observeModalVisibility = () => {};
+  card.attachSwipeControls = () => {};
+  card._root = {
+    querySelector: () => null,
+    querySelectorAll: (selector) => {
+      if (selector === '.day-badge-action') return [actionEl];
+      if (selector === '.day-cell') return [dayEl];
+      return [];
+    }
+  };
+  let createCalls = 0;
+  let dayModalCalls = 0;
+  let dispatched;
+  card.getWritableCalendars = () => ['calendar.family'];
+  card.showCreateEventModal = () => { createCalls += 1; };
+  card.showDayModal = () => { dayModalCalls += 1; };
+  card.dispatchEvent = (event) => { dispatched = event; return true; };
+
+  card.attachEventListeners();
+  handlers['action:click']({ preventDefault: () => {}, stopPropagation: () => {} });
+  handlers['day:click']({ target: { classList: { contains: () => false }, closest: (selector) => selector === '.day-badge-action' } });
+
+  assert.equal(dispatched.type, 'open-day-detail');
+  assert.deepEqual(dispatched.detail, { title: 'Schoolday' });
+  assert.equal(createCalls, 0);
+  assert.equal(dayModalCalls, 0);
+});
+
 test('day badge helper module delegates preserve normalization and resolution behavior', () => {
   const card = makeCard({ entities: ['calendar.a'] });
   const block = card.normalizeDayBadgeBlock({
@@ -5134,6 +5264,8 @@ test('day badge module preserves normalization, safe resolution, and render prep
     buildDayBadgeResolutionContext,
     resolveSafePath,
     resolveDayBadgeDisplayValue,
+    normalizeDayBadgeTapAction,
+    resolveDayBadgeTapAction,
     resolveDayBadgeForRender,
     normalizeDayBadges
   } = await import('./src/badges/day-badges.js');
@@ -5184,6 +5316,9 @@ test('day badge module preserves normalization, safe resolution, and render prep
   assert.equal(resolveSafePath('event.description_json.nested', context), undefined);
   assert.equal(resolveDayBadgeDisplayValue('{{ event.description_json.enabled }}', context), 'true');
   assert.equal(resolveDayBadgeDisplayValue('Literal {{ event.description_json.label }}', context), 'Literal {{ event.description_json.label }}');
+  assert.deepEqual(normalizeDayBadgeTapAction({ action: 'fire-dom-event', event_type: ' helper ', event_data: { title: '{{ title }}' } }), { action: 'fire-dom-event', event_type: 'helper', event_data: { title: '{{ title }}' } });
+  assert.equal(normalizeDayBadgeTapAction({ action: 'navigate', event_type: 'helper' }), undefined);
+  assert.deepEqual(resolveDayBadgeTapAction({ action: 'fire-dom-event', event_type: 'helper', event_data: { date: '{{ date }}', calendar: '{{ calendar }}', title: '{{ title }}', label: '{{ event.description_json.label }}', unsafe: '{{ event.__proto__.polluted }}', nested: '{{ event.description_json.nested }}' } }, context), { action: 'fire-dom-event', event_type: 'helper', event_data: { date: '2026-05-01', calendar: 'calendar.helper', title: 'Helper', label: 'Bus' } });
 
   assert.deepEqual(resolveDayBadgeForRender({
     text: '{{ event.description_json.label }}',

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -3175,6 +3175,61 @@ test('day badge action click listener prevents day modal and create modal confli
   assert.equal(dayModalCalls, 0);
 });
 
+test('day badge actions are treated as interactive swipe targets', () => {
+  const OriginalElement = global.Element;
+  class FakeElement {
+    constructor(matchingSelector) {
+      this.matchingSelector = matchingSelector;
+    }
+    closest(selector) {
+      return selector.split(',').map((part) => part.trim()).includes(this.matchingSelector) ? this : null;
+    }
+  }
+  global.Element = FakeElement;
+
+  try {
+    for (const matchingSelector of ['.day-badge-action', '[data-day-badge-action-id]']) {
+      const card = makeCard({ entities: ['calendar.family'] });
+      const handlers = {};
+      const container = {
+        addEventListener: (eventName, callback) => { handlers[eventName] = callback; }
+      };
+      card._root = {
+        querySelector: (selector) => selector === '.calendar-container' ? container : null
+      };
+      card.shouldEnableSwipeControls = () => true;
+      card.canTriggerSwipePeriodNavigation = () => true;
+      card.canNavigateToPreviousPeriod = () => true;
+      let nextCalls = 0;
+      let previousCalls = 0;
+      card.navigateToNextPeriod = () => { nextCalls += 1; };
+      card.navigateToPreviousPeriod = () => { previousCalls += 1; };
+
+      card.attachSwipeControls();
+      handlers.touchstart({
+        target: new FakeElement(matchingSelector),
+        touches: [{ clientX: 100, clientY: 20 }]
+      });
+      assert.equal(card._swipeStartedOnInteractive, true);
+
+      handlers.touchend({
+        changedTouches: [{ clientX: 20, clientY: 22 }]
+      });
+
+      assert.equal(nextCalls, 0);
+      assert.equal(previousCalls, 0);
+      assert.equal(card._swipeStartedOnInteractive, false);
+      assert.equal(card._swipeTracking, false);
+    }
+  } finally {
+    if (OriginalElement === undefined) {
+      delete global.Element;
+    } else {
+      global.Element = OriginalElement;
+    }
+  }
+});
+
 test('day badge helper module delegates preserve normalization and resolution behavior', () => {
   const card = makeCard({ entities: ['calendar.a'] });
   const block = card.normalizeDayBadgeBlock({

--- a/src/badges/day-badges.js
+++ b/src/badges/day-badges.js
@@ -21,6 +21,31 @@ export function normalizeDayBadgeBlock(rule = {}, {
 
   const fontSize = normalizeStyleSizeValue(rule.font_size);
   if (fontSize) normalized.font_size = fontSize;
+
+  const tapAction = normalizeDayBadgeTapAction(rule.tap_action);
+  if (tapAction) normalized.tap_action = tapAction;
+  return normalized;
+}
+
+export function isPlainObject(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function normalizeDayBadgeTapAction(tapAction) {
+  if (!isPlainObject(tapAction)) return undefined;
+  if (tapAction.action !== 'fire-dom-event') return undefined;
+  const eventType = typeof tapAction.event_type === 'string' ? tapAction.event_type.trim() : '';
+  if (!eventType) return undefined;
+
+  const normalized = {
+    action: 'fire-dom-event',
+    event_type: eventType
+  };
+
+  if (isPlainObject(tapAction.event_data)) {
+    normalized.event_data = { ...tapAction.event_data };
+  }
+
   return normalized;
 }
 
@@ -104,6 +129,27 @@ export function resolveDayBadgeDisplayValue(value, context) {
   return resolveSafePath(match[1], context);
 }
 
+export function resolveDayBadgeTapAction(tapAction, context) {
+  const normalized = normalizeDayBadgeTapAction(tapAction);
+  if (!normalized) return undefined;
+
+  const eventData = {};
+  if (isPlainObject(normalized.event_data)) {
+    Object.entries(normalized.event_data).forEach(([key, value]) => {
+      if (!['string', 'number', 'boolean'].includes(typeof value)) return;
+      const resolvedValue = resolveDayBadgeDisplayValue(value, context);
+      if (!['string', 'number', 'boolean'].includes(typeof resolvedValue)) return;
+      eventData[key] = resolvedValue;
+    });
+  }
+
+  return {
+    action: 'fire-dom-event',
+    event_type: normalized.event_type,
+    event_data: eventData
+  };
+}
+
 export function resolveDayBadgeForRender(rule, date, matchedEvent, {
   formatLocalDate,
   normalizeResolvedDayBadgeDisplayColor
@@ -129,6 +175,12 @@ export function resolveDayBadgeForRender(rule, date, matchedEvent, {
 
     resolved[field] = String(value).trim();
   });
+  const tapAction = resolveDayBadgeTapAction(rule.tap_action, context);
+  if (tapAction) {
+    resolved.tap_action = tapAction;
+  } else {
+    delete resolved.tap_action;
+  }
   return resolved;
 }
 

--- a/src/renderers/day-weather-renderer.js
+++ b/src/renderers/day-weather-renderer.js
@@ -1,4 +1,4 @@
-export function renderDayBadge(badge, { escapeHtml }) {
+export function renderDayBadge(badge, { escapeHtml, registerDayBadgeAction } = {}) {
   const style = [
     badge.background_color ? `--dcc-day-badge-background: ${badge.background_color};` : '',
     badge.color ? `--dcc-day-badge-color: ${badge.color};` : '',
@@ -11,15 +11,21 @@ export function renderDayBadge(badge, { escapeHtml }) {
     hasIcon ? `<ha-icon icon="${escapeHtml(badge.icon)}"></ha-icon>` : '',
     hasText ? `<span class="day-badge-text">${escapeHtml(badge.text)}</span>` : ''
   ].join('');
-  const classes = ['day-badge', hasIcon ? 'has-icon' : '', hasText ? 'has-text' : ''].filter(Boolean).join(' ');
+  const actionId = badge.tap_action && typeof registerDayBadgeAction === 'function'
+    ? registerDayBadgeAction(badge.tap_action)
+    : null;
+  const classes = ['day-badge', actionId ? 'day-badge-action' : '', hasIcon ? 'has-icon' : '', hasText ? 'has-text' : ''].filter(Boolean).join(' ');
+  if (actionId) {
+    return `<button type="button" class="${classes}" style="${style}" data-day-badge-action-id="${escapeHtml(actionId)}">${content}</button>`;
+  }
   return `<span class="${classes}" style="${style}">${content}</span>`;
 }
 
-export function renderDayBadges(date, dayEvents, { escapeHtml, getDayBadges }) {
+export function renderDayBadges(date, dayEvents, { escapeHtml, getDayBadges, registerDayBadgeAction }) {
   const badges = getDayBadges(date, dayEvents);
   if (!badges.length) return '';
 
-  const badgesHtml = badges.map((badge) => renderDayBadge(badge, { escapeHtml })).join('');
+  const badgesHtml = badges.map((badge) => renderDayBadge(badge, { escapeHtml, registerDayBadgeAction })).join('');
 
   return `<div class="day-badges">${badgesHtml}</div>`;
 }

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -397,6 +397,8 @@ class SkylightCalendarCard extends HTMLElement {
     this._swipeStartY = null;
     this._swipeTracking = false;
     this._swipeStartedOnInteractive = false;
+    this._dayBadgeActions = new Map();
+    this._dayBadgeActionSequence = 0;
     this._activeModalBackHandler = null;
     this._combinedEditTargets = null;
     this._combinedDeleteTargets = null;
@@ -2803,6 +2805,8 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   render() {
+    this._dayBadgeActions = new Map();
+    this._dayBadgeActionSequence = 0;
     const shouldRestoreAgendaScrollPosition = this._viewMode === 'agenda' && Number.isFinite(this._agendaPendingScrollTop);
     const agendaScrollTopToRestore = shouldRestoreAgendaScrollPosition ? this._agendaPendingScrollTop : null;
     const today = new Date();
@@ -4034,8 +4038,39 @@ class SkylightCalendarCard extends HTMLElement {
   renderDayBadges(date, dayEvents) {
     return renderDayBadgesHtml(date, dayEvents, {
       escapeHtml: this.escapeHtml.bind(this),
-      getDayBadges: this.getDayBadges.bind(this)
+      getDayBadges: this.getDayBadges.bind(this),
+      registerDayBadgeAction: this.registerDayBadgeAction.bind(this)
     });
+  }
+
+  registerDayBadgeAction(tapAction) {
+    if (!tapAction || tapAction.action !== 'fire-dom-event' || typeof tapAction.event_type !== 'string' || !tapAction.event_type.trim()) {
+      return null;
+    }
+    if (!this._dayBadgeActions) this._dayBadgeActions = new Map();
+    this._dayBadgeActionSequence = (this._dayBadgeActionSequence || 0) + 1;
+    const actionId = `day-badge-action-${this._dayBadgeActionSequence}`;
+    this._dayBadgeActions.set(actionId, {
+      event_type: tapAction.event_type.trim(),
+      event_data: tapAction.event_data && typeof tapAction.event_data === 'object' && !Array.isArray(tapAction.event_data)
+        ? { ...tapAction.event_data }
+        : {}
+    });
+    return actionId;
+  }
+
+  handleDayBadgeActionClick(event, actionEl) {
+    event.preventDefault();
+    event.stopPropagation();
+    const actionId = actionEl?.getAttribute?.('data-day-badge-action-id');
+    const action = actionId ? this._dayBadgeActions?.get(actionId) : null;
+    if (!action?.event_type) return;
+
+    this.dispatchEvent(new CustomEvent(action.event_type, {
+      detail: action.event_data || {},
+      bubbles: true,
+      composed: true
+    }));
   }
 
   trimTrailingNullMonthSpanLanes(monthSpanLanes = []) {
@@ -4821,6 +4856,10 @@ class SkylightCalendarCard extends HTMLElement {
 
     this.attachSwipeControls();
 
+    this._root.querySelectorAll('.day-badge-action').forEach(actionEl => {
+      actionEl.addEventListener('click', (e) => this.handleDayBadgeActionClick(e, actionEl));
+    });
+
     // Event click handlers for all view modes
     this._root.querySelectorAll('.event, .week-compact-event, .week-standard-event, .all-day-event, .agenda-event').forEach(eventEl => {
       eventEl.addEventListener('click', (e) => {
@@ -4850,7 +4889,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._root.querySelectorAll('.day-cell').forEach(dayEl => {
       dayEl.addEventListener('click', (e) => {
         // Don't open if clicking on an event
-        if (e.target.classList.contains('event') || e.target.closest('.event')) {
+        if (e.target.classList.contains('event') || e.target.closest('.event') || e.target.closest('.day-badge-action')) {
           return;
         }
 
@@ -4873,11 +4912,11 @@ class SkylightCalendarCard extends HTMLElement {
     this._root.querySelectorAll('.agenda-day-row').forEach(rowEl => {
       rowEl.addEventListener('click', (e) => {
         // Don't open if clicking on an event
-        if (e.target.classList.contains('agenda-event') || e.target.closest('.agenda-event')) {
+        if (e.target.classList.contains('agenda-event') || e.target.closest('.agenda-event') || e.target.closest('.day-badge-action')) {
           return;
         }
 
-        if (!this._config.enable_event_management || this.getWritableCalendars().length === 0) {
+        if (e.target.closest('.day-badge-action') || !this._config.enable_event_management || this.getWritableCalendars().length === 0) {
           return;
         }
 
@@ -5121,7 +5160,7 @@ class SkylightCalendarCard extends HTMLElement {
       this._swipeStartY = touch.clientY;
       this._swipeTracking = true;
       const eventTarget = event.target instanceof Element ? event.target : null;
-      this._swipeStartedOnInteractive = !!eventTarget?.closest('button, select, input, textarea, .event, .week-compact-event, .week-standard-event, .all-day-event');
+      this._swipeStartedOnInteractive = !!eventTarget?.closest('button, select, input, textarea, .event, .week-compact-event, .week-standard-event, .all-day-event, .day-badge-action, [data-day-badge-action-id]');
     }, { passive: true });
 
     container.addEventListener('touchend', (event) => {

--- a/src/styles/card-styles.js
+++ b/src/styles/card-styles.js
@@ -667,6 +667,13 @@ export function getCardStyles() {
         box-sizing: border-box;
       }
 
+      .day-badge-action {
+        border: 0;
+        font: inherit;
+        appearance: none;
+        cursor: pointer;
+      }
+
       .day-badge.has-text {
         width: auto;
         gap: 4px;

--- a/src/styles/card-styles.js
+++ b/src/styles/card-styles.js
@@ -669,6 +669,7 @@ export function getCardStyles() {
 
       .day-badge-action {
         border: 0;
+        padding: 0;
         font-family: inherit;
         appearance: none;
         cursor: pointer;

--- a/src/styles/card-styles.js
+++ b/src/styles/card-styles.js
@@ -669,7 +669,7 @@ export function getCardStyles() {
 
       .day-badge-action {
         border: 0;
-        font: inherit;
+        font-family: inherit;
         appearance: none;
         cursor: pointer;
       }


### PR DESCRIPTION
### Motivation
- Allow individual `day_badges` to optionally emit a DOM event when tapped, enabling lightweight per-badge interactions from YAML without adding full Home Assistant action parity.
- Keep the change narrowly scoped to a safe, YAML-only `fire-dom-event` action and preserve all existing badge rendering and interaction behavior.

### Description
- Normalize `day_badges[].tap_action` in `src/badges/day-badges.js` with `normalizeDayBadgeTapAction` and `isPlainObject`, accepting only objects where `action === 'fire-dom-event'` and `event_type` is a non-empty string, and preserving optional plain-object `event_data` without mutating the raw config.
- Resolve `tap_action.event_data` using the existing day-badge resolution context via `resolveDayBadgeTapAction`, only resolving full-value templates and including scalar string/number/boolean values while blocking unsafe path segments like `__proto__`, `prototype`, and `constructor`.
- Render actionable badges as native buttons in `src/renderers/day-weather-renderer.js`, adding `day-badge-action` class and `data-day-badge-action-id`, and wire a `registerDayBadgeAction` callback so renderers do not embed full action JSON in HTML.
- Add an instance-level action map in `src/skylight-calendar-card.js` that is reset each render, provide `registerDayBadgeAction()` to generate stable IDs and store resolved action payloads, and add `handleDayBadgeActionClick()` to dispatch bubbling/composed `CustomEvent`s from the card element with `detail` set to the resolved `event_data` (default {}).
- Prevent interaction conflicts by excluding `.day-badge-action` from day/cell/agenda click handlers and from swipe navigation detection, and add a defensive click listener registration in `attachEventListeners` for actionable badges.
- Add minimal CSS for clickable badges in `src/styles/card-styles.js` to preserve appearance while showing pointer and native button behavior.
- Update documentation at `docs/advanced/day-badges.mdx` to describe supported `tap_action` usage and include the requested YAML example.
- Add unit tests to `skylight-calendar-card.test.js` covering: non-action badges, valid `fire-dom-event` rendering and event dispatch with resolved detail, unsupported actions ignored, template resolution for `event_data`, and prevention of modal/create-event/swipe conflicts.

### Testing
- Ran static checks: `node --check` on changed source and test files and they passed.
- Rebuilt the shipped artifact with `npm run build` which regenerated the root `skylight-calendar-card.js` artifact.
- Ran the full test suite: `npm test` and all tests passed (292/292).
- Verified the rendered output and behavior via added unit tests that assert clickable badge markup, `data-day-badge-action-id` presence, dispatched `CustomEvent` contents, and that badge clicks do not open modals or trigger swipe navigation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4417b027b88331a2a98e7a310f6588)