### PR TITLE
Fix compact-height Month span overflow and +N more counting

### DIFF
--- a/playwright/visual.spec.js
+++ b/playwright/visual.spec.js
@@ -805,6 +805,32 @@ for (const scenario of cases) {
   });
 }
 
+test('regression: month compact-height hides overflowing span lanes in more count', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+
+  const fixtureUrl = `file://${path.join(process.cwd(), 'playwright', 'ha-fixture.html')}`;
+  await page.goto(fixtureUrl);
+  await page.evaluate((params) => window.renderCalendarCard(params), {
+    config: { entities: ['calendar.family'], title: 'Regression Calendar', default_view: 'month', compact_height: true },
+    events: {
+      'calendar.family': Array.from({ length: 5 }, (_, index) => ({
+        summary: `Overlap Span ${index + 1}`,
+        start: '2026-03-24',
+        end: '2026-03-27'
+      }))
+    },
+    darkMode: false
+  });
+
+  const card = page.locator('skylight-calendar-card');
+  await expect(card).toContainText('Month');
+  const dayCell = card.locator('.day-cell[data-date^="2026-03-24"]').first();
+  await expect(dayCell).toBeVisible();
+  await expect(dayCell.locator('.month-span-event')).toHaveCount(0);
+  await expect(dayCell).toContainText('5 more');
+  await expect(dayCell).not.toContainText('Overlap Span 1');
+});
+
 test('regression: month compact-height view selector stays clickable without devtools', async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 720 });
 

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -14067,11 +14067,19 @@ class SkylightCalendarCard extends HTMLElement {
     const spannedEventKeys = new Set((monthSpanLanes || [])
       .filter(Boolean)
       .map((lane) => this.getScheduleAllDayEventKey(lane.event)));
-    const occupiedSpanLaneCount = (monthSpanLanes || []).filter(Boolean).length;
     const nonSpannedEventCount = dayEvents.filter((event) => !spannedEventKeys.has(this.getScheduleAllDayEventKey(event))).length;
-    const hasOverflow = nonSpannedEventCount > Math.max(0, maxVisible - occupiedSpanLaneCount);
+    const getHiddenEventCountForVisibleRows = (visibleRows) => {
+      const visibleMonthSpanLanes = (monthSpanLanes || []).slice(0, visibleRows);
+      const visibleSpanLaneCount = visibleMonthSpanLanes.filter(Boolean).length;
+      const hiddenSpanLaneCount = (monthSpanLanes || []).slice(visibleRows).filter(Boolean).length;
+      const hiddenNonSpannedEventCount = Math.max(0, nonSpannedEventCount - Math.max(0, visibleRows - visibleSpanLaneCount));
+
+      return hiddenSpanLaneCount + hiddenNonSpannedEventCount;
+    };
+    const hasOverflow = getHiddenEventCountForVisibleRows(maxVisible) > 0;
     const visibleEvents = hasOverflow ? Math.max(0, maxVisible - 1) : maxVisible;
-    const hiddenEventCount = Math.max(0, nonSpannedEventCount - Math.max(0, visibleEvents - occupiedSpanLaneCount));
+    const visibleMonthSpanLanes = (monthSpanLanes || []).slice(0, visibleEvents);
+    const hiddenEventCount = getHiddenEventCountForVisibleRows(visibleEvents);
 
     const dayStyle = this.getDayStyleAttributes(date, dayEventsForMatching, isToday);
 
@@ -14083,7 +14091,7 @@ class SkylightCalendarCard extends HTMLElement {
       dayStyle,
       hiddenEventCount,
       isOtherMonth,
-      monthSpanLanes,
+      monthSpanLanes: visibleMonthSpanLanes,
       isToday,
       visibleEvents,
       helpers: {

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -9726,11 +9726,12 @@ function renderDayCellEvents({
   dayEvents,
   hiddenEventCount,
   monthSpanLanes,
+  monthSpanEventKeys,
   visibleEvents,
   helpers
 }) {
   const lanes = monthSpanLanes || [];
-  const spannedEventKeys = new Set(lanes.filter(Boolean).map((lane) => helpers.getEventKey(lane.event)));
+  const spannedEventKeys = new Set((monthSpanEventKeys || lanes.filter(Boolean).map((lane) => helpers.getEventKey(lane.event))));
   const occupiedSpanLaneCount = lanes.filter(Boolean).length;
   const visibleNonSpannedEvents = dayEvents
     .filter((event) => !spannedEventKeys.has(helpers.getEventKey(event)))
@@ -9765,6 +9766,7 @@ function renderDayCell({
   hiddenEventCount,
   isOtherMonth,
   monthSpanLanes,
+  monthSpanEventKeys,
   isToday,
   visibleEvents,
   helpers
@@ -9786,6 +9788,7 @@ function renderDayCell({
         dayEvents,
         hiddenEventCount,
         monthSpanLanes,
+        monthSpanEventKeys,
         visibleEvents,
         helpers
       })}
@@ -14067,7 +14070,8 @@ class SkylightCalendarCard extends HTMLElement {
     const spannedEventKeys = new Set((monthSpanLanes || [])
       .filter(Boolean)
       .map((lane) => this.getScheduleAllDayEventKey(lane.event)));
-    const nonSpannedEventCount = dayEvents.filter((event) => !spannedEventKeys.has(this.getScheduleAllDayEventKey(event))).length;
+    const nonSpannedDayEvents = dayEvents.filter((event) => !spannedEventKeys.has(this.getScheduleAllDayEventKey(event)));
+    const nonSpannedEventCount = nonSpannedDayEvents.length;
     const getHiddenEventCountForVisibleRows = (visibleRows) => {
       const visibleMonthSpanLanes = (monthSpanLanes || []).slice(0, visibleRows);
       const visibleSpanLaneCount = visibleMonthSpanLanes.filter(Boolean).length;
@@ -14085,13 +14089,14 @@ class SkylightCalendarCard extends HTMLElement {
 
     return renderDayCell({
       date,
-      dayEvents,
+      dayEvents: nonSpannedDayEvents,
       dayEventsForMatching,
       dayNum,
       dayStyle,
       hiddenEventCount,
       isOtherMonth,
       monthSpanLanes: visibleMonthSpanLanes,
+      monthSpanEventKeys: [...spannedEventKeys],
       isToday,
       visibleEvents,
       helpers: {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -2162,6 +2162,26 @@ test('month hides span lanes beyond visible capacity and counts them in more ind
   assert.match(html, /3 more/);
 });
 
+test('month keeps hidden span lanes out of visible normal event slots', () => {
+  const card = makeCard({ entities: ['calendar.family'] });
+  card.getMaxVisibleEventsForMonthDay = () => 3;
+  const date = new Date('2026-03-26T00:00:00');
+  const visibleSpan = makeAllDayEvent('Visible Span', '2026-03-25', '2026-03-28');
+  const hiddenSpan = makeAllDayEvent('Hidden Span', '2026-03-24', '2026-03-28');
+  card._events = [visibleSpan, hiddenSpan];
+
+  const html = card.renderDay(26, date, false, [
+    null,
+    { event: visibleSpan, isFirstVisibleSegment: true, visibleDaySpan: 1 },
+    null,
+    { event: hiddenSpan, isFirstVisibleSegment: true, visibleDaySpan: 1 }
+  ]);
+
+  assert.match(html, /Visible Span/);
+  assert.doesNotMatch(html, /Hidden Span/);
+  assert.match(html, /1 more/);
+});
+
 test('month fills null span lanes with normal events before lower span lanes', () => {
   const card = makeCard({ entities: ['calendar.family'] });
   card.getMaxVisibleEventsForMonthDay = () => 3;

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -2142,6 +2142,25 @@ test('month trims trailing span placeholders so earlier normal timed events rema
   assert.doesNotMatch(html, /2 more/);
 });
 
+test('month hides span lanes beyond visible capacity and counts them in more indicator', () => {
+  const card = makeCard({ entities: ['calendar.family'] });
+  card.getMaxVisibleEventsForMonthDay = () => 3;
+  card._events = Array.from({ length: 5 }, (_, index) => makeAllDayEvent(`Overlap Span ${index + 1}`, '2026-03-24', '2026-03-27'));
+
+  const weekStart = new Date('2026-03-22T00:00:00');
+  const weekDays = Array.from({ length: 7 }, (_, offset) => new Date(weekStart.getFullYear(), weekStart.getMonth(), weekStart.getDate() + offset));
+  const layout = card.buildMonthSpanLayoutForWeek(weekDays);
+  const date = new Date('2026-03-24T00:00:00');
+  const html = card.renderDay(24, date, false, layout.dayLanesByDateKey.get(card.getDateKey(date)) || []);
+
+  assert.equal(countRenderedMonthSpanBodies(html), 2);
+  assert.match(html, /Overlap Span 1/);
+  assert.match(html, /Overlap Span 2/);
+  assert.doesNotMatch(html, /Overlap Span 3/);
+  assert.doesNotMatch(html, /Overlap Span 4/);
+  assert.doesNotMatch(html, /Overlap Span 5/);
+  assert.match(html, /3 more/);
+});
 
 test('month fills null span lanes with normal events before lower span lanes', () => {
   const card = makeCard({ entities: ['calendar.family'] });

--- a/src/renderers/day-cell-renderer.js
+++ b/src/renderers/day-cell-renderer.js
@@ -17,11 +17,12 @@ export function renderDayCellEvents({
   dayEvents,
   hiddenEventCount,
   monthSpanLanes,
+  monthSpanEventKeys,
   visibleEvents,
   helpers
 }) {
   const lanes = monthSpanLanes || [];
-  const spannedEventKeys = new Set(lanes.filter(Boolean).map((lane) => helpers.getEventKey(lane.event)));
+  const spannedEventKeys = new Set((monthSpanEventKeys || lanes.filter(Boolean).map((lane) => helpers.getEventKey(lane.event))));
   const occupiedSpanLaneCount = lanes.filter(Boolean).length;
   const visibleNonSpannedEvents = dayEvents
     .filter((event) => !spannedEventKeys.has(helpers.getEventKey(event)))
@@ -56,6 +57,7 @@ export function renderDayCell({
   hiddenEventCount,
   isOtherMonth,
   monthSpanLanes,
+  monthSpanEventKeys,
   isToday,
   visibleEvents,
   helpers
@@ -77,6 +79,7 @@ export function renderDayCell({
         dayEvents,
         hiddenEventCount,
         monthSpanLanes,
+        monthSpanEventKeys,
         visibleEvents,
         helpers
       })}

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -4094,11 +4094,19 @@ class SkylightCalendarCard extends HTMLElement {
     const spannedEventKeys = new Set((monthSpanLanes || [])
       .filter(Boolean)
       .map((lane) => this.getScheduleAllDayEventKey(lane.event)));
-    const occupiedSpanLaneCount = (monthSpanLanes || []).filter(Boolean).length;
     const nonSpannedEventCount = dayEvents.filter((event) => !spannedEventKeys.has(this.getScheduleAllDayEventKey(event))).length;
-    const hasOverflow = nonSpannedEventCount > Math.max(0, maxVisible - occupiedSpanLaneCount);
+    const getHiddenEventCountForVisibleRows = (visibleRows) => {
+      const visibleMonthSpanLanes = (monthSpanLanes || []).slice(0, visibleRows);
+      const visibleSpanLaneCount = visibleMonthSpanLanes.filter(Boolean).length;
+      const hiddenSpanLaneCount = (monthSpanLanes || []).slice(visibleRows).filter(Boolean).length;
+      const hiddenNonSpannedEventCount = Math.max(0, nonSpannedEventCount - Math.max(0, visibleRows - visibleSpanLaneCount));
+
+      return hiddenSpanLaneCount + hiddenNonSpannedEventCount;
+    };
+    const hasOverflow = getHiddenEventCountForVisibleRows(maxVisible) > 0;
     const visibleEvents = hasOverflow ? Math.max(0, maxVisible - 1) : maxVisible;
-    const hiddenEventCount = Math.max(0, nonSpannedEventCount - Math.max(0, visibleEvents - occupiedSpanLaneCount));
+    const visibleMonthSpanLanes = (monthSpanLanes || []).slice(0, visibleEvents);
+    const hiddenEventCount = getHiddenEventCountForVisibleRows(visibleEvents);
 
     const dayStyle = this.getDayStyleAttributes(date, dayEventsForMatching, isToday);
 
@@ -4110,7 +4118,7 @@ class SkylightCalendarCard extends HTMLElement {
       dayStyle,
       hiddenEventCount,
       isOtherMonth,
-      monthSpanLanes,
+      monthSpanLanes: visibleMonthSpanLanes,
       isToday,
       visibleEvents,
       helpers: {

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -4094,7 +4094,8 @@ class SkylightCalendarCard extends HTMLElement {
     const spannedEventKeys = new Set((monthSpanLanes || [])
       .filter(Boolean)
       .map((lane) => this.getScheduleAllDayEventKey(lane.event)));
-    const nonSpannedEventCount = dayEvents.filter((event) => !spannedEventKeys.has(this.getScheduleAllDayEventKey(event))).length;
+    const nonSpannedDayEvents = dayEvents.filter((event) => !spannedEventKeys.has(this.getScheduleAllDayEventKey(event)));
+    const nonSpannedEventCount = nonSpannedDayEvents.length;
     const getHiddenEventCountForVisibleRows = (visibleRows) => {
       const visibleMonthSpanLanes = (monthSpanLanes || []).slice(0, visibleRows);
       const visibleSpanLaneCount = visibleMonthSpanLanes.filter(Boolean).length;
@@ -4112,13 +4113,14 @@ class SkylightCalendarCard extends HTMLElement {
 
     return renderDayCell({
       date,
-      dayEvents,
+      dayEvents: nonSpannedDayEvents,
       dayEventsForMatching,
       dayNum,
       dayStyle,
       hiddenEventCount,
       isOtherMonth,
       monthSpanLanes: visibleMonthSpanLanes,
+      monthSpanEventKeys: [...spannedEventKeys],
       isToday,
       visibleEvents,
       helpers: {


### PR DESCRIPTION
### Motivation
- Month-day rendering could render all `monthSpanLanes` even when `getMaxVisibleEventsForMonthDay()` limited visible rows, causing multi-day span rows to overflow into following week rows under `compact_height` and omitting those spans from the `+N more` count.

### Description
- Add a helper to compute hidden counts for a given visible-row cap and use it to include omitted multi-day span lanes in the `hiddenEventCount` used by the day-cell renderer.
- Slice `monthSpanLanes` to the calculated visible row capacity and pass only those `visibleMonthSpanLanes` into the day-cell renderer so rendered rows never exceed the visible capacity while preserving null-lane packing and cross-day lane alignment.
- Keep `getMaxVisibleEventsForMonthDay()` and compact-height sizing unchanged and preserve existing placement/packing behavior.
- Add a focused unit test (`skylight-calendar-card.test.js`) that asserts correct rendering and `+N more` count when more spans exist than the visible capacity, and add a Playwright regression test (`playwright/visual.spec.js`) exercising `compact_height` with dense overlapping all-day spans.
- Rebuilt the generated artifact `skylight-calendar-card.js` from `src/skylight-calendar-card.js` and committed it with the source change.

### Testing
- Ran `npm run build` and the artifact was regenerated successfully.
- Ran unit tests with `npm test` and the suite passed (all tests in `skylight-calendar-card.test.js` succeeded).
- Ran Playwright visual/regression tests with `npm run test:visual` and they passed (visual test suite passed).
- Ran `node --check` on changed JS files and checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49e358497c83319bae3083ab2d9909)