### PR TITLE
Clarify bug report template with troubleshooting note and version field label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,10 @@ assignees: ''
 
 ---
 
+<!--
+Stale resources can make new features appear missing or broken even when HACS shows the latest version. Before opening an issue or bug report, verify that the latest version from HACS is installed and loaded via the "About / Diagnostics" section of the card configuration editor. See an issue? Follow the troubleshooting guide: https://docs.daylightcalendar.com/troubleshooting#updated-to-the-latest-version-but-still-seeing-old-behavior
+-->
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 
@@ -21,8 +25,8 @@ Paste your yaml here.
 **Screenshots**
 Screenshots help.
 
-**Dashboard Version**
-What version are you running?
+**Daylight Calendar Card Version**
+Report the version shown in the "About / Diagnostics" section of the card configuration editor. A screenshot of that section is preferred.
 
 **Home Assistant Version**
 What version are you running?


### PR DESCRIPTION
### Motivation
- Clarify the bug report template to guide users to verify HACS-installed resources are up-to-date and to reduce false reports caused by stale resources.

### Description
- Add an HTML comment with troubleshooting guidance and a docs link, and rename "Dashboard Version" to "Daylight Calendar Card Version" with instruction to report the version shown in the `About / Diagnostics` section.

### Testing
- No automated tests were added or run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c0ea61e448331876c6b7f9618f552)