### PR TITLE
Persistent last-known-good event cache with stale-while-revalidate loading

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -12227,7 +12227,7 @@ class SkylightCalendarCard extends HTMLElement {
     this.scheduleEventRefreshWarningTimer();
   }
 
-  applyEventsByCalendar(eventsByCalendar = {}, { startDate, endDate, lastSuccessfulRefresh = null, successfulEntityIds = null, failedEntityIds = [], source = 'network', requestId = null, coverageMode = 'replace' } = {}) {
+  applyEventsByCalendar(eventsByCalendar = {}, { startDate, endDate, lastSuccessfulRefresh = null, successfulEntityIds = null, failedEntityIds = [], source = 'network', requestId = null, coverageMode = 'replace', perCalendarMetadata = {} } = {}) {
     const range = this.getValidRange(startDate, endDate);
     const successfulSet = successfulEntityIds ? new Set(successfulEntityIds) : new Set(this._config.entities || []);
     const failedSet = new Set(failedEntityIds || []);
@@ -12250,13 +12250,19 @@ class SkylightCalendarCard extends HTMLElement {
       const events = Array.isArray(eventsByCalendar[entityId]) ? eventsByCalendar[entityId] : [];
       this._eventsByCalendar[entityId] = events;
       this._calendarDataSignatures[entityId] = this.getCalendarDataSignature(events);
+      const cachedMetadata = perCalendarMetadata?.[entityId] || {};
+      const cachedRange = this.getValidRange(cachedMetadata.range?.startDate, cachedMetadata.range?.endDate);
+      const effectiveRange = source === 'cache' && cachedRange ? cachedRange : range;
+      const effectiveLastSuccessfulRefresh = source === 'cache' && Number.isFinite(cachedMetadata.lastSuccessfulRefresh)
+        ? cachedMetadata.lastSuccessfulRefresh
+        : lastSuccessfulRefresh;
       const nextRange = coverageMode === 'union'
-        ? this.unionEventRanges(existingMetadata.range, range)
-        : (range || existingMetadata.range || null);
+        ? this.unionEventRanges(existingMetadata.range, effectiveRange)
+        : (effectiveRange || existingMetadata.range || null);
       this._calendarEventMetadata[entityId] = {
         ...existingMetadata,
         range: nextRange,
-        lastSuccessfulRefresh: Number.isFinite(lastSuccessfulRefresh) ? lastSuccessfulRefresh : existingMetadata.lastSuccessfulRefresh,
+        lastSuccessfulRefresh: Number.isFinite(effectiveLastSuccessfulRefresh) ? effectiveLastSuccessfulRefresh : existingMetadata.lastSuccessfulRefresh,
         refreshFailed: hasNewerNetworkFailure ? existingMetadata.refreshFailed : false,
         firstFailureAt: hasNewerNetworkFailure ? existingMetadata.firstFailureAt : null,
         lastNetworkSuccessRequest: source === 'network' ? requestId : existingMetadata.lastNetworkSuccessRequest
@@ -12273,11 +12279,25 @@ class SkylightCalendarCard extends HTMLElement {
     const { available, snapshot } = await readEventCacheSnapshot(configSignature);
     if (generation !== this._eventCacheGeneration || !available || !snapshot) return;
     const cacheEventsByCalendar = {};
+    const cacheMetadataByCalendar = {};
     const successfulEntityIds = [];
     (this._config.entities || []).forEach((entityId) => {
       const metadata = this._calendarEventMetadata[entityId] || {};
       if (metadata.lastNetworkSuccessRequest && metadata.lastNetworkSuccessRequest > requestId) return;
+      const cachedMetadata = snapshot.perCalendarMetadata?.[entityId] || {};
+      const cachedRange = this.getValidRange(
+        cachedMetadata.range?.startDate || snapshot.coveredRange.start,
+        cachedMetadata.range?.endDate || snapshot.coveredRange.end
+      );
+      const cachedLastSuccessfulRefresh = Number.isFinite(cachedMetadata.lastSuccessfulRefresh)
+        ? cachedMetadata.lastSuccessfulRefresh
+        : snapshot.lastSuccessfulRefresh;
+      if (!cachedRange || !Number.isFinite(cachedLastSuccessfulRefresh)) return;
       cacheEventsByCalendar[entityId] = snapshot.eventsByCalendar[entityId] || [];
+      cacheMetadataByCalendar[entityId] = {
+        range: cachedRange,
+        lastSuccessfulRefresh: cachedLastSuccessfulRefresh
+      };
       successfulEntityIds.push(entityId);
     });
     if (successfulEntityIds.length === 0) return;
@@ -12288,18 +12308,26 @@ class SkylightCalendarCard extends HTMLElement {
       lastSuccessfulRefresh: snapshot.lastSuccessfulRefresh,
       successfulEntityIds,
       source: 'cache',
-      requestId
+      requestId,
+      perCalendarMetadata: cacheMetadataByCalendar
     });
     this.render();
   }
 
-  getPrunedEventsByCalendarForCache(eventsByCalendar = {}, range = this._loadedEventRange) {
-    const validRange = this.getValidRange(range?.startDate, range?.endDate);
-    if (!validRange) return eventsByCalendar;
+  getEventCacheRetainedRange() {
+    const fetchRange = this.getEventFetchRange?.();
+    const validRange = this.getValidRange(fetchRange?.startDate, fetchRange?.endDate) || this.getValidRange(this._loadedEventRange?.startDate, this._loadedEventRange?.endDate);
+    if (!validRange) return null;
     const retainedStart = new Date(validRange.startDate);
     retainedStart.setDate(retainedStart.getDate() - 90);
     const retainedEnd = new Date(validRange.endDate);
     retainedEnd.setDate(retainedEnd.getDate() + 90);
+    return { startDate: retainedStart, endDate: retainedEnd };
+  }
+
+  getPrunedEventsByCalendarForCache(eventsByCalendar = {}, range = this.getEventCacheRetainedRange()) {
+    const retainedRange = this.getValidRange(range?.startDate, range?.endDate);
+    if (!retainedRange) return eventsByCalendar;
     const pruned = {};
     Object.entries(eventsByCalendar || {}).forEach(([entityId, events]) => {
       pruned[entityId] = (Array.isArray(events) ? events : []).filter((event) => {
@@ -12307,25 +12335,56 @@ class SkylightCalendarCard extends HTMLElement {
         const rawEnd = event?.end?.dateTime || event?.end?.date || event?.end;
         const eventEnd = rawEnd ? new Date(rawEnd) : eventStart;
         const safeEnd = Number.isFinite(eventEnd.getTime()) ? eventEnd : eventStart;
-        return eventStart <= retainedEnd && safeEnd >= retainedStart;
+        return eventStart <= retainedRange.endDate && safeEnd >= retainedRange.startDate;
       });
     });
     return pruned;
   }
 
+  getPrunedEventMetadataForCache(retainedRange = this.getEventCacheRetainedRange()) {
+    const range = this.getValidRange(retainedRange?.startDate, retainedRange?.endDate);
+    if (!range) return { perCalendarMetadata: {}, coveredRange: null };
+    const perCalendarMetadata = {};
+    let hasRetainedCalendar = false;
+    (this._config.entities || []).forEach((entityId) => {
+      const metadata = this._calendarEventMetadata[entityId] || {};
+      const metadataRange = this.getValidRange(metadata.range?.startDate, metadata.range?.endDate);
+      if (!metadataRange || !Number.isFinite(metadata.lastSuccessfulRefresh)) return;
+      const clippedStart = new Date(Math.max(metadataRange.startDate.getTime(), range.startDate.getTime()));
+      const clippedEnd = new Date(Math.min(metadataRange.endDate.getTime(), range.endDate.getTime()));
+      if (clippedStart > clippedEnd) return;
+      const clippedRange = { startDate: clippedStart, endDate: clippedEnd };
+      perCalendarMetadata[entityId] = {
+        ...metadata,
+        range: clippedRange,
+        lastSuccessfulRefresh: metadata.lastSuccessfulRefresh,
+        refreshFailed: false,
+        firstFailureAt: null
+      };
+      hasRetainedCalendar = true;
+    });
+    if (!hasRetainedCalendar) return { perCalendarMetadata, coveredRange: null };
+    return {
+      perCalendarMetadata,
+      coveredRange: range
+    };
+  }
+
   async persistEventCacheSnapshot({ generation = this._eventWriteGeneration } = {}) {
     if (generation !== this._eventWriteGeneration) return false;
-    if (!this._loadedEventRange || !Number.isFinite(this._lastSuccessfulEventRefresh)) return false;
     const configSignature = this.getEventCacheConfigSignature();
     if (!configSignature) return false;
     const cacheEpoch = getEventCacheMutationEpoch();
+    const retainedRange = this.getEventCacheRetainedRange();
+    const { perCalendarMetadata, coveredRange } = this.getPrunedEventMetadataForCache(retainedRange);
+    if (!coveredRange || !Number.isFinite(this._lastSuccessfulEventRefresh)) return false;
     const snapshot = createEventCacheSnapshot({
       configSignature,
-      startDate: this._loadedEventRange.startDate,
-      endDate: this._loadedEventRange.endDate,
-      eventsByCalendar: this.getPrunedEventsByCalendarForCache(this._eventsByCalendar, this._loadedEventRange),
+      startDate: coveredRange.startDate,
+      endDate: coveredRange.endDate,
+      eventsByCalendar: this.getPrunedEventsByCalendarForCache(this._eventsByCalendar, retainedRange),
       lastSuccessfulRefresh: this._lastSuccessfulEventRefresh,
-      perCalendarMetadata: this._calendarEventMetadata
+      perCalendarMetadata
     });
     if (!snapshot || generation !== this._eventWriteGeneration) return false;
     return writeEventCacheSnapshot(snapshot, { epoch: cacheEpoch });
@@ -12458,7 +12517,7 @@ class SkylightCalendarCard extends HTMLElement {
         requestId: generation
       });
       const warningVisibilityChanged = wasWarningVisible !== this.shouldShowEventRefreshWarning(now);
-      if (failedEntityIds.length === 0) this.persistEventCacheSnapshot({ generation: this._eventWriteGeneration });
+      this.persistEventCacheSnapshot({ generation: this._eventWriteGeneration });
       if (anyChanged || shouldRenderForUnchangedData || failedEntityIds.length > 0 || warningVisibilityChanged) {
         this._lastUnchangedDataRender = now;
         if (preserveScroll) {
@@ -12534,7 +12593,7 @@ class SkylightCalendarCard extends HTMLElement {
         requestId: generation,
         coverageMode: 'union'
       });
-      if (failedEntityIds.length === 0) this.persistEventCacheSnapshot({ generation: this._eventWriteGeneration });
+      this.persistEventCacheSnapshot({ generation: this._eventWriteGeneration });
       if ((render || failedEntityIds.length > 0) && (anyChanged || failedEntityIds.length > 0)) this.render();
       return failedEntityIds.length === 0;
     } finally {
@@ -12559,6 +12618,8 @@ class SkylightCalendarCard extends HTMLElement {
     if (this.isEventManagementDialogOpen() && (force || shouldRefreshForAge)) {
       return;
     }
+
+    if (this._fetching && !force) return;
 
     if (force || shouldRefreshForAge || !this._loadedEventRange) {
       const shouldPreserveScrollDuringRefresh = this._viewMode === 'agenda' && !force && !renderIfCovered;

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -12191,11 +12191,15 @@ class SkylightCalendarCard extends HTMLElement {
       const fetchResultsByCalendar = await this.fetchEventsByCalendarInRange(startDate, endDate);
       const nextEventsByCalendar = { ...this._eventsByCalendar };
       let anySuccess = false;
+      let anyFailure = false;
       let anyChanged = false;
 
       this._config.entities.forEach(entityId => {
         const result = fetchResultsByCalendar[entityId];
-        if (!result?.success) return;
+        if (!result?.success) {
+          anyFailure = true;
+          return;
+        }
         anySuccess = true;
         const events = Array.isArray(result.events) ? result.events : [];
         const oldSignature = this._calendarDataSignatures[entityId];
@@ -12214,9 +12218,11 @@ class SkylightCalendarCard extends HTMLElement {
       const now = Date.now();
       const shouldRenderForUnchangedData = !this._lastUnchangedDataRender ||
         (now - this._lastUnchangedDataRender >= 15 * 60 * 1000);
-      this.applyEventsByCalendar(nextEventsByCalendar, { startDate, endDate, lastSuccessfulRefresh: now });
-      this._lastEventRefreshFailed = false;
-      this.persistEventCacheSnapshot();
+      const refreshMetadata = { startDate, endDate };
+      if (!anyFailure) refreshMetadata.lastSuccessfulRefresh = now;
+      this.applyEventsByCalendar(nextEventsByCalendar, refreshMetadata);
+      this._lastEventRefreshFailed = anyFailure;
+      if (!anyFailure) this.persistEventCacheSnapshot();
       if (anyChanged || shouldRenderForUnchangedData) {
         this._lastUnchangedDataRender = now;
         if (preserveScroll) {

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -596,6 +596,9 @@ async function fetchEventsByCalendarInRange({
   normalizeCalendarEvent
 }) {
   const chunks = getDateRangeChunks(startDate, endDate, 30);
+  const fetchedRange = chunks.length > 0
+    ? { startDate: chunks[0].startDate, endDate: chunks[chunks.length - 1].endDate }
+    : { startDate, endDate };
   const calendarResults = await Promise.all(
     entities.map((entityId, index) => fetchEventsForCalendar({
       hass,
@@ -605,7 +608,8 @@ async function fetchEventsByCalendarInRange({
       formatLocalDate,
       getCalendarColor,
       getEventIdentityKey,
-      normalizeCalendarEvent
+      normalizeCalendarEvent,
+      fetchedRange
     }))
   );
 
@@ -623,7 +627,8 @@ async function fetchEventsForCalendar({
   formatLocalDate,
   getCalendarColor,
   getEventIdentityKey,
-  normalizeCalendarEvent
+  normalizeCalendarEvent,
+  fetchedRange = null
 }) {
   const seen = new Set();
   const color = getCalendarColor(entityId, colorIndex);
@@ -634,7 +639,7 @@ async function fetchEventsForCalendar({
 
   const failedChunks = chunkResults.filter(result => !result?.success);
   if (failedChunks.length > 0) {
-    return { success: false, events: [], failedChunks };
+    return { success: false, events: [], failedChunks, fetchedRange };
   }
 
   const mergedEvents = [];
@@ -650,7 +655,7 @@ async function fetchEventsForCalendar({
     });
   });
 
-  return { success: true, events: mergedEvents };
+  return { success: true, events: mergedEvents, fetchedRange };
 }
 
 async function fetchEventsForChunk({ hass, entityId, chunk, formatLocalDate }) {
@@ -12212,12 +12217,58 @@ class SkylightCalendarCard extends HTMLElement {
     const incoming = this.getValidRange(incomingRange?.startDate, incomingRange?.endDate);
     if (!existing) return incoming;
     if (!incoming) return existing;
-    if (incoming.endDate < existing.startDate) return incoming;
-    if (incoming.startDate > existing.endDate) return incoming;
+    if (incoming.endDate < existing.startDate || incoming.startDate > existing.endDate) {
+      const disjointRanges = [
+        ...(Array.isArray(existingRange?.disjointRanges) ? existingRange.disjointRanges : [existing]),
+        incoming
+      ].map(range => ({
+        startDate: new Date(range.startDate),
+        endDate: new Date(range.endDate)
+      }));
+      return { ...existing, disjointRanges };
+    }
     return {
       startDate: new Date(Math.min(existing.startDate.getTime(), incoming.startDate.getTime())),
       endDate: new Date(Math.max(existing.endDate.getTime(), incoming.endDate.getTime()))
     };
+  }
+
+  doEventRangesOverlap(event, range) {
+    const validRange = this.getValidRange(range?.startDate, range?.endDate);
+    if (!validRange) return false;
+    const eventStart = this.getEventStartDate(event);
+    const eventEnd = this.getEventEndDate(event);
+    if (!Number.isFinite(eventStart.getTime()) || !Number.isFinite(eventEnd.getTime())) return false;
+    return eventStart <= validRange.endDate && eventEnd >= validRange.startDate;
+  }
+
+  isEventContainedInRange(event, range) {
+    const validRange = this.getValidRange(range?.startDate, range?.endDate);
+    if (!validRange) return false;
+    const eventStart = this.getEventStartDate(event);
+    const eventEnd = this.getEventEndDate(event);
+    if (!Number.isFinite(eventStart.getTime()) || !Number.isFinite(eventEnd.getTime())) return false;
+    return eventStart >= validRange.startDate && eventEnd <= validRange.endDate;
+  }
+
+  getEventLogicalIdentityKey(entityId, event) {
+    const stableId = event?.uid || event?.recurring_event_id;
+    return stableId ? `${entityId}|${stableId}` : this.getEventIdentityKey(entityId, event);
+  }
+
+  reconcileEventsForFetchedRange(existingEvents = [], incomingEvents = [], fetchedRange = null) {
+    const range = this.getValidRange(fetchedRange?.startDate, fetchedRange?.endDate);
+    if (!range) return this.mergeEvents(existingEvents, incomingEvents);
+    const incomingLogicalKeys = new Set(
+      (incomingEvents || []).map(event => this.getEventLogicalIdentityKey(event.entityId, event))
+    );
+    const retainedExisting = (existingEvents || []).filter((event) => {
+      const containedInAuthoritativeRange = this.isEventContainedInRange(event, range);
+      if (containedInAuthoritativeRange) return false;
+      const logicalKey = this.getEventLogicalIdentityKey(event.entityId, event);
+      return !(incomingLogicalKeys.has(logicalKey) && this.doEventRangesOverlap(event, range));
+    });
+    return this.mergeEvents(retainedExisting, incomingEvents);
   }
 
   recomputeLoadedEventRange() {
@@ -12353,7 +12404,9 @@ class SkylightCalendarCard extends HTMLElement {
   getEventCacheRetentionAnchorRange() {
     if (this._viewMode === 'agenda') {
       const agendaVisibleRange = this.getValidRange(this._agendaVisibleStartDate, this._agendaVisibleEndDate);
-      if (agendaVisibleRange) return agendaVisibleRange;
+      if (agendaVisibleRange && this.isAgendaRangeWithinCurrentWindow(agendaVisibleRange)) return agendaVisibleRange;
+      const agendaWindowRange = this.getValidRange(this._agendaStartDate, this._agendaEndDate);
+      if (agendaWindowRange) return agendaWindowRange;
       const fallbackStart = new Date(this._currentDate || Date.now());
       fallbackStart.setHours(0, 0, 0, 0);
       const fallbackEnd = new Date(fallbackStart);
@@ -12634,7 +12687,8 @@ class SkylightCalendarCard extends HTMLElement {
           return;
         }
         successfulEntityIds.push(entityId);
-        const mergedEvents = this.mergeEvents(this._eventsByCalendar[entityId] || [], result.events || []);
+        const fetchedRange = this.getValidRange(result.fetchedRange?.startDate, result.fetchedRange?.endDate) || { startDate, endDate };
+        const mergedEvents = this.reconcileEventsForFetchedRange(this._eventsByCalendar[entityId] || [], result.events || [], fetchedRange);
         const oldSignature = this._calendarDataSignatures[entityId];
         const newSignature = this.getCalendarDataSignature(mergedEvents);
         if (oldSignature !== newSignature) anyChanged = true;
@@ -12663,9 +12717,13 @@ class SkylightCalendarCard extends HTMLElement {
         return toResult(false, false, stateChanged);
       }
 
+      const successfulFetchedRange = successfulEntityIds
+        .map(entityId => fetchResultsByCalendar[entityId]?.fetchedRange)
+        .map(range => this.getValidRange(range?.startDate, range?.endDate))
+        .find(Boolean) || { startDate, endDate };
       this.applyEventsByCalendar(nextEventsByCalendar, {
-        startDate,
-        endDate,
+        startDate: successfulFetchedRange.startDate,
+        endDate: successfulFetchedRange.endDate,
         lastSuccessfulRefresh: Date.now(),
         successfulEntityIds,
         failedEntityIds,
@@ -15877,6 +15935,9 @@ class SkylightCalendarCard extends HTMLElement {
       this._agendaStartDate.setHours(0, 0, 0, 0);
       this._agendaEndDate.setDate(this._agendaEndDate.getDate() - backwardDays);
       this._agendaEndDate.setHours(23, 59, 59, 999);
+      this._currentDate = new Date(this._agendaStartDate);
+      this._agendaVisibleStartDate = new Date(this._agendaStartDate);
+      this._agendaVisibleEndDate = new Date(this._agendaEndDate);
     } else if (this._viewMode === 'month') {
       if (this._config.rolling_weeks !== null) {
         // In rolling weeks mode, go back by the number of weeks shown
@@ -15942,6 +16003,9 @@ class SkylightCalendarCard extends HTMLElement {
 
       this._agendaStartDate = targetStart;
       this._agendaEndDate = targetEnd;
+      this._currentDate = new Date(this._agendaStartDate);
+      this._agendaVisibleStartDate = new Date(this._agendaStartDate);
+      this._agendaVisibleEndDate = new Date(this._agendaEndDate);
     } else if (this._viewMode === 'month') {
       if (this._config.rolling_weeks !== null) {
         // In rolling weeks mode, go forward by the number of weeks shown

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -7529,7 +7529,13 @@ function escapeHtmlAttribute(text) {
   return String(text ?? '').replace(/[&<>"']/g, (char) => replacements[char]);
 }
 
-const getEventIdentityKey = (entityId, event) => `${entityId}|${event.uid || ''}|${event.recurring_event_id || ''}|${event.start?.dateTime || event.start?.date || event.start || ''}|${event.end?.dateTime || event.end?.date || event.end || ''}|${event.summary || ''}`;
+const getEventIdentityKey = (entityId, event) => {
+  const uid = event?.uid;
+  const recurrenceId = event?.recurrence_id || event?.recurring_event_id;
+  if (uid && recurrenceId) return `${entityId}|${uid}|${recurrenceId}`;
+  if (uid) return `${entityId}|${uid}`;
+  return `${entityId}|${recurrenceId || ''}|${event?.start?.dateTime || event?.start?.date || event?.start || ''}|${event?.end?.dateTime || event?.end?.date || event?.end || ''}|${event?.summary || ''}`;
+};
 
 const normalizeCalendarEvent = (event, { entityId, color }) => ({
   ...event,
@@ -12250,12 +12256,11 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getEventLogicalIdentityKey(entityId, event) {
-    const uid = event?.uid;
-    const recurrenceId = event?.recurrence_id || event?.recurring_event_id;
-    if (uid && recurrenceId) return `${entityId}|${uid}|${recurrenceId}`;
-    if (uid) return `${entityId}|${uid}`;
-    if (recurrenceId) return `${entityId}|recurrence|${recurrenceId}`;
     return this.getEventIdentityKey(entityId, event);
+  }
+
+  getStableEventIdentityKey(entityId, event) {
+    return event?.uid ? this.getEventIdentityKey(entityId, event) : null;
   }
 
   reconcileEventsForFetchedRange(existingEvents = [], incomingEvents = [], fetchedRange = null) {
@@ -12264,7 +12269,14 @@ class SkylightCalendarCard extends HTMLElement {
     const incomingLogicalKeys = new Set(
       (incomingEvents || []).map(event => this.getEventLogicalIdentityKey(event.entityId, event))
     );
+    const incomingStableKeys = new Set(
+      (incomingEvents || [])
+        .map(event => this.getStableEventIdentityKey(event.entityId, event))
+        .filter(Boolean)
+    );
     const retainedExisting = (existingEvents || []).filter((event) => {
+      const stableKey = this.getStableEventIdentityKey(event.entityId, event);
+      if (stableKey && incomingStableKeys.has(stableKey)) return false;
       const containedInAuthoritativeRange = this.isEventContainedInRange(event, range);
       if (containedInAuthoritativeRange) return false;
       const logicalKey = this.getEventLogicalIdentityKey(event.entityId, event);

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -659,13 +659,15 @@ async function fetchEventsForChunk({ hass, entityId, chunk, formatLocalDate }) {
 
   try {
     const events = await fetchEventsViaWebSocket({ hass, entityId, chunkStartStr, chunkEndStr });
-    return { success: true, events: Array.isArray(events) ? events : [] };
+    if (!Array.isArray(events)) throw new Error('Calendar WebSocket response was not an array');
+    return { success: true, events };
   } catch (error) {
     try {
       const startDateOnly = formatLocalDate(chunk.startDate);
       const endDateOnly = formatLocalDate(chunk.endDate);
       const events = await hass.callApi('GET', `calendars/${entityId}?start=${startDateOnly}T00:00:00Z&end=${endDateOnly}T23:59:59Z`);
-      return { success: true, events: Array.isArray(events) ? events : [] };
+      if (!Array.isArray(events)) throw new Error('Calendar REST response was not an array');
+      return { success: true, events };
     } catch (error2) {
       console.error(`Failed to fetch events for ${entityId}:`, error2.message || error2);
       return { success: false, events: [], error: error2 };
@@ -761,14 +763,14 @@ const openEventCacheDb = () => new Promise((resolve, reject) => {
 
 const transact = async (mode, callback) => {
   const db = await openEventCacheDb();
-  if (!db) return null;
+  if (!db) return { available: false, value: null };
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE_NAME, mode);
     const store = tx.objectStore(STORE_NAME);
     let callbackResult;
     tx.oncomplete = () => {
       db.close?.();
-      resolve(callbackResult);
+      resolve({ available: true, value: callbackResult });
     };
     tx.onerror = () => {
       db.close?.();
@@ -779,8 +781,8 @@ const transact = async (mode, callback) => {
   });
 };
 
-function buildEventCacheConfigSignature({ entities = [], timeZone = null, colors = {} } = {}) {
-  return toStableString({ entities, timeZone: timeZone || null, colors: colors || {} });
+function buildEventCacheConfigSignature({ entities = [], timeZone = null, colors = {}, userScope = null } = {}) {
+  return toStableString({ entities, timeZone: timeZone || null, colors: colors || {}, userScope: userScope || null });
 }
 
 function buildEventCacheKey(configSignature) {
@@ -792,6 +794,9 @@ function normalizeEventCacheSnapshot(snapshot, { configSignature } = {}) {
   if (snapshot.schemaVersion !== EVENT_CACHE_SCHEMA_VERSION) return null;
   if (configSignature && snapshot.configSignature !== configSignature) return null;
   if (!snapshot.coveredRange || !snapshot.coveredRange.start || !snapshot.coveredRange.end) return null;
+  const coveredStart = new Date(snapshot.coveredRange.start);
+  const coveredEnd = new Date(snapshot.coveredRange.end);
+  if (!Number.isFinite(coveredStart.getTime()) || !Number.isFinite(coveredEnd.getTime()) || coveredStart > coveredEnd) return null;
   if (!Number.isFinite(snapshot.lastSuccessfulRefresh)) return null;
   if (!snapshot.eventsByCalendar || typeof snapshot.eventsByCalendar !== 'object') return null;
 
@@ -806,15 +811,16 @@ function normalizeEventCacheSnapshot(snapshot, { configSignature } = {}) {
     updatedAt: Number(snapshot.updatedAt) || snapshot.lastSuccessfulRefresh,
     lastSuccessfulRefresh: snapshot.lastSuccessfulRefresh,
     coveredRange: {
-      start: snapshot.coveredRange.start,
-      end: snapshot.coveredRange.end
+      start: coveredStart.toISOString(),
+      end: coveredEnd.toISOString()
     },
     configSignature: snapshot.configSignature,
-    eventsByCalendar
+    eventsByCalendar,
+    perCalendarMetadata: snapshot.perCalendarMetadata && typeof snapshot.perCalendarMetadata === 'object' ? snapshot.perCalendarMetadata : {}
   };
 }
 
-function createEventCacheSnapshot({ configSignature, startDate, endDate, eventsByCalendar, lastSuccessfulRefresh = Date.now() }) {
+function createEventCacheSnapshot({ configSignature, startDate, endDate, eventsByCalendar, lastSuccessfulRefresh = Date.now(), perCalendarMetadata = {} }) {
   return normalizeEventCacheSnapshot({
     schemaVersion: EVENT_CACHE_SCHEMA_VERSION,
     key: buildEventCacheKey(configSignature),
@@ -825,21 +831,23 @@ function createEventCacheSnapshot({ configSignature, startDate, endDate, eventsB
       end: endDate instanceof Date ? endDate.toISOString() : endDate
     },
     configSignature,
-    eventsByCalendar
+    eventsByCalendar,
+    perCalendarMetadata
   }, { configSignature });
 }
 
 async function readEventCacheSnapshot(configSignature) {
   try {
     const key = buildEventCacheKey(configSignature);
-    const snapshot = await transact('readonly', (store, setResult) => {
+    const result = await transact('readonly', (store, setResult) => {
       const request = store.get(key);
       request.onsuccess = () => setResult(request.result || null);
     });
-    return normalizeEventCacheSnapshot(snapshot, { configSignature });
+    if (!result.available) return { available: false, snapshot: null };
+    return { available: true, snapshot: normalizeEventCacheSnapshot(result.value, { configSignature }) };
   } catch (error) {
     console.warn('Failed to read Daylight event cache:', error);
-    return null;
+    return { available: false, snapshot: null, error };
   }
 }
 
@@ -847,7 +855,7 @@ async function writeEventCacheSnapshot(snapshot) {
   const normalized = normalizeEventCacheSnapshot(snapshot, { configSignature: snapshot?.configSignature });
   if (!normalized) return false;
   try {
-    await transact('readwrite', (store) => {
+    const result = await transact('readwrite', (store) => {
       store.put(normalized);
       const getAllRequest = store.getAll();
       getAllRequest.onsuccess = () => {
@@ -857,7 +865,7 @@ async function writeEventCacheSnapshot(snapshot) {
         entries.slice(MAX_CACHE_ENTRIES).forEach((entry) => store.delete(entry.key));
       };
     });
-    return true;
+    return !!result.available;
   } catch (error) {
     console.warn('Failed to write Daylight event cache:', error);
     return false;
@@ -866,7 +874,7 @@ async function writeEventCacheSnapshot(snapshot) {
 
 async function clearAllEventCacheSnapshots() {
   try {
-    await transact('readwrite', (store) => {
+    const result = await transact('readwrite', (store) => {
       const getAllKeysRequest = store.getAllKeys();
       getAllKeysRequest.onsuccess = () => {
         (getAllKeysRequest.result || [])
@@ -874,7 +882,7 @@ async function clearAllEventCacheSnapshots() {
           .forEach((key) => store.delete(key));
       };
     });
-    return true;
+    return !!result.available;
   } catch (error) {
     console.warn('Failed to clear Daylight event cache:', error);
     return false;
@@ -6068,7 +6076,8 @@ const TRANSLATIONS = {
       durationMinutes: '{count} minutes',
       moreEvents: '+{count} de plus',
       eventTitleWithStartTime: '{title}, {time}',
-      monthWeekPrefix: 'Sem'
+      monthWeekPrefix: 'Sem',
+      eventRefreshStaleWarning: 'Impossible d’actualiser les données du calendrier depuis {time}'
     }
   },
 
@@ -6182,7 +6191,8 @@ const TRANSLATIONS = {
       durationMinutes: '{count} Minuten',
       moreEvents: '+{count} mehr',
       eventTitleWithStartTime: '{title}, {time}',
-      monthWeekPrefix: 'KW'
+      monthWeekPrefix: 'KW',
+      eventRefreshStaleWarning: 'Kalenderdaten konnten seit {time} nicht aktualisiert werden'
     }
   },
 
@@ -6296,7 +6306,8 @@ const TRANSLATIONS = {
       durationMinutes: '{count} minuten',
       moreEvents: '+{count} meer',
       eventTitleWithStartTime: '{title}, {time}',
-      monthWeekPrefix: 'KW'
+      monthWeekPrefix: 'KW',
+      eventRefreshStaleWarning: 'Kan agendagegevens niet vernieuwen sinds {time}'
     }
   },
   es: {
@@ -6409,7 +6420,8 @@ const TRANSLATIONS = {
       durationMinutes: '{count} minutos',
       moreEvents: '+{count} más',
       eventTitleWithStartTime: '{title}, {time}',
-      monthWeekPrefix: 'Sem.'
+      monthWeekPrefix: 'Sem.',
+      eventRefreshStaleWarning: 'No se pueden actualizar los datos del calendario desde {time}'
     }
   },
   
@@ -6528,7 +6540,8 @@ const TRANSLATIONS = {
       durationMinutes: '{count} minutit',
       moreEvents: '+{count} veel',
       eventTitleWithStartTime: '{title}, {time}',
-      monthWeekPrefix: 'Nädal'
+      monthWeekPrefix: 'Nädal',
+      eventRefreshStaleWarning: 'Kalendriandmeid ei saanud värskendada alates {time}'
     }
   },
 
@@ -6642,7 +6655,8 @@ const TRANSLATIONS = {
       durationMinutes: '{count} minuts',
       moreEvents: '+{count} més',
       eventTitleWithStartTime: '{title}, {time}',
-      monthWeekPrefix: 'Set.'
+      monthWeekPrefix: 'Set.',
+      eventRefreshStaleWarning: 'No es poden actualitzar les dades del calendari des de {time}'
     }
   },
 
@@ -6756,7 +6770,8 @@ const TRANSLATIONS = {
       durationMinutes: '{count} minutter',
       moreEvents: '+{count} flere',
       eventTitleWithStartTime: '{title}, {time}',
-      monthWeekPrefix: 'Uge'
+      monthWeekPrefix: 'Uge',
+      eventRefreshStaleWarning: 'Kan ikke opdatere kalenderdata siden {time}'
     }
   },
 
@@ -6864,7 +6879,8 @@ const TRANSLATIONS = {
       durationMinutes: '{count} minuter',
       moreEvents: '+{count} fler',
       eventTitleWithStartTime: '{title}, {time}',
-      monthWeekPrefix: 'v.'
+      monthWeekPrefix: 'v.',
+      eventRefreshStaleWarning: 'Det går inte att uppdatera kalenderdata sedan {time}'
     }
   }
 };
@@ -10600,9 +10616,14 @@ class SkylightCalendarCard extends HTMLElement {
     this._events = [];
     this._eventsByCalendar = {};
     this._eventCacheGeneration = 0;
+    this._eventFetchGeneration = 0;
+    this._eventWriteGeneration = 0;
+    this._pendingEventRefreshAfterCurrentFetch = false;
+    this._eventRefreshWarningTimer = null;
     this._eventCacheHydrated = false;
     this._lastSuccessfulEventRefresh = null;
     this._lastEventRefreshFailed = false;
+    this._calendarEventMetadata = {};
     this._currentDate = new Date();
     this._viewMode = DEFAULT_VIEW; // 'month', 'week-compact', 'week-standard', or 'agenda'
     this._weekStart = new Date();
@@ -11212,9 +11233,14 @@ class SkylightCalendarCard extends HTMLElement {
     this._loadedEventRange = null;
     this._eventsByCalendar = {};
     this._eventCacheGeneration += 1;
+    this._eventFetchGeneration += 1;
+    this._eventWriteGeneration += 1;
+    this._pendingEventRefreshAfterCurrentFetch = false;
     this._eventCacheHydrated = false;
     this._lastSuccessfulEventRefresh = null;
     this._lastEventRefreshFailed = false;
+    this._calendarEventMetadata = {};
+    this.clearEventRefreshWarningTimer();
     this._calendarDataSignatures = {};
     this._lastUnchangedDataRender = null;
     this._weatherForecastController.handleConfigChanged(previousHeaderWeatherSensor, this._config.header_weather_sensor);
@@ -11290,6 +11316,7 @@ class SkylightCalendarCard extends HTMLElement {
 
     // Refresh only when stale or when current view needs dates outside loaded range.
     if (!oldHass) {
+      this.loadEventCacheForCurrentConfig();
       this.ensureEventsForCurrentRange({ force: true });
     } else {
       this.ensureEventsForCurrentRange();
@@ -12107,55 +12134,142 @@ class SkylightCalendarCard extends HTMLElement {
     return getCalendarDataSignature(events);
   }
 
+  getEventCacheUserScope() {
+    return this._hass?.user?.id || this._hass?.user?.name || this._hass?.auth?.data?.user?.id || null;
+  }
+
   getEventCacheConfigSignature() {
+    const userScope = this.getEventCacheUserScope();
+    if (!userScope) return null;
     return buildEventCacheConfigSignature({
       entities: this._config?.entities || [],
       timeZone: this.getConfiguredTimeZone(),
-      colors: this._config?.colors || {}
+      colors: this._config?.colors || {},
+      userScope
     });
   }
 
-  applyEventsByCalendar(eventsByCalendar = {}, { startDate, endDate, lastSuccessfulRefresh = null } = {}) {
-    const normalizedByCalendar = {};
-    (this._config.entities || []).forEach((entityId) => {
-      normalizedByCalendar[entityId] = Array.isArray(eventsByCalendar[entityId]) ? eventsByCalendar[entityId] : [];
-      this._calendarDataSignatures[entityId] = this.getCalendarDataSignature(normalizedByCalendar[entityId]);
+  getValidRange(startDate, endDate) {
+    const start = startDate instanceof Date ? startDate : new Date(startDate);
+    const end = endDate instanceof Date ? endDate : new Date(endDate);
+    if (!Number.isFinite(start.getTime()) || !Number.isFinite(end.getTime()) || start > end) return null;
+    return { startDate: start, endDate: end };
+  }
+
+  recomputeLoadedEventRange() {
+    const ranges = (this._config.entities || []).map((entityId) => {
+      const range = this._calendarEventMetadata[entityId]?.range;
+      return this.getValidRange(range?.startDate, range?.endDate);
     });
-    this._eventsByCalendar = normalizedByCalendar;
-    this._events = sortEventsByStartDate(Object.values(normalizedByCalendar).flat(), {
+    if (ranges.length === 0 || ranges.some(range => !range)) {
+      this._loadedEventRange = null;
+      return;
+    }
+    const startDate = new Date(Math.max(...ranges.map(range => range.startDate.getTime())));
+    const endDate = new Date(Math.min(...ranges.map(range => range.endDate.getTime())));
+    this._loadedEventRange = startDate <= endDate ? { startDate, endDate } : null;
+  }
+
+  recomputeLastSuccessfulEventRefresh() {
+    const refreshTimes = (this._config.entities || [])
+      .map(entityId => this._calendarEventMetadata[entityId]?.lastSuccessfulRefresh)
+      .filter(Number.isFinite);
+    this._lastSuccessfulEventRefresh = refreshTimes.length ? Math.min(...refreshTimes) : null;
+  }
+
+  recomputeEventRefreshFailure() {
+    this._lastEventRefreshFailed = (this._config.entities || [])
+      .some(entityId => this._calendarEventMetadata[entityId]?.refreshFailed);
+  }
+
+  recomputeEventState() {
+    this._events = sortEventsByStartDate(Object.values(this._eventsByCalendar).flat(), {
       getEventStartDate: this.getEventStartDate.bind(this)
     });
-    if (startDate && endDate) this._loadedEventRange = { startDate, endDate };
-    if (Number.isFinite(lastSuccessfulRefresh)) this._lastSuccessfulEventRefresh = lastSuccessfulRefresh;
+    this.recomputeLoadedEventRange();
+    this.recomputeLastSuccessfulEventRefresh();
+    this.recomputeEventRefreshFailure();
+    this.scheduleEventRefreshWarningTimer();
+  }
+
+  applyEventsByCalendar(eventsByCalendar = {}, { startDate, endDate, lastSuccessfulRefresh = null, successfulEntityIds = null, failedEntityIds = [], source = 'network', requestId = null } = {}) {
+    const range = this.getValidRange(startDate, endDate);
+    const successfulSet = successfulEntityIds ? new Set(successfulEntityIds) : new Set(this._config.entities || []);
+    const failedSet = new Set(failedEntityIds || []);
+    (this._config.entities || []).forEach((entityId) => {
+      const existingMetadata = this._calendarEventMetadata[entityId] || {};
+      if (!successfulSet.has(entityId)) {
+        this._calendarEventMetadata[entityId] = {
+          ...existingMetadata,
+          lastSuccessfulRefresh: existingMetadata.lastSuccessfulRefresh ?? this._lastSuccessfulEventRefresh,
+          refreshFailed: failedSet.has(entityId) || existingMetadata.refreshFailed
+        };
+        return;
+      }
+      if (source === 'cache' && existingMetadata.lastNetworkSuccessRequest && existingMetadata.lastNetworkSuccessRequest > requestId) return;
+      const events = Array.isArray(eventsByCalendar[entityId]) ? eventsByCalendar[entityId] : [];
+      this._eventsByCalendar[entityId] = events;
+      this._calendarDataSignatures[entityId] = this.getCalendarDataSignature(events);
+      this._calendarEventMetadata[entityId] = {
+        ...existingMetadata,
+        range: range || existingMetadata.range || null,
+        lastSuccessfulRefresh: Number.isFinite(lastSuccessfulRefresh) ? lastSuccessfulRefresh : existingMetadata.lastSuccessfulRefresh,
+        refreshFailed: false,
+        lastNetworkSuccessRequest: source === 'network' ? requestId : existingMetadata.lastNetworkSuccessRequest
+      };
+    });
+    this.recomputeEventState();
   }
 
   async loadEventCacheForCurrentConfig() {
     const generation = ++this._eventCacheGeneration;
+    const requestId = this._eventFetchGeneration;
     const configSignature = this.getEventCacheConfigSignature();
-    const snapshot = await readEventCacheSnapshot(configSignature);
-    if (generation !== this._eventCacheGeneration || !snapshot || this._lastSuccessfulEventRefresh) return;
+    if (!configSignature) return;
+    const { available, snapshot } = await readEventCacheSnapshot(configSignature);
+    if (generation !== this._eventCacheGeneration || !available || !snapshot) return;
+    const cacheEventsByCalendar = {};
+    const successfulEntityIds = [];
+    (this._config.entities || []).forEach((entityId) => {
+      const metadata = this._calendarEventMetadata[entityId] || {};
+      if (metadata.lastNetworkSuccessRequest && metadata.lastNetworkSuccessRequest > requestId) return;
+      cacheEventsByCalendar[entityId] = snapshot.eventsByCalendar[entityId] || [];
+      successfulEntityIds.push(entityId);
+    });
+    if (successfulEntityIds.length === 0) return;
     this._eventCacheHydrated = true;
-    this.applyEventsByCalendar(snapshot.eventsByCalendar, {
+    this.applyEventsByCalendar(cacheEventsByCalendar, {
       startDate: new Date(snapshot.coveredRange.start),
       endDate: new Date(snapshot.coveredRange.end),
-      lastSuccessfulRefresh: snapshot.lastSuccessfulRefresh
+      lastSuccessfulRefresh: snapshot.lastSuccessfulRefresh,
+      successfulEntityIds,
+      source: 'cache',
+      requestId
     });
     this.render();
   }
 
-  persistEventCacheSnapshot() {
-    if (!this._loadedEventRange) return;
+  async persistEventCacheSnapshot({ generation = this._eventWriteGeneration } = {}) {
+    if (!this._loadedEventRange || !Number.isFinite(this._lastSuccessfulEventRefresh)) return false;
+    const configSignature = this.getEventCacheConfigSignature();
+    if (!configSignature) return false;
     const snapshot = createEventCacheSnapshot({
-      configSignature: this.getEventCacheConfigSignature(),
+      configSignature,
       startDate: this._loadedEventRange.startDate,
       endDate: this._loadedEventRange.endDate,
       eventsByCalendar: this._eventsByCalendar,
-      lastSuccessfulRefresh: this._lastSuccessfulEventRefresh || Date.now()
+      lastSuccessfulRefresh: this._lastSuccessfulEventRefresh,
+      perCalendarMetadata: this._calendarEventMetadata
     });
-    writeEventCacheSnapshot(snapshot);
+    if (!snapshot) return false;
+    const persisted = await writeEventCacheSnapshot(snapshot);
+    return generation === this._eventWriteGeneration && persisted;
   }
 
   async flushEventCache({ refresh = true } = {}) {
+    this._eventCacheGeneration += 1;
+    this._eventFetchGeneration += 1;
+    this._eventWriteGeneration += 1;
     const cleared = await clearAllEventCacheSnapshots();
     this._eventCacheGeneration += 1;
     this._eventCacheHydrated = false;
@@ -12163,54 +12277,100 @@ class SkylightCalendarCard extends HTMLElement {
     this._events = [];
     this._loadedEventRange = null;
     this._calendarDataSignatures = {};
+    this._calendarEventMetadata = {};
     this._lastSuccessfulEventRefresh = null;
     this._lastEventRefreshFailed = false;
+    this.clearEventRefreshWarningTimer();
     this.render();
-    if (refresh && this._hass) this.ensureEventsForCurrentRange({ force: true });
+    if (refresh && this._hass) {
+      if (this._fetching) {
+        this._pendingEventRefreshAfterCurrentFetch = true;
+      } else {
+        await this.ensureEventsForCurrentRange({ force: true });
+      }
+    }
     return cleared;
   }
 
+  getOldestFailedEventRefreshTime() {
+    const failedTimes = (this._config.entities || [])
+      .map(entityId => this._calendarEventMetadata[entityId])
+      .filter(metadata => metadata?.refreshFailed && Number.isFinite(metadata.lastSuccessfulRefresh))
+      .map(metadata => metadata.lastSuccessfulRefresh);
+    return failedTimes.length ? Math.min(...failedTimes) : null;
+  }
+
+  clearEventRefreshWarningTimer() {
+    if (this._eventRefreshWarningTimer) clearTimeout(this._eventRefreshWarningTimer);
+    this._eventRefreshWarningTimer = null;
+  }
+
+  scheduleEventRefreshWarningTimer() {
+    this.clearEventRefreshWarningTimer();
+    const oldestFailedRefresh = this.getOldestFailedEventRefreshTime();
+    if (!Number.isFinite(oldestFailedRefresh)) return;
+    const delay = Math.max(0, oldestFailedRefresh + 30 * 60 * 1000 - Date.now());
+    this._eventRefreshWarningTimer = setTimeout(() => {
+      this._eventRefreshWarningTimer = null;
+      this.render();
+    }, delay);
+  }
+
   shouldShowEventRefreshWarning(now = Date.now()) {
-    return !!this._lastEventRefreshFailed && Number.isFinite(this._lastSuccessfulEventRefresh) &&
-      (now - this._lastSuccessfulEventRefresh) > 30 * 60 * 1000;
+    const oldestFailedRefresh = this.getOldestFailedEventRefreshTime();
+    return Number.isFinite(oldestFailedRefresh) && (now - oldestFailedRefresh) > 30 * 60 * 1000;
   }
 
   renderEventRefreshWarning() {
     if (!this.shouldShowEventRefreshWarning()) return '';
-    return `<div class="event-refresh-warning" role="status">${this.t('eventRefreshStaleWarning', { time: this.formatTime(new Date(this._lastSuccessfulEventRefresh)) })}</div>`;
+    const oldestFailedRefresh = this.getOldestFailedEventRefreshTime();
+    return `<div class="event-refresh-warning" role="status">${this.t('eventRefreshStaleWarning', { time: this.formatTime(new Date(oldestFailedRefresh)) })}</div>`;
   }
 
   async updateEvents({ preserveScroll = false } = {}) {
-    if (!this._hass || this._fetching) return;
+    if (!this._hass) return;
+    if (this._fetching) {
+      this._pendingEventRefreshAfterCurrentFetch = true;
+      return;
+    }
 
     const { startDate, endDate } = this.getEventFetchRange();
+    const generation = ++this._eventFetchGeneration;
     this._fetching = true;
     this._lastFetch = Date.now();
 
     try {
       const fetchResultsByCalendar = await this.fetchEventsByCalendarInRange(startDate, endDate);
+      if (generation !== this._eventFetchGeneration) return;
       const nextEventsByCalendar = { ...this._eventsByCalendar };
-      let anySuccess = false;
-      let anyFailure = false;
+      const successfulEntityIds = [];
+      const failedEntityIds = [];
       let anyChanged = false;
 
       this._config.entities.forEach(entityId => {
         const result = fetchResultsByCalendar[entityId];
         if (!result?.success) {
-          anyFailure = true;
+          failedEntityIds.push(entityId);
           return;
         }
-        anySuccess = true;
+        successfulEntityIds.push(entityId);
         const events = Array.isArray(result.events) ? result.events : [];
         const oldSignature = this._calendarDataSignatures[entityId];
         const newSignature = this.getCalendarDataSignature(events);
         if (oldSignature !== newSignature) anyChanged = true;
         nextEventsByCalendar[entityId] = events;
-        this._calendarDataSignatures[entityId] = newSignature;
       });
 
-      if (!anySuccess) {
-        this._lastEventRefreshFailed = true;
+      if (successfulEntityIds.length === 0) {
+        failedEntityIds.forEach((entityId) => {
+          const existingMetadata = this._calendarEventMetadata[entityId] || {};
+          this._calendarEventMetadata[entityId] = {
+            ...existingMetadata,
+            lastSuccessfulRefresh: existingMetadata.lastSuccessfulRefresh ?? this._lastSuccessfulEventRefresh,
+            refreshFailed: true
+          };
+        });
+        this.recomputeEventState();
         this.render();
         return;
       }
@@ -12218,12 +12378,17 @@ class SkylightCalendarCard extends HTMLElement {
       const now = Date.now();
       const shouldRenderForUnchangedData = !this._lastUnchangedDataRender ||
         (now - this._lastUnchangedDataRender >= 15 * 60 * 1000);
-      const refreshMetadata = { startDate, endDate };
-      if (!anyFailure) refreshMetadata.lastSuccessfulRefresh = now;
-      this.applyEventsByCalendar(nextEventsByCalendar, refreshMetadata);
-      this._lastEventRefreshFailed = anyFailure;
-      if (!anyFailure) this.persistEventCacheSnapshot();
-      if (anyChanged || shouldRenderForUnchangedData) {
+      this.applyEventsByCalendar(nextEventsByCalendar, {
+        startDate,
+        endDate,
+        lastSuccessfulRefresh: now,
+        successfulEntityIds,
+        failedEntityIds,
+        source: 'network',
+        requestId: generation
+      });
+      if (failedEntityIds.length === 0) this.persistEventCacheSnapshot({ generation: this._eventWriteGeneration });
+      if (anyChanged || shouldRenderForUnchangedData || failedEntityIds.length > 0) {
         this._lastUnchangedDataRender = now;
         if (preserveScroll) {
           this.renderPreservingAgendaScroll();
@@ -12233,28 +12398,77 @@ class SkylightCalendarCard extends HTMLElement {
       }
     } finally {
       this._fetching = false;
+      if (this._pendingEventRefreshAfterCurrentFetch) {
+        this._pendingEventRefreshAfterCurrentFetch = false;
+        this.ensureEventsForCurrentRange({ force: true });
+      }
     }
   }
 
   async extendEventsForRange(startDate, endDate, { render = true } = {}) {
-    if (!this._hass || this._fetching) return;
+    if (!this._hass) return;
+    if (this._fetching) {
+      this._pendingEventRefreshAfterCurrentFetch = true;
+      return false;
+    }
 
+    const generation = ++this._eventFetchGeneration;
     this._fetching = true;
     this._lastFetch = Date.now();
 
     try {
-      const additionalEvents = await this.fetchEventsInRange(startDate, endDate);
-      if (!additionalEvents) {
-        this._lastEventRefreshFailed = true;
+      const fetchResultsByCalendar = await this.fetchEventsByCalendarInRange(startDate, endDate);
+      if (generation !== this._eventFetchGeneration) return false;
+      const nextEventsByCalendar = { ...this._eventsByCalendar };
+      const successfulEntityIds = [];
+      const failedEntityIds = [];
+      let anyChanged = false;
+
+      this._config.entities.forEach(entityId => {
+        const result = fetchResultsByCalendar[entityId];
+        if (!result?.success) {
+          failedEntityIds.push(entityId);
+          return;
+        }
+        successfulEntityIds.push(entityId);
+        const mergedEvents = this.mergeEvents(this._eventsByCalendar[entityId] || [], result.events || []);
+        const oldSignature = this._calendarDataSignatures[entityId];
+        const newSignature = this.getCalendarDataSignature(mergedEvents);
+        if (oldSignature !== newSignature) anyChanged = true;
+        nextEventsByCalendar[entityId] = mergedEvents;
+      });
+
+      if (successfulEntityIds.length === 0) {
+        failedEntityIds.forEach((entityId) => {
+          const existingMetadata = this._calendarEventMetadata[entityId] || {};
+          this._calendarEventMetadata[entityId] = {
+            ...existingMetadata,
+            lastSuccessfulRefresh: existingMetadata.lastSuccessfulRefresh ?? this._lastSuccessfulEventRefresh,
+            refreshFailed: true
+          };
+        });
+        this.recomputeEventState();
         return false;
       }
-      this._lastEventRefreshFailed = false;
-      this._events = this.mergeEvents(this._events, additionalEvents);
-      if (render) {
-        this.render();
-      }
+
+      this.applyEventsByCalendar(nextEventsByCalendar, {
+        startDate,
+        endDate,
+        lastSuccessfulRefresh: Date.now(),
+        successfulEntityIds,
+        failedEntityIds,
+        source: 'network',
+        requestId: generation
+      });
+      if (failedEntityIds.length === 0) this.persistEventCacheSnapshot({ generation: this._eventWriteGeneration });
+      if (render && (anyChanged || failedEntityIds.length > 0)) this.render();
+      return failedEntityIds.length === 0;
     } finally {
       this._fetching = false;
+      if (this._pendingEventRefreshAfterCurrentFetch) {
+        this._pendingEventRefreshAfterCurrentFetch = false;
+        this.ensureEventsForCurrentRange({ force: true });
+      }
     }
   }
 
@@ -12306,17 +12520,13 @@ class SkylightCalendarCard extends HTMLElement {
       missingRanges.push({ startDate: missingEndStart, endDate });
     }
 
+    let allExtended = true;
     for (const range of missingRanges) {
       const extended = await this.extendEventsForRange(range.startDate, range.endDate, { render: false });
-      if (extended === false) return;
+      if (extended === false) allExtended = false;
     }
 
-    this._loadedEventRange = {
-      startDate: new Date(Math.min(this._loadedEventRange.startDate.getTime(), startDate.getTime())),
-      endDate: new Date(Math.max(this._loadedEventRange.endDate.getTime(), endDate.getTime()))
-    };
-
-    this.render();
+    if (allExtended) this.render();
   }
 
   getEventFetchRange() {
@@ -12476,6 +12686,9 @@ class SkylightCalendarCard extends HTMLElement {
     window.removeEventListener('resize', this._handleViewportResize);
     window.removeEventListener('daylight-calendar-card-flush-event-cache', this._handleEventCacheFlush);
     window.visualViewport?.removeEventListener('resize', this._handleViewportResize);
+    this._eventCacheGeneration += 1;
+    this._eventFetchGeneration += 1;
+    this.clearEventRefreshWarningTimer();
     this.cancelMonthCompactMeasurement();
     if (this._monthGridResizeObserver) {
       this._monthGridResizeObserver.disconnect();

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -12209,11 +12209,14 @@ class SkylightCalendarCard extends HTMLElement {
 
   unionEventRanges(existingRange, incomingRange) {
     const existing = this.getValidRange(existingRange?.startDate, existingRange?.endDate);
-    if (!existing) return incomingRange;
-    if (!incomingRange) return existing;
+    const incoming = this.getValidRange(incomingRange?.startDate, incomingRange?.endDate);
+    if (!existing) return incoming;
+    if (!incoming) return existing;
+    if (incoming.endDate < existing.startDate) return incoming;
+    if (incoming.startDate > existing.endDate) return incoming;
     return {
-      startDate: new Date(Math.min(existing.startDate.getTime(), incomingRange.startDate.getTime())),
-      endDate: new Date(Math.max(existing.endDate.getTime(), incomingRange.endDate.getTime()))
+      startDate: new Date(Math.min(existing.startDate.getTime(), incoming.startDate.getTime())),
+      endDate: new Date(Math.max(existing.endDate.getTime(), incoming.endDate.getTime()))
     };
   }
 
@@ -12381,8 +12384,7 @@ class SkylightCalendarCard extends HTMLElement {
     Object.entries(eventsByCalendar || {}).forEach(([entityId, events]) => {
       pruned[entityId] = (Array.isArray(events) ? events : []).filter((event) => {
         const eventStart = this.getEventStartDate(event);
-        const rawEnd = event?.end?.dateTime || event?.end?.date || event?.end;
-        const eventEnd = rawEnd ? new Date(rawEnd) : eventStart;
+        const eventEnd = this.getEventEndDate(event);
         const safeEnd = Number.isFinite(eventEnd.getTime()) ? eventEnd : eventStart;
         return eventStart <= retainedRange.endDate && safeEnd >= retainedRange.startDate;
       });
@@ -12597,11 +12599,14 @@ class SkylightCalendarCard extends HTMLElement {
     }
   }
 
-  async extendEventsForRange(startDate, endDate, { render = true } = {}) {
-    if (!this._hass) return;
+  async extendEventsForRange(startDate, endDate, { render = true, returnDetails = false } = {}) {
+    const toResult = (complete, dataChanged = false, stateChanged = false) => (
+      returnDetails ? { complete, dataChanged, stateChanged, applied: dataChanged || stateChanged } : complete
+    );
+    if (!this._hass) return toResult(false);
     if (this._fetching) {
       this._pendingEventRefreshAfterCurrentFetch = true;
-      return false;
+      return toResult(false);
     }
 
     const generation = ++this._eventFetchGeneration;
@@ -12616,6 +12621,11 @@ class SkylightCalendarCard extends HTMLElement {
       const successfulEntityIds = [];
       const failedEntityIds = [];
       let anyChanged = false;
+      const stateSignatureBefore = this.toStableString((this._config.entities || []).map(entityId => ({
+        entityId,
+        refreshFailed: !!this._calendarEventMetadata[entityId]?.refreshFailed,
+        firstFailureAt: this._calendarEventMetadata[entityId]?.firstFailureAt ?? null
+      })));
 
       this._config.entities.forEach(entityId => {
         const result = fetchResultsByCalendar[entityId];
@@ -12643,7 +12653,14 @@ class SkylightCalendarCard extends HTMLElement {
           };
         });
         this.recomputeEventState();
-        return false;
+        const stateSignatureAfter = this.toStableString((this._config.entities || []).map(entityId => ({
+          entityId,
+          refreshFailed: !!this._calendarEventMetadata[entityId]?.refreshFailed,
+          firstFailureAt: this._calendarEventMetadata[entityId]?.firstFailureAt ?? null
+        })));
+        const stateChanged = stateSignatureBefore !== stateSignatureAfter;
+        if (!returnDetails && (render || stateChanged) && stateChanged) this.render();
+        return toResult(false, false, stateChanged);
       }
 
       this.applyEventsByCalendar(nextEventsByCalendar, {
@@ -12657,8 +12674,14 @@ class SkylightCalendarCard extends HTMLElement {
         coverageMode: 'union'
       });
       this.persistEventCacheSnapshot({ generation: this._eventWriteGeneration });
-      if ((render || failedEntityIds.length > 0) && (anyChanged || failedEntityIds.length > 0)) this.render();
-      return failedEntityIds.length === 0;
+      const stateSignatureAfter = this.toStableString((this._config.entities || []).map(entityId => ({
+        entityId,
+        refreshFailed: !!this._calendarEventMetadata[entityId]?.refreshFailed,
+        firstFailureAt: this._calendarEventMetadata[entityId]?.firstFailureAt ?? null
+      })));
+      const stateChanged = stateSignatureBefore !== stateSignatureAfter;
+      if (!returnDetails && (render || failedEntityIds.length > 0) && (anyChanged || stateChanged)) this.render();
+      return toResult(failedEntityIds.length === 0, anyChanged, stateChanged);
     } finally {
       this._fetching = false;
       this._activeEventFetchRange = null;
@@ -12730,25 +12753,23 @@ class SkylightCalendarCard extends HTMLElement {
 
     if (startDate < this._loadedEventRange.startDate) {
       const missingStartEnd = new Date(this._loadedEventRange.startDate);
-      missingStartEnd.setDate(missingStartEnd.getDate() - 1);
-      missingStartEnd.setHours(23, 59, 59, 999);
       missingRanges.push({ startDate, endDate: missingStartEnd });
     }
 
     if (endDate > this._loadedEventRange.endDate) {
       const missingEndStart = new Date(this._loadedEventRange.endDate);
-      missingEndStart.setDate(missingEndStart.getDate() + 1);
-      missingEndStart.setHours(0, 0, 0, 0);
       missingRanges.push({ startDate: missingEndStart, endDate });
     }
 
     let allExtended = true;
+    let shouldRenderAfterExtensions = false;
     for (const range of missingRanges) {
-      const extended = await this.extendEventsForRange(range.startDate, range.endDate, { render: false });
-      if (extended === false) allExtended = false;
+      const extended = await this.extendEventsForRange(range.startDate, range.endDate, { render: false, returnDetails: true });
+      if (!extended?.complete) allExtended = false;
+      if (extended?.dataChanged || extended?.stateChanged) shouldRenderAfterExtensions = true;
     }
 
-    if (allExtended) this.render();
+    if (allExtended || shouldRenderAfterExtensions) this.render();
   }
 
   getEventFetchRange() {
@@ -12784,6 +12805,12 @@ class SkylightCalendarCard extends HTMLElement {
 
   getEventStartDate(event) {
     return getEventStartDate(event, { parseLocalDate: this.parseLocalDate.bind(this) });
+  }
+
+  getEventEndDate(event) {
+    if (event?.end?.dateTime) return new Date(event.end.dateTime);
+    if (event?.end?.date) return this.parseLocalDate(event.end.date);
+    return new Date(event?.end);
   }
 
   parseLocalDate(dateStr) {

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -817,14 +817,22 @@ function normalizeEventCacheSnapshot(snapshot, { configSignature } = {}) {
   if (!Number.isFinite(snapshot.lastSuccessfulRefresh)) return null;
   if (!snapshot.eventsByCalendar || typeof snapshot.eventsByCalendar !== 'object') return null;
 
+  const getSupportedEventDateValue = (value) => {
+    if (typeof value === 'string') return { kind: 'string', value };
+    if (!value || typeof value !== 'object' || value instanceof Date) return null;
+    if (typeof value.dateTime === 'string' && value.date === undefined) return { kind: 'dateTime', value: value.dateTime };
+    if (typeof value.date === 'string' && value.dateTime === undefined) return { kind: 'date', value: value.date };
+    return null;
+  };
   const isValidCachedEvent = (event, entityId) => {
     if (!event || typeof event !== 'object') return false;
     if (event.entityId !== entityId) return false;
-    const rawStart = event?.start?.dateTime || event?.start?.date || event?.start;
-    const rawEnd = event?.end?.dateTime || event?.end?.date || event?.end;
-    const start = rawStart ? new Date(rawStart) : null;
-    const end = rawEnd ? new Date(rawEnd) : null;
-    return !!start && !!end && Number.isFinite(start.getTime()) && Number.isFinite(end.getTime());
+    const startValue = getSupportedEventDateValue(event.start);
+    const endValue = getSupportedEventDateValue(event.end);
+    if (!startValue || !endValue || startValue.kind !== endValue.kind) return false;
+    const start = new Date(startValue.value);
+    const end = new Date(endValue.value);
+    return Number.isFinite(start.getTime()) && Number.isFinite(end.getTime()) && end >= start;
   };
   const eventsByCalendar = {};
   Object.entries(snapshot.eventsByCalendar).forEach(([entityId, events]) => {
@@ -12339,12 +12347,24 @@ class SkylightCalendarCard extends HTMLElement {
     };
   }
 
-  getEventCacheRetainedRange() {
-    const fetchRange = this.getEventFetchRange?.();
+  getEventCacheRetentionAnchorRange() {
+    if (this._viewMode === 'agenda') {
+      const agendaVisibleRange = this.getValidRange(this._agendaVisibleStartDate, this._agendaVisibleEndDate);
+      if (agendaVisibleRange) return agendaVisibleRange;
+      const fallbackStart = new Date(this._currentDate || Date.now());
+      fallbackStart.setHours(0, 0, 0, 0);
+      const fallbackEnd = new Date(fallbackStart);
+      fallbackEnd.setDate(fallbackEnd.getDate() + 14);
+      fallbackEnd.setHours(23, 59, 59, 999);
+      return this.getValidRange(fallbackStart, fallbackEnd);
+    }
     const visibleRange = this.getVisibleDateRange?.();
-    const validRange = this.getValidRange(fetchRange?.startDate, fetchRange?.endDate) ||
-      this.getValidRange(visibleRange?.startDate, visibleRange?.endDate) ||
+    return this.getValidRange(visibleRange?.startDate, visibleRange?.endDate) ||
       this.getValidRange(this._loadedEventRange?.startDate, this._loadedEventRange?.endDate);
+  }
+
+  getEventCacheRetainedRange() {
+    const validRange = this.getEventCacheRetentionAnchorRange();
     if (!validRange) return null;
     const maxSpanMs = MAX_PERSISTED_EVENT_CACHE_SPAN_DAYS * 24 * 60 * 60 * 1000;
     const rangeSpanMs = validRange.endDate.getTime() - validRange.startDate.getTime();
@@ -12670,12 +12690,17 @@ class SkylightCalendarCard extends HTMLElement {
     const { startDate, endDate } = this.getEventFetchRange();
 
     if (this._fetching) {
+      if (force) {
+        this._pendingEventRefreshAfterCurrentFetch = true;
+        if (renderIfCovered) this._pendingEventRenderAfterCurrentFetch = true;
+        return;
+      }
       if (this.isDateRangeCoveredByLoadedEvents(visibleStartDate, visibleEndDate)) {
         if (renderIfCovered) this.render();
         return;
       }
       const activeRange = this.getValidRange(this._activeEventFetchRange?.startDate, this._activeEventFetchRange?.endDate);
-      if (force || !activeRange || !isDateRangeCoveredByLoadedEvents(activeRange, startDate, endDate)) {
+      if (!activeRange || !isDateRangeCoveredByLoadedEvents(activeRange, startDate, endDate)) {
         this._pendingEventRefreshAfterCurrentFetch = true;
         if (renderIfCovered) this._pendingEventRenderAfterCurrentFetch = true;
       } else if (renderIfCovered) {

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -12265,8 +12265,7 @@ class SkylightCalendarCard extends HTMLElement {
     if (!event?.uid) return null;
     const recurrenceId = event.recurrence_id || event.recurring_event_id;
     if (recurrenceId) return `${entityId}|${event.uid}|${recurrenceId}`;
-    if (event.rrule) return null;
-    return `${entityId}|${event.uid}`;
+    return null;
   }
 
   reconcileEventsForFetchedRange(existingEvents = [], incomingEvents = [], fetchedRange = null) {

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -743,6 +743,23 @@ const DB_NAME = 'daylight-calendar-card-events';
 const DB_VERSION = 1;
 const STORE_NAME = 'eventSnapshots';
 const MAX_CACHE_ENTRIES = 12;
+let eventCacheMutationQueue = Promise.resolve();
+let eventCacheMutationEpoch = 0;
+
+function getEventCacheMutationEpoch() {
+  return eventCacheMutationEpoch;
+}
+
+function beginEventCacheFlush() {
+  eventCacheMutationEpoch += 1;
+  return eventCacheMutationEpoch;
+}
+
+const queueEventCacheMutation = (callback) => {
+  const run = eventCacheMutationQueue.then(callback, callback);
+  eventCacheMutationQueue = run.catch(() => {});
+  return run;
+};
 
 const openEventCacheDb = () => new Promise((resolve, reject) => {
   const indexedDBRef = globalThis.indexedDB;
@@ -851,42 +868,48 @@ async function readEventCacheSnapshot(configSignature) {
   }
 }
 
-async function writeEventCacheSnapshot(snapshot) {
+async function writeEventCacheSnapshot(snapshot, { epoch = getEventCacheMutationEpoch() } = {}) {
   const normalized = normalizeEventCacheSnapshot(snapshot, { configSignature: snapshot?.configSignature });
   if (!normalized) return false;
-  try {
-    const result = await transact('readwrite', (store) => {
-      store.put(normalized);
-      const getAllRequest = store.getAll();
-      getAllRequest.onsuccess = () => {
-        const entries = (getAllRequest.result || [])
-          .filter((entry) => entry?.key && String(entry.key).startsWith('events:'))
-          .sort((a, b) => (Number(b.updatedAt) || 0) - (Number(a.updatedAt) || 0));
-        entries.slice(MAX_CACHE_ENTRIES).forEach((entry) => store.delete(entry.key));
-      };
-    });
-    return !!result.available;
-  } catch (error) {
-    console.warn('Failed to write Daylight event cache:', error);
-    return false;
-  }
+  return queueEventCacheMutation(async () => {
+    if (epoch !== eventCacheMutationEpoch) return false;
+    try {
+      const result = await transact('readwrite', (store) => {
+        store.put(normalized);
+        const getAllRequest = store.getAll();
+        getAllRequest.onsuccess = () => {
+          const entries = (getAllRequest.result || [])
+            .filter((entry) => entry?.key && String(entry.key).startsWith('events:'))
+            .sort((a, b) => (Number(b.updatedAt) || 0) - (Number(a.updatedAt) || 0));
+          entries.slice(MAX_CACHE_ENTRIES).forEach((entry) => store.delete(entry.key));
+        };
+      });
+      return epoch === eventCacheMutationEpoch && !!result.available;
+    } catch (error) {
+      console.warn('Failed to write Daylight event cache:', error);
+      return false;
+    }
+  });
 }
 
-async function clearAllEventCacheSnapshots() {
-  try {
-    const result = await transact('readwrite', (store) => {
-      const getAllKeysRequest = store.getAllKeys();
-      getAllKeysRequest.onsuccess = () => {
-        (getAllKeysRequest.result || [])
-          .filter((key) => String(key).startsWith('events:'))
-          .forEach((key) => store.delete(key));
-      };
-    });
-    return !!result.available;
-  } catch (error) {
-    console.warn('Failed to clear Daylight event cache:', error);
-    return false;
-  }
+async function clearAllEventCacheSnapshots({ epoch = beginEventCacheFlush() } = {}) {
+  return queueEventCacheMutation(async () => {
+    if (epoch !== eventCacheMutationEpoch) return false;
+    try {
+      const result = await transact('readwrite', (store) => {
+        const getAllKeysRequest = store.getAllKeys();
+        getAllKeysRequest.onsuccess = () => {
+          (getAllKeysRequest.result || [])
+            .filter((key) => String(key).startsWith('events:'))
+            .forEach((key) => store.delete(key));
+        };
+      });
+      return epoch === eventCacheMutationEpoch && !!result.available;
+    } catch (error) {
+      console.warn('Failed to clear Daylight event cache:', error);
+      return false;
+    }
+  });
 }
 
 function normalizeDashboardPath(pathValue) {
@@ -10619,7 +10642,6 @@ class SkylightCalendarCard extends HTMLElement {
     this._eventFetchGeneration = 0;
     this._eventWriteGeneration = 0;
     this._pendingEventRefreshAfterCurrentFetch = false;
-    this._eventCacheMutationQueue = Promise.resolve();
     this._eventRefreshWarningTimer = null;
     this._eventCacheHydrated = false;
     this._lastSuccessfulEventRefresh = null;
@@ -11244,6 +11266,7 @@ class SkylightCalendarCard extends HTMLElement {
     this.clearEventRefreshWarningTimer();
     this._calendarDataSignatures = {};
     this._lastUnchangedDataRender = null;
+    this._lastFetch = null;
     this._weatherForecastController.handleConfigChanged(previousHeaderWeatherSensor, this._config.header_weather_sensor);
     this.ensureWeatherForecastSubscription();
     this.setWeekStart();
@@ -11251,6 +11274,7 @@ class SkylightCalendarCard extends HTMLElement {
     this.render();
     this._activeLanguage = language;
     this.loadEventCacheForCurrentConfig();
+    if (this._hass) this.ensureEventsForCurrentRange({ force: true });
   }
 
   set hass(hass) {
@@ -12167,12 +12191,6 @@ class SkylightCalendarCard extends HTMLElement {
     };
   }
 
-  queueEventCacheMutation(callback) {
-    const run = this._eventCacheMutationQueue.then(callback, callback);
-    this._eventCacheMutationQueue = run.catch(() => {});
-    return run;
-  }
-
   recomputeLoadedEventRange() {
     const ranges = (this._config.entities || []).map((entityId) => {
       const range = this._calendarEventMetadata[entityId]?.range;
@@ -12219,7 +12237,7 @@ class SkylightCalendarCard extends HTMLElement {
         const isFailure = failedSet.has(entityId);
         this._calendarEventMetadata[entityId] = {
           ...existingMetadata,
-          lastSuccessfulRefresh: existingMetadata.lastSuccessfulRefresh ?? this._lastSuccessfulEventRefresh,
+          lastSuccessfulRefresh: existingMetadata.lastSuccessfulRefresh,
           refreshFailed: isFailure || existingMetadata.refreshFailed,
           firstFailureAt: isFailure ? (existingMetadata.firstFailureAt ?? Date.now()) : existingMetadata.firstFailureAt,
           lastNetworkFailureRequest: isFailure && source === 'network' ? requestId : existingMetadata.lastNetworkFailureRequest
@@ -12275,34 +12293,50 @@ class SkylightCalendarCard extends HTMLElement {
     this.render();
   }
 
-  async persistEventCacheSnapshot({ generation = this._eventWriteGeneration } = {}) {
-    return this.queueEventCacheMutation(async () => {
-      if (generation !== this._eventWriteGeneration) return false;
-      if (!this._loadedEventRange || !Number.isFinite(this._lastSuccessfulEventRefresh)) return false;
-      const configSignature = this.getEventCacheConfigSignature();
-      if (!configSignature) return false;
-      const snapshot = createEventCacheSnapshot({
-        configSignature,
-        startDate: this._loadedEventRange.startDate,
-        endDate: this._loadedEventRange.endDate,
-        eventsByCalendar: this._eventsByCalendar,
-        lastSuccessfulRefresh: this._lastSuccessfulEventRefresh,
-        perCalendarMetadata: this._calendarEventMetadata
+  getPrunedEventsByCalendarForCache(eventsByCalendar = {}, range = this._loadedEventRange) {
+    const validRange = this.getValidRange(range?.startDate, range?.endDate);
+    if (!validRange) return eventsByCalendar;
+    const retainedStart = new Date(validRange.startDate);
+    retainedStart.setDate(retainedStart.getDate() - 90);
+    const retainedEnd = new Date(validRange.endDate);
+    retainedEnd.setDate(retainedEnd.getDate() + 90);
+    const pruned = {};
+    Object.entries(eventsByCalendar || {}).forEach(([entityId, events]) => {
+      pruned[entityId] = (Array.isArray(events) ? events : []).filter((event) => {
+        const eventStart = this.getEventStartDate(event);
+        const rawEnd = event?.end?.dateTime || event?.end?.date || event?.end;
+        const eventEnd = rawEnd ? new Date(rawEnd) : eventStart;
+        const safeEnd = Number.isFinite(eventEnd.getTime()) ? eventEnd : eventStart;
+        return eventStart <= retainedEnd && safeEnd >= retainedStart;
       });
-      if (!snapshot || generation !== this._eventWriteGeneration) return false;
-      return writeEventCacheSnapshot(snapshot);
     });
+    return pruned;
+  }
+
+  async persistEventCacheSnapshot({ generation = this._eventWriteGeneration } = {}) {
+    if (generation !== this._eventWriteGeneration) return false;
+    if (!this._loadedEventRange || !Number.isFinite(this._lastSuccessfulEventRefresh)) return false;
+    const configSignature = this.getEventCacheConfigSignature();
+    if (!configSignature) return false;
+    const cacheEpoch = getEventCacheMutationEpoch();
+    const snapshot = createEventCacheSnapshot({
+      configSignature,
+      startDate: this._loadedEventRange.startDate,
+      endDate: this._loadedEventRange.endDate,
+      eventsByCalendar: this.getPrunedEventsByCalendarForCache(this._eventsByCalendar, this._loadedEventRange),
+      lastSuccessfulRefresh: this._lastSuccessfulEventRefresh,
+      perCalendarMetadata: this._calendarEventMetadata
+    });
+    if (!snapshot || generation !== this._eventWriteGeneration) return false;
+    return writeEventCacheSnapshot(snapshot, { epoch: cacheEpoch });
   }
 
   async flushEventCache({ refresh = true } = {}) {
     this._eventCacheGeneration += 1;
     this._eventFetchGeneration += 1;
     this._eventWriteGeneration += 1;
-    const clearGeneration = this._eventWriteGeneration;
-    const cleared = await this.queueEventCacheMutation(async () => {
-      if (clearGeneration !== this._eventWriteGeneration) return false;
-      return clearAllEventCacheSnapshots();
-    });
+    const clearEpoch = beginEventCacheFlush();
+    const cleared = await clearAllEventCacheSnapshots({ epoch: clearEpoch });
     this._eventCacheGeneration += 1;
     this._eventCacheHydrated = false;
     this._eventsByCalendar = {};
@@ -12351,7 +12385,7 @@ class SkylightCalendarCard extends HTMLElement {
 
   shouldShowEventRefreshWarning(now = Date.now()) {
     const oldestFailedRefresh = this.getOldestFailedEventRefreshTime();
-    return Number.isFinite(oldestFailedRefresh) && (now - oldestFailedRefresh) > 30 * 60 * 1000;
+    return Number.isFinite(oldestFailedRefresh) && (now - oldestFailedRefresh) >= 30 * 60 * 1000;
   }
 
   renderEventRefreshWarning() {
@@ -12399,7 +12433,7 @@ class SkylightCalendarCard extends HTMLElement {
           const existingMetadata = this._calendarEventMetadata[entityId] || {};
           this._calendarEventMetadata[entityId] = {
             ...existingMetadata,
-            lastSuccessfulRefresh: existingMetadata.lastSuccessfulRefresh ?? this._lastSuccessfulEventRefresh,
+            lastSuccessfulRefresh: existingMetadata.lastSuccessfulRefresh,
             refreshFailed: true,
             firstFailureAt: existingMetadata.firstFailureAt ?? Date.now(),
             lastNetworkFailureRequest: generation
@@ -12480,7 +12514,7 @@ class SkylightCalendarCard extends HTMLElement {
           const existingMetadata = this._calendarEventMetadata[entityId] || {};
           this._calendarEventMetadata[entityId] = {
             ...existingMetadata,
-            lastSuccessfulRefresh: existingMetadata.lastSuccessfulRefresh ?? this._lastSuccessfulEventRefresh,
+            lastSuccessfulRefresh: existingMetadata.lastSuccessfulRefresh,
             refreshFailed: true,
             firstFailureAt: existingMetadata.firstFailureAt ?? Date.now(),
             lastNetworkFailureRequest: generation

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -668,9 +668,7 @@ async function fetchEventsForChunk({ hass, entityId, chunk, formatLocalDate }) {
     return { success: true, events };
   } catch (error) {
     try {
-      const startDateOnly = formatLocalDate(chunk.startDate);
-      const endDateOnly = formatLocalDate(chunk.endDate);
-      const events = await hass.callApi('GET', `calendars/${entityId}?start=${startDateOnly}T00:00:00Z&end=${endDateOnly}T23:59:59Z`);
+      const events = await hass.callApi('GET', `calendars/${entityId}?start=${encodeURIComponent(chunkStartStr)}&end=${encodeURIComponent(chunkEndStr)}`);
       if (!Array.isArray(events)) throw new Error('Calendar REST response was not an array');
       return { success: true, events };
     } catch (error2) {
@@ -12252,8 +12250,12 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getEventLogicalIdentityKey(entityId, event) {
-    const stableId = event?.uid || event?.recurring_event_id;
-    return stableId ? `${entityId}|${stableId}` : this.getEventIdentityKey(entityId, event);
+    const uid = event?.uid;
+    const recurrenceId = event?.recurrence_id || event?.recurring_event_id;
+    if (uid && recurrenceId) return `${entityId}|${uid}|${recurrenceId}`;
+    if (uid) return `${entityId}|${uid}`;
+    if (recurrenceId) return `${entityId}|recurrence|${recurrenceId}`;
+    return this.getEventIdentityKey(entityId, event);
   }
 
   reconcileEventsForFetchedRange(existingEvents = [], incomingEvents = [], fetchedRange = null) {
@@ -12417,6 +12419,25 @@ class SkylightCalendarCard extends HTMLElement {
     const visibleRange = this.getVisibleDateRange?.();
     return this.getValidRange(visibleRange?.startDate, visibleRange?.endDate) ||
       this.getValidRange(this._loadedEventRange?.startDate, this._loadedEventRange?.endDate);
+  }
+
+  setAgendaNavigationViewportAnchor(startDate = this._agendaStartDate) {
+    const agendaWindowRange = this.getValidRange(this._agendaStartDate, this._agendaEndDate);
+    const anchorStart = new Date(startDate || this._agendaStartDate || Date.now());
+    anchorStart.setHours(0, 0, 0, 0);
+    const viewportDays = Math.max(1, Number(this.getAgendaViewportDayCapacity?.() || 14));
+    const anchorEnd = new Date(anchorStart);
+    anchorEnd.setDate(anchorEnd.getDate() + viewportDays);
+    anchorEnd.setHours(23, 59, 59, 999);
+    if (agendaWindowRange) {
+      const clampedStart = new Date(Math.max(anchorStart.getTime(), agendaWindowRange.startDate.getTime()));
+      const clampedEnd = new Date(Math.min(anchorEnd.getTime(), agendaWindowRange.endDate.getTime()));
+      this._agendaVisibleStartDate = clampedStart;
+      this._agendaVisibleEndDate = clampedEnd >= clampedStart ? clampedEnd : new Date(clampedStart);
+      return;
+    }
+    this._agendaVisibleStartDate = anchorStart;
+    this._agendaVisibleEndDate = anchorEnd;
   }
 
   getEventCacheRetainedRange() {
@@ -15936,8 +15957,7 @@ class SkylightCalendarCard extends HTMLElement {
       this._agendaEndDate.setDate(this._agendaEndDate.getDate() - backwardDays);
       this._agendaEndDate.setHours(23, 59, 59, 999);
       this._currentDate = new Date(this._agendaStartDate);
-      this._agendaVisibleStartDate = new Date(this._agendaStartDate);
-      this._agendaVisibleEndDate = new Date(this._agendaEndDate);
+      this.setAgendaNavigationViewportAnchor(this._agendaStartDate);
     } else if (this._viewMode === 'month') {
       if (this._config.rolling_weeks !== null) {
         // In rolling weeks mode, go back by the number of weeks shown
@@ -16004,8 +16024,7 @@ class SkylightCalendarCard extends HTMLElement {
       this._agendaStartDate = targetStart;
       this._agendaEndDate = targetEnd;
       this._currentDate = new Date(this._agendaStartDate);
-      this._agendaVisibleStartDate = new Date(this._agendaStartDate);
-      this._agendaVisibleEndDate = new Date(this._agendaEndDate);
+      this.setAgendaNavigationViewportAnchor(this._agendaStartDate);
     } else if (this._viewMode === 'month') {
       if (this._config.rolling_weeks !== null) {
         // In rolling weeks mode, go forward by the number of weeks shown

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -584,6 +584,303 @@ function getDaylightCalendarCardVersion() {
     : DAYLIGHT_CALENDAR_CARD_VERSION;
 }
 
+async function fetchEventsByCalendarInRange({
+  hass,
+  entities = [],
+  startDate,
+  endDate,
+  getDateRangeChunks,
+  formatLocalDate,
+  getCalendarColor,
+  getEventIdentityKey,
+  normalizeCalendarEvent
+}) {
+  const chunks = getDateRangeChunks(startDate, endDate, 30);
+  const calendarResults = await Promise.all(
+    entities.map((entityId, index) => fetchEventsForCalendar({
+      hass,
+      entityId,
+      colorIndex: index,
+      chunks,
+      formatLocalDate,
+      getCalendarColor,
+      getEventIdentityKey,
+      normalizeCalendarEvent
+    }))
+  );
+
+  return entities.reduce((acc, entityId, index) => {
+    acc[entityId] = calendarResults[index] || { success: false, events: [] };
+    return acc;
+  }, {});
+}
+
+async function fetchEventsForCalendar({
+  hass,
+  entityId,
+  colorIndex = 0,
+  chunks = [],
+  formatLocalDate,
+  getCalendarColor,
+  getEventIdentityKey,
+  normalizeCalendarEvent
+}) {
+  const seen = new Set();
+  const color = getCalendarColor(entityId, colorIndex);
+
+  const chunkResults = await Promise.all(
+    chunks.map(chunk => fetchEventsForChunk({ hass, entityId, chunk, formatLocalDate }))
+  );
+
+  const failedChunks = chunkResults.filter(result => !result?.success);
+  if (failedChunks.length > 0) {
+    return { success: false, events: [], failedChunks };
+  }
+
+  const mergedEvents = [];
+  chunkResults.forEach(result => {
+    const events = Array.isArray(result?.events) ? result.events : [];
+
+    events.forEach(event => {
+      const key = getEventIdentityKey(entityId, event);
+      if (seen.has(key)) return;
+      seen.add(key);
+
+      mergedEvents.push(normalizeCalendarEvent(event, { entityId, color }));
+    });
+  });
+
+  return { success: true, events: mergedEvents };
+}
+
+async function fetchEventsForChunk({ hass, entityId, chunk, formatLocalDate }) {
+  const chunkStartStr = chunk.startDate.toISOString();
+  const chunkEndStr = chunk.endDate.toISOString();
+
+  try {
+    const events = await fetchEventsViaWebSocket({ hass, entityId, chunkStartStr, chunkEndStr });
+    return { success: true, events: Array.isArray(events) ? events : [] };
+  } catch (error) {
+    try {
+      const startDateOnly = formatLocalDate(chunk.startDate);
+      const endDateOnly = formatLocalDate(chunk.endDate);
+      const events = await hass.callApi('GET', `calendars/${entityId}?start=${startDateOnly}T00:00:00Z&end=${endDateOnly}T23:59:59Z`);
+      return { success: true, events: Array.isArray(events) ? events : [] };
+    } catch (error2) {
+      console.error(`Failed to fetch events for ${entityId}:`, error2.message || error2);
+      return { success: false, events: [], error: error2 };
+    }
+  }
+}
+
+async function fetchEventsViaWebSocket({ hass, entityId, chunkStartStr, chunkEndStr }) {
+  return hass.callWS({
+    type: 'calendar/events',
+    entity_id: entityId,
+    start_date_time: chunkStartStr,
+    end_date_time: chunkEndStr
+  });
+}
+
+function mergeEvents(existingEvents, incomingEvents, { getEventIdentityKey, getEventStartDate }) {
+  const mergedByKey = new Map();
+
+  existingEvents.forEach(event => {
+    mergedByKey.set(getEventIdentityKey(event.entityId, event), event);
+  });
+
+  incomingEvents.forEach(event => {
+    mergedByKey.set(getEventIdentityKey(event.entityId, event), event);
+  });
+
+  return sortEventsByStartDate(Array.from(mergedByKey.values()), { getEventStartDate });
+}
+
+function sortEventsByStartDate(events, { getEventStartDate }) {
+  return [...events].sort((a, b) => getEventStartDate(a) - getEventStartDate(b));
+}
+
+function toStableString(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(item => toStableString(item)).join(',')}]`;
+  }
+
+  if (value && typeof value === 'object') {
+    const entries = Object.keys(value)
+      .sort()
+      .map(key => `${JSON.stringify(key)}:${toStableString(value[key])}`);
+    return `{${entries.join(',')}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
+function getCalendarDataSignature(events = []) {
+  return events
+    .map(event => {
+      const { entityId, color, ...eventData } = event;
+      return toStableString(eventData);
+    })
+    .sort()
+    .join('|');
+}
+
+function isDateRangeCoveredByLoadedEvents(loadedEventRange, targetStartDate, targetEndDate) {
+  if (!loadedEventRange) return false;
+
+  return targetStartDate >= loadedEventRange.startDate &&
+         targetEndDate <= loadedEventRange.endDate;
+}
+
+function shouldRefreshEvents({ lastFetch, now = Date.now(), maxAge = 60000 } = {}) {
+  return !lastFetch || (now - lastFetch > maxAge);
+}
+
+const EVENT_CACHE_SCHEMA_VERSION = 1;
+const DB_NAME = 'daylight-calendar-card-events';
+const DB_VERSION = 1;
+const STORE_NAME = 'eventSnapshots';
+const MAX_CACHE_ENTRIES = 12;
+
+const openEventCacheDb = () => new Promise((resolve, reject) => {
+  const indexedDBRef = globalThis.indexedDB;
+  if (!indexedDBRef) {
+    resolve(null);
+    return;
+  }
+  const request = indexedDBRef.open(DB_NAME, DB_VERSION);
+  request.onupgradeneeded = () => {
+    const db = request.result;
+    if (!db.objectStoreNames.contains(STORE_NAME)) {
+      db.createObjectStore(STORE_NAME, { keyPath: 'key' });
+    }
+  };
+  request.onsuccess = () => resolve(request.result);
+  request.onerror = () => reject(request.error || new Error('Unable to open event cache'));
+});
+
+const transact = async (mode, callback) => {
+  const db = await openEventCacheDb();
+  if (!db) return null;
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, mode);
+    const store = tx.objectStore(STORE_NAME);
+    let callbackResult;
+    tx.oncomplete = () => {
+      db.close?.();
+      resolve(callbackResult);
+    };
+    tx.onerror = () => {
+      db.close?.();
+      reject(tx.error || new Error('Event cache transaction failed'));
+    };
+    tx.onabort = tx.onerror;
+    callbackResult = callback(store, (value) => { callbackResult = value; });
+  });
+};
+
+function buildEventCacheConfigSignature({ entities = [], timeZone = null, colors = {} } = {}) {
+  return toStableString({ entities, timeZone: timeZone || null, colors: colors || {} });
+}
+
+function buildEventCacheKey(configSignature) {
+  return `events:${configSignature}`;
+}
+
+function normalizeEventCacheSnapshot(snapshot, { configSignature } = {}) {
+  if (!snapshot || typeof snapshot !== 'object') return null;
+  if (snapshot.schemaVersion !== EVENT_CACHE_SCHEMA_VERSION) return null;
+  if (configSignature && snapshot.configSignature !== configSignature) return null;
+  if (!snapshot.coveredRange || !snapshot.coveredRange.start || !snapshot.coveredRange.end) return null;
+  if (!Number.isFinite(snapshot.lastSuccessfulRefresh)) return null;
+  if (!snapshot.eventsByCalendar || typeof snapshot.eventsByCalendar !== 'object') return null;
+
+  const eventsByCalendar = {};
+  Object.entries(snapshot.eventsByCalendar).forEach(([entityId, events]) => {
+    eventsByCalendar[entityId] = Array.isArray(events) ? events.filter((event) => event && typeof event === 'object') : [];
+  });
+
+  return {
+    schemaVersion: EVENT_CACHE_SCHEMA_VERSION,
+    key: snapshot.key || buildEventCacheKey(snapshot.configSignature),
+    updatedAt: Number(snapshot.updatedAt) || snapshot.lastSuccessfulRefresh,
+    lastSuccessfulRefresh: snapshot.lastSuccessfulRefresh,
+    coveredRange: {
+      start: snapshot.coveredRange.start,
+      end: snapshot.coveredRange.end
+    },
+    configSignature: snapshot.configSignature,
+    eventsByCalendar
+  };
+}
+
+function createEventCacheSnapshot({ configSignature, startDate, endDate, eventsByCalendar, lastSuccessfulRefresh = Date.now() }) {
+  return normalizeEventCacheSnapshot({
+    schemaVersion: EVENT_CACHE_SCHEMA_VERSION,
+    key: buildEventCacheKey(configSignature),
+    updatedAt: Date.now(),
+    lastSuccessfulRefresh,
+    coveredRange: {
+      start: startDate instanceof Date ? startDate.toISOString() : startDate,
+      end: endDate instanceof Date ? endDate.toISOString() : endDate
+    },
+    configSignature,
+    eventsByCalendar
+  }, { configSignature });
+}
+
+async function readEventCacheSnapshot(configSignature) {
+  try {
+    const key = buildEventCacheKey(configSignature);
+    const snapshot = await transact('readonly', (store, setResult) => {
+      const request = store.get(key);
+      request.onsuccess = () => setResult(request.result || null);
+    });
+    return normalizeEventCacheSnapshot(snapshot, { configSignature });
+  } catch (error) {
+    console.warn('Failed to read Daylight event cache:', error);
+    return null;
+  }
+}
+
+async function writeEventCacheSnapshot(snapshot) {
+  const normalized = normalizeEventCacheSnapshot(snapshot, { configSignature: snapshot?.configSignature });
+  if (!normalized) return false;
+  try {
+    await transact('readwrite', (store) => {
+      store.put(normalized);
+      const getAllRequest = store.getAll();
+      getAllRequest.onsuccess = () => {
+        const entries = (getAllRequest.result || [])
+          .filter((entry) => entry?.key && String(entry.key).startsWith('events:'))
+          .sort((a, b) => (Number(b.updatedAt) || 0) - (Number(a.updatedAt) || 0));
+        entries.slice(MAX_CACHE_ENTRIES).forEach((entry) => store.delete(entry.key));
+      };
+    });
+    return true;
+  } catch (error) {
+    console.warn('Failed to write Daylight event cache:', error);
+    return false;
+  }
+}
+
+async function clearAllEventCacheSnapshots() {
+  try {
+    await transact('readwrite', (store) => {
+      const getAllKeysRequest = store.getAllKeys();
+      getAllKeysRequest.onsuccess = () => {
+        (getAllKeysRequest.result || [])
+          .filter((key) => String(key).startsWith('events:'))
+          .forEach((key) => store.delete(key));
+      };
+    });
+    return true;
+  } catch (error) {
+    console.warn('Failed to clear Daylight event cache:', error);
+    return false;
+  }
+}
+
 function normalizeDashboardPath(pathValue) {
   if (typeof pathValue !== 'string') return null;
   const trimmedPath = pathValue.trim();
@@ -827,6 +1124,7 @@ class SkylightCalendarCardEditor extends HTMLElement {
     this._config = createDefaultStubConfig();
     this._hass = null;
     this._rendered = false;
+    this._eventCacheFlushStatus = '';
     this._lastCalendarEntitiesKey = '';
     this._colorPickerState = { field: null, mapKey: null, color: '#3f51b5' };
     this._combineBackgroundMode = DEFAULT_COMBINE_BACKGROUND;
@@ -1861,6 +2159,11 @@ class SkylightCalendarCardEditor extends HTMLElement {
       <p class="helper">Loaded version: ${this.escapeHtml(getDaylightCalendarCardVersion())}</p>
       <p class="helper">Resource file: skylight-calendar-card.js</p>
       <p class="helper">If this version does not match the version shown in HACS, Home Assistant may be loading a cached or stale resource.</p>
+      <div class="diagnostic-action">
+        <button type="button" data-event-cache-action="flush">Flush event cache</button>
+        <p class="helper">Clears persistent Daylight calendar event snapshots only. Hidden calendars and custom event colors are not changed.</p>
+        ${this._eventCacheFlushStatus ? `<p class="helper">${this.escapeHtml(this._eventCacheFlushStatus)}</p>` : ''}
+      </div>
       ${staleResourceDiagnostics}
     `);
 
@@ -2258,6 +2561,10 @@ class SkylightCalendarCardEditor extends HTMLElement {
       button.addEventListener('click', (event) => this.handleVirtualCalendarAction(event));
     });
 
+    this.querySelectorAll('[data-event-cache-action="flush"]').forEach((button) => {
+      button.addEventListener('click', () => this.handleFlushEventCache());
+    });
+
     this.querySelectorAll('[data-virtual-calendar-field]').forEach((input) => {
       input.addEventListener('change', (event) => this.handleVirtualCalendarInput(event));
     });
@@ -2284,6 +2591,15 @@ class SkylightCalendarCardEditor extends HTMLElement {
     });
 
     this._rendered = true;
+  }
+
+  async handleFlushEventCache() {
+    const cleared = await clearAllEventCacheSnapshots();
+    this._eventCacheFlushStatus = cleared
+      ? 'Event cache cleared. The card will load fresh calendar data.'
+      : 'Event cache is unavailable or could not be cleared; normal loading is unaffected.';
+    window.dispatchEvent(new CustomEvent('daylight-calendar-card-flush-event-cache'));
+    this.render();
   }
 
   refreshCalendarEntities() {
@@ -2741,6 +3057,17 @@ function getCardStyles() {
 
       .header-compact {
         padding: 16px 24px;
+      }
+
+      .event-refresh-warning {
+        margin: 8px 12px 0;
+        padding: 8px 10px;
+        border-radius: 8px;
+        background: rgba(251, 191, 36, 0.18);
+        border: 1px solid rgba(245, 158, 11, 0.55);
+        color: var(--warning-color, #92400e);
+        font-size: 13px;
+        line-height: 1.35;
       }
 
       .calendar-body {
@@ -5626,7 +5953,8 @@ const TRANSLATIONS = {
       durationMinutes: '{count} minutes',
       moreEvents: '+{count} more',
       eventTitleWithStartTime: '{title}, {time}',
-      monthWeekPrefix: 'CW'
+      monthWeekPrefix: 'CW',
+      eventRefreshStaleWarning: 'Unable to refresh calendar data since {time}'
     }
   },
 
@@ -8342,151 +8670,6 @@ function getScheduleVisualInfo(event, { getEventDateTimeInfo, shouldRenderTimedE
   };
 }
 
-async function fetchEventsByCalendarInRange({
-  hass,
-  entities = [],
-  startDate,
-  endDate,
-  getDateRangeChunks,
-  formatLocalDate,
-  getCalendarColor,
-  getEventIdentityKey,
-  normalizeCalendarEvent
-}) {
-  const chunks = getDateRangeChunks(startDate, endDate, 30);
-  const eventsByCalendar = await Promise.all(
-    entities.map((entityId, index) => fetchEventsForCalendar({
-      hass,
-      entityId,
-      colorIndex: index,
-      chunks,
-      formatLocalDate,
-      getCalendarColor,
-      getEventIdentityKey,
-      normalizeCalendarEvent
-    }))
-  );
-
-  return entities.reduce((acc, entityId, index) => {
-    acc[entityId] = eventsByCalendar[index] || [];
-    return acc;
-  }, {});
-}
-
-async function fetchEventsForCalendar({
-  hass,
-  entityId,
-  colorIndex = 0,
-  chunks = [],
-  formatLocalDate,
-  getCalendarColor,
-  getEventIdentityKey,
-  normalizeCalendarEvent
-}) {
-  const seen = new Set();
-  const color = getCalendarColor(entityId, colorIndex);
-
-  const chunkEventLists = await Promise.all(
-    chunks.map(chunk => fetchEventsForChunk({ hass, entityId, chunk, formatLocalDate }))
-  );
-
-  const mergedEvents = [];
-  chunkEventLists.forEach(events => {
-    if (!events || !Array.isArray(events)) return;
-
-    events.forEach(event => {
-      const key = getEventIdentityKey(entityId, event);
-      if (seen.has(key)) return;
-      seen.add(key);
-
-      mergedEvents.push(normalizeCalendarEvent(event, { entityId, color }));
-    });
-  });
-
-  return mergedEvents;
-}
-
-async function fetchEventsForChunk({ hass, entityId, chunk, formatLocalDate }) {
-  const chunkStartStr = chunk.startDate.toISOString();
-  const chunkEndStr = chunk.endDate.toISOString();
-
-  try {
-    return await fetchEventsViaWebSocket({ hass, entityId, chunkStartStr, chunkEndStr });
-  } catch (error) {
-    try {
-      const startDateOnly = formatLocalDate(chunk.startDate);
-      const endDateOnly = formatLocalDate(chunk.endDate);
-      return await hass.callApi('GET', `calendars/${entityId}?start=${startDateOnly}T00:00:00Z&end=${endDateOnly}T23:59:59Z`);
-    } catch (error2) {
-      console.error(`Failed to fetch events for ${entityId}:`, error2.message || error2);
-      return [];
-    }
-  }
-}
-
-async function fetchEventsViaWebSocket({ hass, entityId, chunkStartStr, chunkEndStr }) {
-  return hass.callWS({
-    type: 'calendar/events',
-    entity_id: entityId,
-    start_date_time: chunkStartStr,
-    end_date_time: chunkEndStr
-  });
-}
-
-function mergeEvents(existingEvents, incomingEvents, { getEventIdentityKey, getEventStartDate }) {
-  const mergedByKey = new Map();
-
-  existingEvents.forEach(event => {
-    mergedByKey.set(getEventIdentityKey(event.entityId, event), event);
-  });
-
-  incomingEvents.forEach(event => {
-    mergedByKey.set(getEventIdentityKey(event.entityId, event), event);
-  });
-
-  return sortEventsByStartDate(Array.from(mergedByKey.values()), { getEventStartDate });
-}
-
-function sortEventsByStartDate(events, { getEventStartDate }) {
-  return [...events].sort((a, b) => getEventStartDate(a) - getEventStartDate(b));
-}
-
-function toStableString(value) {
-  if (Array.isArray(value)) {
-    return `[${value.map(item => toStableString(item)).join(',')}]`;
-  }
-
-  if (value && typeof value === 'object') {
-    const entries = Object.keys(value)
-      .sort()
-      .map(key => `${JSON.stringify(key)}:${toStableString(value[key])}`);
-    return `{${entries.join(',')}}`;
-  }
-
-  return JSON.stringify(value);
-}
-
-function getCalendarDataSignature(events = []) {
-  return events
-    .map(event => {
-      const { entityId, color, ...eventData } = event;
-      return toStableString(eventData);
-    })
-    .sort()
-    .join('|');
-}
-
-function isDateRangeCoveredByLoadedEvents(loadedEventRange, targetStartDate, targetEndDate) {
-  if (!loadedEventRange) return false;
-
-  return targetStartDate >= loadedEventRange.startDate &&
-         targetEndDate <= loadedEventRange.endDate;
-}
-
-function shouldRefreshEvents({ lastFetch, now = Date.now(), maxAge = 60000 } = {}) {
-  return !lastFetch || (now - lastFetch > maxAge);
-}
-
 function buildContinuousDaySpanLayout(days, options = {}) {
   const {
     getDateKey,
@@ -10415,6 +10598,11 @@ class SkylightCalendarCard extends HTMLElement {
     this._root = this;
     this._config = {};
     this._events = [];
+    this._eventsByCalendar = {};
+    this._eventCacheGeneration = 0;
+    this._eventCacheHydrated = false;
+    this._lastSuccessfulEventRefresh = null;
+    this._lastEventRefreshFailed = false;
     this._currentDate = new Date();
     this._viewMode = DEFAULT_VIEW; // 'month', 'week-compact', 'week-standard', or 'agenda'
     this._weekStart = new Date();
@@ -10492,6 +10680,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._lastObservedHostSize = null;
     this._monthCompactMeasurementDirty = true;
     this._lastCompactMonthViewportHeight = null;
+    this._handleEventCacheFlush = () => this.flushEventCache({ refresh: true });
     this._handleViewportResize = () => {
       if (this.isEventManagementDialogOpen()) {
         return;
@@ -11021,6 +11210,11 @@ class SkylightCalendarCard extends HTMLElement {
     this._customEventColors = createEmptyCustomEventColors();
     this.loadPersistedPreferences();
     this._loadedEventRange = null;
+    this._eventsByCalendar = {};
+    this._eventCacheGeneration += 1;
+    this._eventCacheHydrated = false;
+    this._lastSuccessfulEventRefresh = null;
+    this._lastEventRefreshFailed = false;
     this._calendarDataSignatures = {};
     this._lastUnchangedDataRender = null;
     this._weatherForecastController.handleConfigChanged(previousHeaderWeatherSensor, this._config.header_weather_sensor);
@@ -11029,6 +11223,7 @@ class SkylightCalendarCard extends HTMLElement {
     this.resetAgendaWindowToToday();
     this.render();
     this._activeLanguage = language;
+    this.loadEventCacheForCurrentConfig();
   }
 
   set hass(hass) {
@@ -11839,8 +12034,9 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   async fetchEventsInRange(startDate, endDate) {
-    const eventsByCalendar = await this.fetchEventsByCalendarInRange(startDate, endDate);
-    return Object.values(eventsByCalendar).flat();
+    const resultsByCalendar = await this.fetchEventsByCalendarInRange(startDate, endDate);
+    if (Object.values(resultsByCalendar).some(result => !result?.success)) return null;
+    return Object.values(resultsByCalendar).flatMap(result => result.events || []);
   }
 
   async fetchEventsByCalendarInRange(startDate, endDate) {
@@ -11911,6 +12107,79 @@ class SkylightCalendarCard extends HTMLElement {
     return getCalendarDataSignature(events);
   }
 
+  getEventCacheConfigSignature() {
+    return buildEventCacheConfigSignature({
+      entities: this._config?.entities || [],
+      timeZone: this.getConfiguredTimeZone(),
+      colors: this._config?.colors || {}
+    });
+  }
+
+  applyEventsByCalendar(eventsByCalendar = {}, { startDate, endDate, lastSuccessfulRefresh = null } = {}) {
+    const normalizedByCalendar = {};
+    (this._config.entities || []).forEach((entityId) => {
+      normalizedByCalendar[entityId] = Array.isArray(eventsByCalendar[entityId]) ? eventsByCalendar[entityId] : [];
+      this._calendarDataSignatures[entityId] = this.getCalendarDataSignature(normalizedByCalendar[entityId]);
+    });
+    this._eventsByCalendar = normalizedByCalendar;
+    this._events = sortEventsByStartDate(Object.values(normalizedByCalendar).flat(), {
+      getEventStartDate: this.getEventStartDate.bind(this)
+    });
+    if (startDate && endDate) this._loadedEventRange = { startDate, endDate };
+    if (Number.isFinite(lastSuccessfulRefresh)) this._lastSuccessfulEventRefresh = lastSuccessfulRefresh;
+  }
+
+  async loadEventCacheForCurrentConfig() {
+    const generation = ++this._eventCacheGeneration;
+    const configSignature = this.getEventCacheConfigSignature();
+    const snapshot = await readEventCacheSnapshot(configSignature);
+    if (generation !== this._eventCacheGeneration || !snapshot || this._lastSuccessfulEventRefresh) return;
+    this._eventCacheHydrated = true;
+    this.applyEventsByCalendar(snapshot.eventsByCalendar, {
+      startDate: new Date(snapshot.coveredRange.start),
+      endDate: new Date(snapshot.coveredRange.end),
+      lastSuccessfulRefresh: snapshot.lastSuccessfulRefresh
+    });
+    this.render();
+  }
+
+  persistEventCacheSnapshot() {
+    if (!this._loadedEventRange) return;
+    const snapshot = createEventCacheSnapshot({
+      configSignature: this.getEventCacheConfigSignature(),
+      startDate: this._loadedEventRange.startDate,
+      endDate: this._loadedEventRange.endDate,
+      eventsByCalendar: this._eventsByCalendar,
+      lastSuccessfulRefresh: this._lastSuccessfulEventRefresh || Date.now()
+    });
+    writeEventCacheSnapshot(snapshot);
+  }
+
+  async flushEventCache({ refresh = true } = {}) {
+    const cleared = await clearAllEventCacheSnapshots();
+    this._eventCacheGeneration += 1;
+    this._eventCacheHydrated = false;
+    this._eventsByCalendar = {};
+    this._events = [];
+    this._loadedEventRange = null;
+    this._calendarDataSignatures = {};
+    this._lastSuccessfulEventRefresh = null;
+    this._lastEventRefreshFailed = false;
+    this.render();
+    if (refresh && this._hass) this.ensureEventsForCurrentRange({ force: true });
+    return cleared;
+  }
+
+  shouldShowEventRefreshWarning(now = Date.now()) {
+    return !!this._lastEventRefreshFailed && Number.isFinite(this._lastSuccessfulEventRefresh) &&
+      (now - this._lastSuccessfulEventRefresh) > 30 * 60 * 1000;
+  }
+
+  renderEventRefreshWarning() {
+    if (!this.shouldShowEventRefreshWarning()) return '';
+    return `<div class="event-refresh-warning" role="status">${this.t('eventRefreshStaleWarning', { time: this.formatTime(new Date(this._lastSuccessfulEventRefresh)) })}</div>`;
+  }
+
   async updateEvents({ preserveScroll = false } = {}) {
     if (!this._hass || this._fetching) return;
 
@@ -11919,52 +12188,42 @@ class SkylightCalendarCard extends HTMLElement {
     this._lastFetch = Date.now();
 
     try {
-      const newEventsByCalendar = await this.fetchEventsByCalendarInRange(startDate, endDate);
-      const changedCalendars = this._config.entities.filter(entityId => {
-        const hasOldSignature = Object.prototype.hasOwnProperty.call(this._calendarDataSignatures, entityId);
-        if (!hasOldSignature) {
-          return true;
-        }
+      const fetchResultsByCalendar = await this.fetchEventsByCalendarInRange(startDate, endDate);
+      const nextEventsByCalendar = { ...this._eventsByCalendar };
+      let anySuccess = false;
+      let anyChanged = false;
 
+      this._config.entities.forEach(entityId => {
+        const result = fetchResultsByCalendar[entityId];
+        if (!result?.success) return;
+        anySuccess = true;
+        const events = Array.isArray(result.events) ? result.events : [];
         const oldSignature = this._calendarDataSignatures[entityId];
-        const newSignature = this.getCalendarDataSignature(newEventsByCalendar[entityId]);
-        return oldSignature !== newSignature;
+        const newSignature = this.getCalendarDataSignature(events);
+        if (oldSignature !== newSignature) anyChanged = true;
+        nextEventsByCalendar[entityId] = events;
+        this._calendarDataSignatures[entityId] = newSignature;
       });
 
-      if (changedCalendars.length === 0) {
-        this._loadedEventRange = { startDate, endDate };
-
-        const now = Date.now();
-        const shouldRenderForUnchangedData = !this._lastUnchangedDataRender ||
-          (now - this._lastUnchangedDataRender >= 15 * 60 * 1000);
-
-        if (shouldRenderForUnchangedData) {
-          this._lastUnchangedDataRender = now;
-          if (preserveScroll) {
-            this.renderPreservingAgendaScroll();
-          } else {
-            this.render();
-          }
-        }
-
+      if (!anySuccess) {
+        this._lastEventRefreshFailed = true;
+        this.render();
         return;
       }
 
-      this._config.entities.forEach(entityId => {
-        this._calendarDataSignatures[entityId] = this.getCalendarDataSignature(newEventsByCalendar[entityId]);
-      });
-
-      const mergedEvents = sortEventsByStartDate(Object.values(newEventsByCalendar).flat(), {
-        getEventStartDate: this.getEventStartDate.bind(this)
-      });
-
-      this._events = mergedEvents;
-      this._loadedEventRange = { startDate, endDate };
-      this._lastUnchangedDataRender = Date.now();
-      if (preserveScroll) {
-        this.renderPreservingAgendaScroll();
-      } else {
-        this.render();
+      const now = Date.now();
+      const shouldRenderForUnchangedData = !this._lastUnchangedDataRender ||
+        (now - this._lastUnchangedDataRender >= 15 * 60 * 1000);
+      this.applyEventsByCalendar(nextEventsByCalendar, { startDate, endDate, lastSuccessfulRefresh: now });
+      this._lastEventRefreshFailed = false;
+      this.persistEventCacheSnapshot();
+      if (anyChanged || shouldRenderForUnchangedData) {
+        this._lastUnchangedDataRender = now;
+        if (preserveScroll) {
+          this.renderPreservingAgendaScroll();
+        } else {
+          this.render();
+        }
       }
     } finally {
       this._fetching = false;
@@ -11979,6 +12238,11 @@ class SkylightCalendarCard extends HTMLElement {
 
     try {
       const additionalEvents = await this.fetchEventsInRange(startDate, endDate);
+      if (!additionalEvents) {
+        this._lastEventRefreshFailed = true;
+        return false;
+      }
+      this._lastEventRefreshFailed = false;
       this._events = this.mergeEvents(this._events, additionalEvents);
       if (render) {
         this.render();
@@ -12037,7 +12301,8 @@ class SkylightCalendarCard extends HTMLElement {
     }
 
     for (const range of missingRanges) {
-      await this.extendEventsForRange(range.startDate, range.endDate, { render: false });
+      const extended = await this.extendEventsForRange(range.startDate, range.endDate, { render: false });
+      if (extended === false) return;
     }
 
     this._loadedEventRange = {
@@ -12194,6 +12459,7 @@ class SkylightCalendarCard extends HTMLElement {
   connectedCallback() {
     checkAndShowStaleResourceWarning();
     window.addEventListener('resize', this._handleViewportResize);
+    window.addEventListener('daylight-calendar-card-flush-event-cache', this._handleEventCacheFlush);
     window.visualViewport?.addEventListener('resize', this._handleViewportResize);
     this.attachSystemThemeListener();
     this.observeHostAndParentResize();
@@ -12202,6 +12468,7 @@ class SkylightCalendarCard extends HTMLElement {
 
   disconnectedCallback() {
     window.removeEventListener('resize', this._handleViewportResize);
+    window.removeEventListener('daylight-calendar-card-flush-event-cache', this._handleEventCacheFlush);
     window.visualViewport?.removeEventListener('resize', this._handleViewportResize);
     this.cancelMonthCompactMeasurement();
     if (this._monthGridResizeObserver) {
@@ -12968,6 +13235,7 @@ class SkylightCalendarCard extends HTMLElement {
 
       <div class="calendar-container ${this._isDarkMode ? 'dark-mode' : ''} ${hasCustomBackground ? 'custom-background' : ''} ${this._config.hide_year ? 'hide-year' : ''} ${this._config.agenda_compact_events ? 'agenda-compact-events' : ''}" style="${containerStyle}">
         ${this._config.hide_header ? '' : (this._config.compact_header ? this.renderCompactHeader() : this.renderStandardHeader())}
+        ${this.renderEventRefreshWarning()}
         <div class="calendar-body">
           ${this.renderCalendarView()}
         </div>

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -817,18 +817,24 @@ function normalizeEventCacheSnapshot(snapshot, { configSignature } = {}) {
   if (!Number.isFinite(snapshot.lastSuccessfulRefresh)) return null;
   if (!snapshot.eventsByCalendar || typeof snapshot.eventsByCalendar !== 'object') return null;
 
-  const isValidCachedEvent = (event) => {
+  const isValidCachedEvent = (event, entityId) => {
     if (!event || typeof event !== 'object') return false;
+    if (event.entityId !== entityId) return false;
     const rawStart = event?.start?.dateTime || event?.start?.date || event?.start;
     const rawEnd = event?.end?.dateTime || event?.end?.date || event?.end;
     const start = rawStart ? new Date(rawStart) : null;
-    const end = rawEnd ? new Date(rawEnd) : start;
-    return !!start && Number.isFinite(start.getTime()) && (!rawEnd || Number.isFinite(end.getTime()));
+    const end = rawEnd ? new Date(rawEnd) : null;
+    return !!start && !!end && Number.isFinite(start.getTime()) && Number.isFinite(end.getTime());
   };
   const eventsByCalendar = {};
   Object.entries(snapshot.eventsByCalendar).forEach(([entityId, events]) => {
     if (!Array.isArray(events)) return;
-    eventsByCalendar[entityId] = events.filter(isValidCachedEvent);
+    if (events.length === 0) {
+      eventsByCalendar[entityId] = [];
+      return;
+    }
+    if (!events.every(event => isValidCachedEvent(event, entityId))) return;
+    eventsByCalendar[entityId] = events;
   });
 
   return {
@@ -10527,7 +10533,7 @@ const translate = (language, key, params = {}) => {
   return interpolate(strings[key] || fallback, params);
 };
 
-
+const MAX_PERSISTED_EVENT_CACHE_SPAN_DAYS = 210;
 const STALE_RESOURCE_BANNER_ID = 'daylight-calendar-card-stale-resource-warning';
 let staleResourceWarningHandled = false;
 
@@ -10651,6 +10657,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._eventFetchGeneration = 0;
     this._eventWriteGeneration = 0;
     this._pendingEventRefreshAfterCurrentFetch = false;
+    this._pendingEventRenderAfterCurrentFetch = false;
     this._eventRefreshWarningTimer = null;
     this._eventCacheHydrated = false;
     this._lastSuccessfulEventRefresh = null;
@@ -11269,6 +11276,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._eventFetchGeneration += 1;
     this._eventWriteGeneration += 1;
     this._pendingEventRefreshAfterCurrentFetch = false;
+    this._pendingEventRenderAfterCurrentFetch = false;
     this._eventCacheHydrated = false;
     this._lastSuccessfulEventRefresh = null;
     this._lastEventRefreshFailed = false;
@@ -12333,12 +12341,16 @@ class SkylightCalendarCard extends HTMLElement {
 
   getEventCacheRetainedRange() {
     const fetchRange = this.getEventFetchRange?.();
-    const validRange = this.getValidRange(fetchRange?.startDate, fetchRange?.endDate) || this.getValidRange(this._loadedEventRange?.startDate, this._loadedEventRange?.endDate);
+    const visibleRange = this.getVisibleDateRange?.();
+    const validRange = this.getValidRange(fetchRange?.startDate, fetchRange?.endDate) ||
+      this.getValidRange(visibleRange?.startDate, visibleRange?.endDate) ||
+      this.getValidRange(this._loadedEventRange?.startDate, this._loadedEventRange?.endDate);
     if (!validRange) return null;
-    const retainedStart = new Date(validRange.startDate);
-    retainedStart.setDate(retainedStart.getDate() - 90);
-    const retainedEnd = new Date(validRange.endDate);
-    retainedEnd.setDate(retainedEnd.getDate() + 90);
+    const maxSpanMs = MAX_PERSISTED_EVENT_CACHE_SPAN_DAYS * 24 * 60 * 60 * 1000;
+    const rangeSpanMs = validRange.endDate.getTime() - validRange.startDate.getTime();
+    const center = validRange.startDate.getTime() + Math.max(0, rangeSpanMs) / 2;
+    const retainedStart = new Date(center - maxSpanMs / 2);
+    const retainedEnd = new Date(center + maxSpanMs / 2);
     return { startDate: retainedStart, endDate: retainedEnd };
   }
 
@@ -12417,6 +12429,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._eventCacheGeneration += 1;
     this._eventFetchGeneration += 1;
     this._eventWriteGeneration += 1;
+    this._pendingEventRenderAfterCurrentFetch = false;
     const clearEpoch = beginEventCacheFlush();
     const cleared = await clearAllEventCacheSnapshots({ epoch: clearEpoch });
     this._eventCacheGeneration += 1;
@@ -12476,7 +12489,7 @@ class SkylightCalendarCard extends HTMLElement {
     return `<div class="event-refresh-warning" role="status">${this.t('eventRefreshStaleWarning', { time: this.formatTime(new Date(oldestFailedRefresh)) })}</div>`;
   }
 
-  async updateEvents({ preserveScroll = false } = {}) {
+  async updateEvents({ preserveScroll = false, renderAfterFetch = false } = {}) {
     if (!this._hass) return;
     if (this._fetching) {
       this._pendingEventRefreshAfterCurrentFetch = true;
@@ -12542,7 +12555,7 @@ class SkylightCalendarCard extends HTMLElement {
       });
       const warningVisibilityChanged = wasWarningVisible !== this.shouldShowEventRefreshWarning(now);
       this.persistEventCacheSnapshot({ generation: this._eventWriteGeneration });
-      if (anyChanged || shouldRenderForUnchangedData || failedEntityIds.length > 0 || warningVisibilityChanged) {
+      if (anyChanged || shouldRenderForUnchangedData || failedEntityIds.length > 0 || warningVisibilityChanged || renderAfterFetch) {
         this._lastUnchangedDataRender = now;
         if (preserveScroll) {
           this.renderPreservingAgendaScroll();
@@ -12553,9 +12566,13 @@ class SkylightCalendarCard extends HTMLElement {
     } finally {
       this._fetching = false;
       this._activeEventFetchRange = null;
+      const shouldRenderAfterFetch = this._pendingEventRenderAfterCurrentFetch;
+      this._pendingEventRenderAfterCurrentFetch = false;
       if (this._pendingEventRefreshAfterCurrentFetch) {
         this._pendingEventRefreshAfterCurrentFetch = false;
-        this.ensureEventsForCurrentRange({ force: true });
+        this.ensureEventsForCurrentRange({ force: true, renderIfCovered: shouldRenderAfterFetch });
+      } else if (shouldRenderAfterFetch) {
+        this.render();
       }
     }
   }
@@ -12625,9 +12642,13 @@ class SkylightCalendarCard extends HTMLElement {
     } finally {
       this._fetching = false;
       this._activeEventFetchRange = null;
+      const shouldRenderAfterFetch = this._pendingEventRenderAfterCurrentFetch;
+      this._pendingEventRenderAfterCurrentFetch = false;
       if (this._pendingEventRefreshAfterCurrentFetch) {
         this._pendingEventRefreshAfterCurrentFetch = false;
-        this.ensureEventsForCurrentRange({ force: true });
+        this.ensureEventsForCurrentRange({ force: true, renderIfCovered: shouldRenderAfterFetch });
+      } else if (shouldRenderAfterFetch) {
+        this.render();
       }
     }
   }
@@ -12656,13 +12677,16 @@ class SkylightCalendarCard extends HTMLElement {
       const activeRange = this.getValidRange(this._activeEventFetchRange?.startDate, this._activeEventFetchRange?.endDate);
       if (force || !activeRange || !isDateRangeCoveredByLoadedEvents(activeRange, startDate, endDate)) {
         this._pendingEventRefreshAfterCurrentFetch = true;
+        if (renderIfCovered) this._pendingEventRenderAfterCurrentFetch = true;
+      } else if (renderIfCovered) {
+        this._pendingEventRenderAfterCurrentFetch = true;
       }
       return;
     }
 
     if (force || shouldRefreshForAge || !this._loadedEventRange) {
       const shouldPreserveScrollDuringRefresh = this._viewMode === 'agenda' && !force && !renderIfCovered;
-      await this.updateEvents({ preserveScroll: shouldPreserveScrollDuringRefresh });
+      await this.updateEvents({ preserveScroll: shouldPreserveScrollDuringRefresh, renderAfterFetch: renderIfCovered });
       return;
     }
 

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -10619,6 +10619,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._eventFetchGeneration = 0;
     this._eventWriteGeneration = 0;
     this._pendingEventRefreshAfterCurrentFetch = false;
+    this._eventCacheMutationQueue = Promise.resolve();
     this._eventRefreshWarningTimer = null;
     this._eventCacheHydrated = false;
     this._lastSuccessfulEventRefresh = null;
@@ -12156,6 +12157,22 @@ class SkylightCalendarCard extends HTMLElement {
     return { startDate: start, endDate: end };
   }
 
+  unionEventRanges(existingRange, incomingRange) {
+    const existing = this.getValidRange(existingRange?.startDate, existingRange?.endDate);
+    if (!existing) return incomingRange;
+    if (!incomingRange) return existing;
+    return {
+      startDate: new Date(Math.min(existing.startDate.getTime(), incomingRange.startDate.getTime())),
+      endDate: new Date(Math.max(existing.endDate.getTime(), incomingRange.endDate.getTime()))
+    };
+  }
+
+  queueEventCacheMutation(callback) {
+    const run = this._eventCacheMutationQueue.then(callback, callback);
+    this._eventCacheMutationQueue = run.catch(() => {});
+    return run;
+  }
+
   recomputeLoadedEventRange() {
     const ranges = (this._config.entities || []).map((entityId) => {
       const range = this._calendarEventMetadata[entityId]?.range;
@@ -12192,29 +12209,38 @@ class SkylightCalendarCard extends HTMLElement {
     this.scheduleEventRefreshWarningTimer();
   }
 
-  applyEventsByCalendar(eventsByCalendar = {}, { startDate, endDate, lastSuccessfulRefresh = null, successfulEntityIds = null, failedEntityIds = [], source = 'network', requestId = null } = {}) {
+  applyEventsByCalendar(eventsByCalendar = {}, { startDate, endDate, lastSuccessfulRefresh = null, successfulEntityIds = null, failedEntityIds = [], source = 'network', requestId = null, coverageMode = 'replace' } = {}) {
     const range = this.getValidRange(startDate, endDate);
     const successfulSet = successfulEntityIds ? new Set(successfulEntityIds) : new Set(this._config.entities || []);
     const failedSet = new Set(failedEntityIds || []);
     (this._config.entities || []).forEach((entityId) => {
       const existingMetadata = this._calendarEventMetadata[entityId] || {};
       if (!successfulSet.has(entityId)) {
+        const isFailure = failedSet.has(entityId);
         this._calendarEventMetadata[entityId] = {
           ...existingMetadata,
           lastSuccessfulRefresh: existingMetadata.lastSuccessfulRefresh ?? this._lastSuccessfulEventRefresh,
-          refreshFailed: failedSet.has(entityId) || existingMetadata.refreshFailed
+          refreshFailed: isFailure || existingMetadata.refreshFailed,
+          firstFailureAt: isFailure ? (existingMetadata.firstFailureAt ?? Date.now()) : existingMetadata.firstFailureAt,
+          lastNetworkFailureRequest: isFailure && source === 'network' ? requestId : existingMetadata.lastNetworkFailureRequest
         };
         return;
       }
-      if (source === 'cache' && existingMetadata.lastNetworkSuccessRequest && existingMetadata.lastNetworkSuccessRequest > requestId) return;
+      const hasNewerNetworkSuccess = existingMetadata.lastNetworkSuccessRequest && existingMetadata.lastNetworkSuccessRequest > requestId;
+      if (source === 'cache' && hasNewerNetworkSuccess) return;
+      const hasNewerNetworkFailure = source === 'cache' && existingMetadata.lastNetworkFailureRequest && existingMetadata.lastNetworkFailureRequest > requestId;
       const events = Array.isArray(eventsByCalendar[entityId]) ? eventsByCalendar[entityId] : [];
       this._eventsByCalendar[entityId] = events;
       this._calendarDataSignatures[entityId] = this.getCalendarDataSignature(events);
+      const nextRange = coverageMode === 'union'
+        ? this.unionEventRanges(existingMetadata.range, range)
+        : (range || existingMetadata.range || null);
       this._calendarEventMetadata[entityId] = {
         ...existingMetadata,
-        range: range || existingMetadata.range || null,
+        range: nextRange,
         lastSuccessfulRefresh: Number.isFinite(lastSuccessfulRefresh) ? lastSuccessfulRefresh : existingMetadata.lastSuccessfulRefresh,
-        refreshFailed: false,
+        refreshFailed: hasNewerNetworkFailure ? existingMetadata.refreshFailed : false,
+        firstFailureAt: hasNewerNetworkFailure ? existingMetadata.firstFailureAt : null,
         lastNetworkSuccessRequest: source === 'network' ? requestId : existingMetadata.lastNetworkSuccessRequest
       };
     });
@@ -12250,27 +12276,33 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   async persistEventCacheSnapshot({ generation = this._eventWriteGeneration } = {}) {
-    if (!this._loadedEventRange || !Number.isFinite(this._lastSuccessfulEventRefresh)) return false;
-    const configSignature = this.getEventCacheConfigSignature();
-    if (!configSignature) return false;
-    const snapshot = createEventCacheSnapshot({
-      configSignature,
-      startDate: this._loadedEventRange.startDate,
-      endDate: this._loadedEventRange.endDate,
-      eventsByCalendar: this._eventsByCalendar,
-      lastSuccessfulRefresh: this._lastSuccessfulEventRefresh,
-      perCalendarMetadata: this._calendarEventMetadata
+    return this.queueEventCacheMutation(async () => {
+      if (generation !== this._eventWriteGeneration) return false;
+      if (!this._loadedEventRange || !Number.isFinite(this._lastSuccessfulEventRefresh)) return false;
+      const configSignature = this.getEventCacheConfigSignature();
+      if (!configSignature) return false;
+      const snapshot = createEventCacheSnapshot({
+        configSignature,
+        startDate: this._loadedEventRange.startDate,
+        endDate: this._loadedEventRange.endDate,
+        eventsByCalendar: this._eventsByCalendar,
+        lastSuccessfulRefresh: this._lastSuccessfulEventRefresh,
+        perCalendarMetadata: this._calendarEventMetadata
+      });
+      if (!snapshot || generation !== this._eventWriteGeneration) return false;
+      return writeEventCacheSnapshot(snapshot);
     });
-    if (!snapshot) return false;
-    const persisted = await writeEventCacheSnapshot(snapshot);
-    return generation === this._eventWriteGeneration && persisted;
   }
 
   async flushEventCache({ refresh = true } = {}) {
     this._eventCacheGeneration += 1;
     this._eventFetchGeneration += 1;
     this._eventWriteGeneration += 1;
-    const cleared = await clearAllEventCacheSnapshots();
+    const clearGeneration = this._eventWriteGeneration;
+    const cleared = await this.queueEventCacheMutation(async () => {
+      if (clearGeneration !== this._eventWriteGeneration) return false;
+      return clearAllEventCacheSnapshots();
+    });
     this._eventCacheGeneration += 1;
     this._eventCacheHydrated = false;
     this._eventsByCalendar = {};
@@ -12295,8 +12327,8 @@ class SkylightCalendarCard extends HTMLElement {
   getOldestFailedEventRefreshTime() {
     const failedTimes = (this._config.entities || [])
       .map(entityId => this._calendarEventMetadata[entityId])
-      .filter(metadata => metadata?.refreshFailed && Number.isFinite(metadata.lastSuccessfulRefresh))
-      .map(metadata => metadata.lastSuccessfulRefresh);
+      .filter(metadata => metadata?.refreshFailed && (Number.isFinite(metadata.lastSuccessfulRefresh) || Number.isFinite(metadata.firstFailureAt)))
+      .map(metadata => Number.isFinite(metadata.lastSuccessfulRefresh) ? metadata.lastSuccessfulRefresh : metadata.firstFailureAt);
     return failedTimes.length ? Math.min(...failedTimes) : null;
   }
 
@@ -12314,6 +12346,7 @@ class SkylightCalendarCard extends HTMLElement {
       this._eventRefreshWarningTimer = null;
       this.render();
     }, delay);
+    this._eventRefreshWarningTimer?.unref?.();
   }
 
   shouldShowEventRefreshWarning(now = Date.now()) {
@@ -12367,7 +12400,9 @@ class SkylightCalendarCard extends HTMLElement {
           this._calendarEventMetadata[entityId] = {
             ...existingMetadata,
             lastSuccessfulRefresh: existingMetadata.lastSuccessfulRefresh ?? this._lastSuccessfulEventRefresh,
-            refreshFailed: true
+            refreshFailed: true,
+            firstFailureAt: existingMetadata.firstFailureAt ?? Date.now(),
+            lastNetworkFailureRequest: generation
           };
         });
         this.recomputeEventState();
@@ -12376,6 +12411,7 @@ class SkylightCalendarCard extends HTMLElement {
       }
 
       const now = Date.now();
+      const wasWarningVisible = this.shouldShowEventRefreshWarning(now);
       const shouldRenderForUnchangedData = !this._lastUnchangedDataRender ||
         (now - this._lastUnchangedDataRender >= 15 * 60 * 1000);
       this.applyEventsByCalendar(nextEventsByCalendar, {
@@ -12387,8 +12423,9 @@ class SkylightCalendarCard extends HTMLElement {
         source: 'network',
         requestId: generation
       });
+      const warningVisibilityChanged = wasWarningVisible !== this.shouldShowEventRefreshWarning(now);
       if (failedEntityIds.length === 0) this.persistEventCacheSnapshot({ generation: this._eventWriteGeneration });
-      if (anyChanged || shouldRenderForUnchangedData || failedEntityIds.length > 0) {
+      if (anyChanged || shouldRenderForUnchangedData || failedEntityIds.length > 0 || warningVisibilityChanged) {
         this._lastUnchangedDataRender = now;
         if (preserveScroll) {
           this.renderPreservingAgendaScroll();
@@ -12444,7 +12481,9 @@ class SkylightCalendarCard extends HTMLElement {
           this._calendarEventMetadata[entityId] = {
             ...existingMetadata,
             lastSuccessfulRefresh: existingMetadata.lastSuccessfulRefresh ?? this._lastSuccessfulEventRefresh,
-            refreshFailed: true
+            refreshFailed: true,
+            firstFailureAt: existingMetadata.firstFailureAt ?? Date.now(),
+            lastNetworkFailureRequest: generation
           };
         });
         this.recomputeEventState();
@@ -12458,10 +12497,11 @@ class SkylightCalendarCard extends HTMLElement {
         successfulEntityIds,
         failedEntityIds,
         source: 'network',
-        requestId: generation
+        requestId: generation,
+        coverageMode: 'union'
       });
       if (failedEntityIds.length === 0) this.persistEventCacheSnapshot({ generation: this._eventWriteGeneration });
-      if (render && (anyChanged || failedEntityIds.length > 0)) this.render();
+      if ((render || failedEntityIds.length > 0) && (anyChanged || failedEntityIds.length > 0)) this.render();
       return failedEntityIds.length === 0;
     } finally {
       this._fetching = false;

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -7532,9 +7532,11 @@ function escapeHtmlAttribute(text) {
 const getEventIdentityKey = (entityId, event) => {
   const uid = event?.uid;
   const recurrenceId = event?.recurrence_id || event?.recurring_event_id;
+  const start = event?.start?.dateTime || event?.start?.date || event?.start || '';
+  const end = event?.end?.dateTime || event?.end?.date || event?.end || '';
   if (uid && recurrenceId) return `${entityId}|${uid}|${recurrenceId}`;
-  if (uid) return `${entityId}|${uid}`;
-  return `${entityId}|${recurrenceId || ''}|${event?.start?.dateTime || event?.start?.date || event?.start || ''}|${event?.end?.dateTime || event?.end?.date || event?.end || ''}|${event?.summary || ''}`;
+  if (uid) return `${entityId}|${uid}|${start}|${end}`;
+  return `${entityId}|${recurrenceId || ''}|${start}|${end}|${event?.summary || ''}`;
 };
 
 const normalizeCalendarEvent = (event, { entityId, color }) => ({
@@ -12243,7 +12245,7 @@ class SkylightCalendarCard extends HTMLElement {
     const eventStart = this.getEventStartDate(event);
     const eventEnd = this.getEventEndDate(event);
     if (!Number.isFinite(eventStart.getTime()) || !Number.isFinite(eventEnd.getTime())) return false;
-    return eventStart <= validRange.endDate && eventEnd >= validRange.startDate;
+    return eventEnd > validRange.startDate && eventStart < validRange.endDate;
   }
 
   isEventContainedInRange(event, range) {
@@ -12260,15 +12262,16 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getStableEventIdentityKey(entityId, event) {
-    return event?.uid ? this.getEventIdentityKey(entityId, event) : null;
+    if (!event?.uid) return null;
+    const recurrenceId = event.recurrence_id || event.recurring_event_id;
+    if (recurrenceId) return `${entityId}|${event.uid}|${recurrenceId}`;
+    if (event.rrule) return null;
+    return `${entityId}|${event.uid}`;
   }
 
   reconcileEventsForFetchedRange(existingEvents = [], incomingEvents = [], fetchedRange = null) {
     const range = this.getValidRange(fetchedRange?.startDate, fetchedRange?.endDate);
     if (!range) return this.mergeEvents(existingEvents, incomingEvents);
-    const incomingLogicalKeys = new Set(
-      (incomingEvents || []).map(event => this.getEventLogicalIdentityKey(event.entityId, event))
-    );
     const incomingStableKeys = new Set(
       (incomingEvents || [])
         .map(event => this.getStableEventIdentityKey(event.entityId, event))
@@ -12277,10 +12280,7 @@ class SkylightCalendarCard extends HTMLElement {
     const retainedExisting = (existingEvents || []).filter((event) => {
       const stableKey = this.getStableEventIdentityKey(event.entityId, event);
       if (stableKey && incomingStableKeys.has(stableKey)) return false;
-      const containedInAuthoritativeRange = this.isEventContainedInRange(event, range);
-      if (containedInAuthoritativeRange) return false;
-      const logicalKey = this.getEventLogicalIdentityKey(event.entityId, event);
-      return !(incomingLogicalKeys.has(logicalKey) && this.doEventRangesOverlap(event, range));
+      return !this.doEventRangesOverlap(event, range);
     });
     return this.mergeEvents(retainedExisting, incomingEvents);
   }

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -7535,9 +7535,7 @@ const getEventIdentityKey = (entityId, event) => {
   const start = event?.start?.dateTime || event?.start?.date || event?.start || '';
   const end = event?.end?.dateTime || event?.end?.date || event?.end || '';
   if (uid && recurrenceId) return `${entityId}|${uid}|${recurrenceId}`;
-  if (uid && event?.rrule) return `${entityId}|${uid}|${start}|${end}`;
-  // Non-recurring UID events are intentionally keyed by UID so later chunks/merges deterministically replace earlier copies.
-  if (uid) return `${entityId}|${uid}`;
+  if (uid) return `${entityId}|${uid}|${start}|${end}`;
   return `${entityId}|${recurrenceId || ''}|${start}|${end}|${event?.summary || ''}`;
 };
 

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -738,7 +738,7 @@ function shouldRefreshEvents({ lastFetch, now = Date.now(), maxAge = 60000 } = {
   return !lastFetch || (now - lastFetch > maxAge);
 }
 
-const EVENT_CACHE_SCHEMA_VERSION = 1;
+const EVENT_CACHE_SCHEMA_VERSION = 2;
 const DB_NAME = 'daylight-calendar-card-events';
 const DB_VERSION = 1;
 const STORE_NAME = 'eventSnapshots';
@@ -817,9 +817,18 @@ function normalizeEventCacheSnapshot(snapshot, { configSignature } = {}) {
   if (!Number.isFinite(snapshot.lastSuccessfulRefresh)) return null;
   if (!snapshot.eventsByCalendar || typeof snapshot.eventsByCalendar !== 'object') return null;
 
+  const isValidCachedEvent = (event) => {
+    if (!event || typeof event !== 'object') return false;
+    const rawStart = event?.start?.dateTime || event?.start?.date || event?.start;
+    const rawEnd = event?.end?.dateTime || event?.end?.date || event?.end;
+    const start = rawStart ? new Date(rawStart) : null;
+    const end = rawEnd ? new Date(rawEnd) : start;
+    return !!start && Number.isFinite(start.getTime()) && (!rawEnd || Number.isFinite(end.getTime()));
+  };
   const eventsByCalendar = {};
   Object.entries(snapshot.eventsByCalendar).forEach(([entityId, events]) => {
-    eventsByCalendar[entityId] = Array.isArray(events) ? events.filter((event) => event && typeof event === 'object') : [];
+    if (!Array.isArray(events)) return;
+    eventsByCalendar[entityId] = events.filter(isValidCachedEvent);
   });
 
   return {
@@ -10651,6 +10660,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._viewMode = DEFAULT_VIEW; // 'month', 'week-compact', 'week-standard', or 'agenda'
     this._weekStart = new Date();
     this._fetching = false;
+    this._activeEventFetchRange = null;
     this._lastFetch = null;
     this._loadedEventRange = null;
     this._calendarDataSignatures = {}; // Track per-calendar data for change detection
@@ -12278,40 +12288,47 @@ class SkylightCalendarCard extends HTMLElement {
     if (!configSignature) return;
     const { available, snapshot } = await readEventCacheSnapshot(configSignature);
     if (generation !== this._eventCacheGeneration || !available || !snapshot) return;
+    const hydratable = this.getHydratableEventCacheSnapshotData(snapshot, requestId);
+    if (hydratable.successfulEntityIds.length === 0) return;
+    this._eventCacheHydrated = true;
+    this.applyEventsByCalendar(hydratable.eventsByCalendar, {
+      startDate: new Date(snapshot.coveredRange.start),
+      endDate: new Date(snapshot.coveredRange.end),
+      lastSuccessfulRefresh: snapshot.lastSuccessfulRefresh,
+      successfulEntityIds: hydratable.successfulEntityIds,
+      source: 'cache',
+      requestId,
+      perCalendarMetadata: hydratable.perCalendarMetadata
+    });
+    this.render();
+  }
+
+  getHydratableEventCacheSnapshotData(snapshot, requestId = this._eventFetchGeneration) {
     const cacheEventsByCalendar = {};
     const cacheMetadataByCalendar = {};
     const successfulEntityIds = [];
     (this._config.entities || []).forEach((entityId) => {
       const metadata = this._calendarEventMetadata[entityId] || {};
       if (metadata.lastNetworkSuccessRequest && metadata.lastNetworkSuccessRequest > requestId) return;
-      const cachedMetadata = snapshot.perCalendarMetadata?.[entityId] || {};
-      const cachedRange = this.getValidRange(
-        cachedMetadata.range?.startDate || snapshot.coveredRange.start,
-        cachedMetadata.range?.endDate || snapshot.coveredRange.end
-      );
-      const cachedLastSuccessfulRefresh = Number.isFinite(cachedMetadata.lastSuccessfulRefresh)
-        ? cachedMetadata.lastSuccessfulRefresh
-        : snapshot.lastSuccessfulRefresh;
+      if (!Object.prototype.hasOwnProperty.call(snapshot.perCalendarMetadata || {}, entityId)) return;
+      if (!Object.prototype.hasOwnProperty.call(snapshot.eventsByCalendar || {}, entityId)) return;
+      if (!Array.isArray(snapshot.eventsByCalendar[entityId])) return;
+      const cachedMetadata = snapshot.perCalendarMetadata[entityId] || {};
+      const cachedRange = this.getValidRange(cachedMetadata.range?.startDate, cachedMetadata.range?.endDate);
+      const cachedLastSuccessfulRefresh = cachedMetadata.lastSuccessfulRefresh;
       if (!cachedRange || !Number.isFinite(cachedLastSuccessfulRefresh)) return;
-      cacheEventsByCalendar[entityId] = snapshot.eventsByCalendar[entityId] || [];
+      cacheEventsByCalendar[entityId] = snapshot.eventsByCalendar[entityId];
       cacheMetadataByCalendar[entityId] = {
         range: cachedRange,
         lastSuccessfulRefresh: cachedLastSuccessfulRefresh
       };
       successfulEntityIds.push(entityId);
     });
-    if (successfulEntityIds.length === 0) return;
-    this._eventCacheHydrated = true;
-    this.applyEventsByCalendar(cacheEventsByCalendar, {
-      startDate: new Date(snapshot.coveredRange.start),
-      endDate: new Date(snapshot.coveredRange.end),
-      lastSuccessfulRefresh: snapshot.lastSuccessfulRefresh,
-      successfulEntityIds,
-      source: 'cache',
-      requestId,
-      perCalendarMetadata: cacheMetadataByCalendar
-    });
-    this.render();
+    return {
+      eventsByCalendar: cacheEventsByCalendar,
+      perCalendarMetadata: cacheMetadataByCalendar,
+      successfulEntityIds
+    };
   }
 
   getEventCacheRetainedRange() {
@@ -12378,11 +12395,17 @@ class SkylightCalendarCard extends HTMLElement {
     const retainedRange = this.getEventCacheRetainedRange();
     const { perCalendarMetadata, coveredRange } = this.getPrunedEventMetadataForCache(retainedRange);
     if (!coveredRange || !Number.isFinite(this._lastSuccessfulEventRefresh)) return false;
+    const persistedEventsByCalendar = {};
+    Object.keys(perCalendarMetadata).forEach((entityId) => {
+      if (Object.prototype.hasOwnProperty.call(this._eventsByCalendar, entityId)) {
+        persistedEventsByCalendar[entityId] = this.getPrunedEventsByCalendarForCache({ [entityId]: this._eventsByCalendar[entityId] }, retainedRange)[entityId] || [];
+      }
+    });
     const snapshot = createEventCacheSnapshot({
       configSignature,
       startDate: coveredRange.startDate,
       endDate: coveredRange.endDate,
-      eventsByCalendar: this.getPrunedEventsByCalendarForCache(this._eventsByCalendar, retainedRange),
+      eventsByCalendar: persistedEventsByCalendar,
       lastSuccessfulRefresh: this._lastSuccessfulEventRefresh,
       perCalendarMetadata
     });
@@ -12463,6 +12486,7 @@ class SkylightCalendarCard extends HTMLElement {
     const { startDate, endDate } = this.getEventFetchRange();
     const generation = ++this._eventFetchGeneration;
     this._fetching = true;
+    this._activeEventFetchRange = { startDate, endDate };
     this._lastFetch = Date.now();
 
     try {
@@ -12528,6 +12552,7 @@ class SkylightCalendarCard extends HTMLElement {
       }
     } finally {
       this._fetching = false;
+      this._activeEventFetchRange = null;
       if (this._pendingEventRefreshAfterCurrentFetch) {
         this._pendingEventRefreshAfterCurrentFetch = false;
         this.ensureEventsForCurrentRange({ force: true });
@@ -12544,6 +12569,7 @@ class SkylightCalendarCard extends HTMLElement {
 
     const generation = ++this._eventFetchGeneration;
     this._fetching = true;
+    this._activeEventFetchRange = { startDate, endDate };
     this._lastFetch = Date.now();
 
     try {
@@ -12598,6 +12624,7 @@ class SkylightCalendarCard extends HTMLElement {
       return failedEntityIds.length === 0;
     } finally {
       this._fetching = false;
+      this._activeEventFetchRange = null;
       if (this._pendingEventRefreshAfterCurrentFetch) {
         this._pendingEventRefreshAfterCurrentFetch = false;
         this.ensureEventsForCurrentRange({ force: true });
@@ -12619,7 +12646,19 @@ class SkylightCalendarCard extends HTMLElement {
       return;
     }
 
-    if (this._fetching && !force) return;
+    const { startDate, endDate } = this.getEventFetchRange();
+
+    if (this._fetching) {
+      if (this.isDateRangeCoveredByLoadedEvents(visibleStartDate, visibleEndDate)) {
+        if (renderIfCovered) this.render();
+        return;
+      }
+      const activeRange = this.getValidRange(this._activeEventFetchRange?.startDate, this._activeEventFetchRange?.endDate);
+      if (force || !activeRange || !isDateRangeCoveredByLoadedEvents(activeRange, startDate, endDate)) {
+        this._pendingEventRefreshAfterCurrentFetch = true;
+      }
+      return;
+    }
 
     if (force || shouldRefreshForAge || !this._loadedEventRange) {
       const shouldPreserveScrollDuringRefresh = this._viewMode === 'agenda' && !force && !renderIfCovered;
@@ -12638,7 +12677,6 @@ class SkylightCalendarCard extends HTMLElement {
 
     // Once visible range falls outside loaded coverage, fetch around current view
     // (with buffer) and only request missing leading/trailing segments.
-    const { startDate, endDate } = this.getEventFetchRange();
     const missingRanges = [];
 
     if (startDate < this._loadedEventRange.startDate) {

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -630,7 +630,7 @@ async function fetchEventsForCalendar({
   normalizeCalendarEvent,
   fetchedRange = null
 }) {
-  const seen = new Set();
+  const mergedRawEventsByKey = new Map();
   const color = getCalendarColor(entityId, colorIndex);
 
   const chunkResults = await Promise.all(
@@ -642,20 +642,20 @@ async function fetchEventsForCalendar({
     return { success: false, events: [], failedChunks, fetchedRange };
   }
 
-  const mergedEvents = [];
   chunkResults.forEach(result => {
     const events = Array.isArray(result?.events) ? result.events : [];
 
     events.forEach(event => {
       const key = getEventIdentityKey(entityId, event);
-      if (seen.has(key)) return;
-      seen.add(key);
-
-      mergedEvents.push(normalizeCalendarEvent(event, { entityId, color }));
+      mergedRawEventsByKey.set(key, event);
     });
   });
 
-  return { success: true, events: mergedEvents, fetchedRange };
+  return {
+    success: true,
+    events: Array.from(mergedRawEventsByKey.values()).map(event => normalizeCalendarEvent(event, { entityId, color })),
+    fetchedRange
+  };
 }
 
 async function fetchEventsForChunk({ hass, entityId, chunk, formatLocalDate }) {
@@ -7535,7 +7535,9 @@ const getEventIdentityKey = (entityId, event) => {
   const start = event?.start?.dateTime || event?.start?.date || event?.start || '';
   const end = event?.end?.dateTime || event?.end?.date || event?.end || '';
   if (uid && recurrenceId) return `${entityId}|${uid}|${recurrenceId}`;
-  if (uid) return `${entityId}|${uid}|${start}|${end}`;
+  if (uid && event?.rrule) return `${entityId}|${uid}|${start}|${end}`;
+  // Non-recurring UID events are intentionally keyed by UID so later chunks/merges deterministically replace earlier copies.
+  if (uid) return `${entityId}|${uid}`;
   return `${entityId}|${recurrenceId || ''}|${start}|${end}|${event?.summary || ''}`;
 };
 

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -6884,13 +6884,43 @@ test('partial calendar refresh preserves failed calendar and successful empty cl
     'calendar.b': [{ entityId: 'calendar.b', summary: 'old b', start: { date: '2026-01-02' }, end: { date: '2026-01-03' } }]
   };
   card._events = Object.values(card._eventsByCalendar).flat();
-  card.persistEventCacheSnapshot = () => {};
+  let persisted = false;
+  card.persistEventCacheSnapshot = () => { persisted = true; };
   card.render = () => {};
 
   await card.updateEvents();
   assert.deepEqual(card._eventsByCalendar['calendar.a'], []);
   assert.equal(card._eventsByCalendar['calendar.b'][0].summary, 'old b');
   assert.equal(card._events.length, 1);
+  assert.equal(card._lastEventRefreshFailed, true);
+  assert.equal(card._lastSuccessfulEventRefresh, null);
+  assert.equal(persisted, false);
+});
+
+test('partial refresh keeps prior success timestamp stale and skips mixed cache persistence', async () => {
+  const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
+  card._hass = {};
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') });
+  card.fetchEventsByCalendarInRange = async () => ({
+    'calendar.a': { success: true, events: [{ entityId: 'calendar.a', summary: 'new a', start: { date: '2026-01-04' }, end: { date: '2026-01-05' } }] },
+    'calendar.b': { success: false, events: [] }
+  });
+  card._eventsByCalendar = {
+    'calendar.a': [],
+    'calendar.b': [{ entityId: 'calendar.b', summary: 'cached b', start: { date: '2026-01-02' }, end: { date: '2026-01-03' } }]
+  };
+  card._lastSuccessfulEventRefresh = Date.parse('2026-01-01T12:00:00Z');
+  let persisted = false;
+  card.persistEventCacheSnapshot = () => { persisted = true; };
+  card.render = () => {};
+
+  await card.updateEvents();
+  assert.equal(card._eventsByCalendar['calendar.a'][0].summary, 'new a');
+  assert.equal(card._eventsByCalendar['calendar.b'][0].summary, 'cached b');
+  assert.equal(card._lastSuccessfulEventRefresh, Date.parse('2026-01-01T12:00:00Z'));
+  assert.equal(card._lastEventRefreshFailed, true);
+  assert.equal(card.shouldShowEventRefreshWarning(Date.parse('2026-01-01T12:30:01Z')), true);
+  assert.equal(persisted, false);
 });
 
 test('failed refresh preserves last-known-good events and stale warning timing', async () => {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -6911,7 +6911,10 @@ test('partial refresh keeps prior success timestamp stale and skips mixed cache 
     'calendar.a': [],
     'calendar.b': [{ entityId: 'calendar.b', summary: 'cached b', start: { date: '2026-01-02' }, end: { date: '2026-01-03' } }]
   };
-  card._lastSuccessfulEventRefresh = Date.parse('2026-01-01T12:00:00Z');
+  card._calendarEventMetadata = {
+    'calendar.b': { lastSuccessfulRefresh: Date.parse('2026-01-01T12:00:00Z') }
+  };
+  card.recomputeEventState();
   let persisted = false;
   card.persistEventCacheSnapshot = () => { persisted = true; };
   card.render = () => {};
@@ -7176,25 +7179,18 @@ test('visible stale warning clears immediately after unchanged successful refres
   assert.equal(renderCount, 1);
 });
 
-test('flush barrier rejects queued stale persistent writes before they open storage', async () => {
-  const card = makeCard({ entities: ['calendar.a'] });
-  card._hass = { user: { id: 'user-1' } };
-  card.applyEventsByCalendar({ 'calendar.a': [] }, {
+test('shared flush barrier rejects stale persistent writes before storage opens', async () => {
+  const { beginEventCacheFlush, createEventCacheSnapshot, getEventCacheMutationEpoch, writeEventCacheSnapshot } = await import('./src/events/event-cache.js');
+  const epoch = getEventCacheMutationEpoch();
+  beginEventCacheFlush();
+  const snapshot = createEventCacheSnapshot({
+    configSignature: 'shared-flush-test',
     startDate: new Date('2026-01-01T00:00:00Z'),
     endDate: new Date('2026-02-01T00:00:00Z'),
     lastSuccessfulRefresh: Date.parse('2026-01-01T12:00:00Z'),
-    successfulEntityIds: ['calendar.a'],
-    source: 'network',
-    requestId: 1
+    eventsByCalendar: { 'calendar.a': [] }
   });
-  let releaseQueue;
-  card._eventCacheMutationQueue = new Promise(resolve => { releaseQueue = resolve; });
-  const staleWrite = card.persistEventCacheSnapshot({ generation: card._eventWriteGeneration });
-  const flush = card.flushEventCache({ refresh: false });
-  releaseQueue();
-  assert.equal(await staleWrite, false);
-  assert.equal(await flush, false);
-  assert.deepEqual(card._eventsByCalendar, {});
+  assert.equal(await writeEventCacheSnapshot(snapshot, { epoch }), false);
 });
 
 test('prolonged initial calendar failure without prior success shows stale warning', async () => {
@@ -7214,6 +7210,91 @@ test('prolonged initial calendar failure without prior success shows stale warni
   assert.equal(card.shouldShowEventRefreshWarning(Date.parse('2026-01-01T12:30:01Z')), true);
 });
 
+
+
+test('setConfig forces Home Assistant refresh even with recent fetch and cache coverage', async () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  card._hass = { user: { id: 'user-1' }, states: {} };
+  card._lastFetch = Date.now();
+  card._loadedEventRange = { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') };
+  card.loadEventCacheForCurrentConfig = async () => {
+    card.applyEventsByCalendar({ 'calendar.a': [] }, {
+      startDate: new Date('2026-01-01T00:00:00Z'),
+      endDate: new Date('2026-02-01T00:00:00Z'),
+      lastSuccessfulRefresh: Date.parse('2026-01-01T12:00:00Z'),
+      successfulEntityIds: ['calendar.a'],
+      source: 'cache',
+      requestId: card._eventFetchGeneration
+    });
+  };
+  let forcedRefreshes = 0;
+  card.ensureEventsForCurrentRange = async ({ force = false } = {}) => {
+    if (force) forcedRefreshes += 1;
+  };
+
+  card.setConfig({ entities: ['calendar.a'] });
+  assert.equal(card._lastFetch, null);
+  assert.equal(forcedRefreshes, 1);
+});
+
+test('failed calendars never inherit aggregate success timestamps', async () => {
+  const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
+  card._hass = { user: { id: 'user-1' } };
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') });
+  const originalNow = Date.now;
+  Date.now = () => Date.parse('2026-01-01T12:00:00Z');
+  card.fetchEventsByCalendarInRange = async () => ({
+    'calendar.a': { success: false, events: [] },
+    'calendar.b': { success: false, events: [] }
+  });
+  card.render = () => {};
+  try {
+    await card.updateEvents();
+  } finally {
+    Date.now = originalNow;
+  }
+
+  Date.now = () => Date.parse('2026-01-01T12:10:00Z');
+  card.fetchEventsByCalendarInRange = async () => ({
+    'calendar.a': { success: true, events: [] },
+    'calendar.b': { success: false, events: [] }
+  });
+  try {
+    await card.updateEvents();
+  } finally {
+    Date.now = originalNow;
+  }
+
+  assert.equal(Number.isFinite(card._calendarEventMetadata['calendar.a'].lastSuccessfulRefresh), true);
+  assert.equal(card._calendarEventMetadata['calendar.b'].lastSuccessfulRefresh, undefined);
+  assert.equal(card._calendarEventMetadata['calendar.b'].firstFailureAt, Date.parse('2026-01-01T12:00:00Z'));
+  assert.equal(card.shouldShowEventRefreshWarning(Date.parse('2026-01-01T12:30:00Z')), true);
+});
+
+test('cache pruning bounds snapshot events while preserving overlapping multi-day events', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const range = { startDate: new Date('2026-06-01T00:00:00Z'), endDate: new Date('2026-06-30T23:59:59Z') };
+  const pruned = card.getPrunedEventsByCalendarForCache({
+    'calendar.a': [
+      { entityId: 'calendar.a', summary: 'too old', start: { date: '2025-01-01' }, end: { date: '2025-01-02' } },
+      { entityId: 'calendar.a', summary: 'overlaps retained window', start: { date: '2026-02-15' }, end: { date: '2026-06-02' } },
+      { entityId: 'calendar.a', summary: 'visible', start: { date: '2026-06-10' }, end: { date: '2026-06-11' } },
+      { entityId: 'calendar.a', summary: 'too new', start: { date: '2027-01-01' }, end: { date: '2027-01-02' } }
+    ]
+  }, range);
+  assert.deepEqual(pruned['calendar.a'].map(event => event.summary), ['overlaps retained window', 'visible']);
+});
+
+test('stale warning is visible at the exact thirty-minute boundary', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  card._calendarEventMetadata = {
+    'calendar.a': { firstFailureAt: Date.parse('2026-01-01T12:00:00Z'), refreshFailed: true }
+  };
+  card.recomputeEventState();
+  assert.equal(card.shouldShowEventRefreshWarning(Date.parse('2026-01-01T12:29:59Z')), false);
+  assert.equal(card.shouldShowEventRefreshWarning(Date.parse('2026-01-01T12:30:00Z')), true);
+});
+
 test('failed refresh preserves last-known-good events and stale warning timing', async () => {
   const card = makeCard({ entities: ['calendar.a'] });
   card._hass = {};
@@ -7221,7 +7302,10 @@ test('failed refresh preserves last-known-good events and stale warning timing',
   card.fetchEventsByCalendarInRange = async () => ({ 'calendar.a': { success: false, events: [] } });
   card._eventsByCalendar = { 'calendar.a': [{ entityId: 'calendar.a', summary: 'old', start: { date: '2026-01-02' }, end: { date: '2026-01-03' } }] };
   card._events = card._eventsByCalendar['calendar.a'];
-  card._lastSuccessfulEventRefresh = Date.parse('2026-01-01T12:00:00Z');
+  card._calendarEventMetadata = {
+    'calendar.a': { lastSuccessfulRefresh: Date.parse('2026-01-01T12:00:00Z') }
+  };
+  card.recomputeEventState();
   card.render = () => {};
 
   await card.updateEvents();

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -7241,6 +7241,7 @@ test('setConfig forces Home Assistant refresh even with recent fetch and cache c
 test('failed calendars never inherit aggregate success timestamps', async () => {
   const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
   card._hass = { user: { id: 'user-1' } };
+  card.getVisibleDateRange = () => ({ startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') });
   card.getEventFetchRange = () => ({ startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') });
   const originalNow = Date.now;
   Date.now = () => Date.parse('2026-01-01T12:00:00Z');
@@ -7289,6 +7290,7 @@ test('cache pruning bounds snapshot events while preserving overlapping multi-da
 test('mixed partial cache reload keeps successful empty and stale last-known-good calendars', async () => {
   const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
   card._hass = { user: { id: 'user-1' } };
+  card.getVisibleDateRange = () => ({ startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') });
   card.getEventFetchRange = () => ({ startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') });
   card._eventsByCalendar = {
     'calendar.a': [{ entityId: 'calendar.a', summary: 'old a', start: { date: '2026-01-02' }, end: { date: '2026-01-03' } }],
@@ -7503,9 +7505,69 @@ test('cached event with mismatched entity id is rejected for its containing cale
   assert.deepEqual(hydratable.successfulEntityIds, []);
 });
 
+test('cached numeric and Date-object event date shapes are rejected', async () => {
+  const { normalizeEventCacheSnapshot, EVENT_CACHE_SCHEMA_VERSION } = await import('./src/events/event-cache.js');
+  const snapshot = normalizeEventCacheSnapshot({
+    schemaVersion: EVENT_CACHE_SCHEMA_VERSION,
+    configSignature: 'unsupported-date-shapes',
+    coveredRange: { start: '2026-01-01T00:00:00Z', end: '2026-02-01T00:00:00Z' },
+    lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z'),
+    eventsByCalendar: {
+      'calendar.a': [{ entityId: 'calendar.a', summary: 'numeric', start: 1767225600000, end: 1767312000000 }],
+      'calendar.b': [{ entityId: 'calendar.b', summary: 'date object', start: new Date('2026-01-02T00:00:00Z'), end: new Date('2026-01-03T00:00:00Z') }]
+    },
+    perCalendarMetadata: {
+      'calendar.a': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z') },
+      'calendar.b': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z') }
+    }
+  }, { configSignature: 'unsupported-date-shapes' });
+  const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
+  const hydratable = card.getHydratableEventCacheSnapshotData(snapshot, 0);
+  assert.deepEqual(hydratable.successfulEntityIds, []);
+});
+
+test('cached mixed date and dateTime shapes are rejected', async () => {
+  const { normalizeEventCacheSnapshot, EVENT_CACHE_SCHEMA_VERSION } = await import('./src/events/event-cache.js');
+  const snapshot = normalizeEventCacheSnapshot({
+    schemaVersion: EVENT_CACHE_SCHEMA_VERSION,
+    configSignature: 'mixed-date-shapes',
+    coveredRange: { start: '2026-01-01T00:00:00Z', end: '2026-02-01T00:00:00Z' },
+    lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z'),
+    eventsByCalendar: {
+      'calendar.a': [{ entityId: 'calendar.a', summary: 'mixed', start: { date: '2026-01-02' }, end: { dateTime: '2026-01-03T00:00:00Z' } }]
+    },
+    perCalendarMetadata: {
+      'calendar.a': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z') }
+    }
+  }, { configSignature: 'mixed-date-shapes' });
+  const card = makeCard({ entities: ['calendar.a'] });
+  const hydratable = card.getHydratableEventCacheSnapshotData(snapshot, 0);
+  assert.deepEqual(hydratable.successfulEntityIds, []);
+});
+
+test('cached reversed event ranges are rejected', async () => {
+  const { normalizeEventCacheSnapshot, EVENT_CACHE_SCHEMA_VERSION } = await import('./src/events/event-cache.js');
+  const snapshot = normalizeEventCacheSnapshot({
+    schemaVersion: EVENT_CACHE_SCHEMA_VERSION,
+    configSignature: 'reversed-event-range',
+    coveredRange: { start: '2026-01-01T00:00:00Z', end: '2026-02-01T00:00:00Z' },
+    lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z'),
+    eventsByCalendar: {
+      'calendar.a': [{ entityId: 'calendar.a', summary: 'reversed', start: { date: '2026-01-03' }, end: { date: '2026-01-02' } }]
+    },
+    perCalendarMetadata: {
+      'calendar.a': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z') }
+    }
+  }, { configSignature: 'reversed-event-range' });
+  const card = makeCard({ entities: ['calendar.a'] });
+  const hydratable = card.getHydratableEventCacheSnapshotData(snapshot, 0);
+  assert.deepEqual(hydratable.successfulEntityIds, []);
+});
+
 test('mixed partial cache reload keeps newer successful calendar data', async () => {
   const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
   card._hass = { user: { id: 'user-1' } };
+  card.getVisibleDateRange = () => ({ startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') });
   card.getEventFetchRange = () => ({ startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') });
   card._eventsByCalendar = {
     'calendar.a': [{ entityId: 'calendar.a', summary: 'old a', start: { date: '2026-01-02' }, end: { date: '2026-01-03' } }],
@@ -7612,10 +7674,12 @@ test('persisted snapshot span stays bounded after multi-year agenda expansion', 
   card._hass = { user: { id: 'user-1' } };
   card._viewMode = 'agenda';
   card.getVisibleDateRange = () => ({ startDate: new Date('2026-06-01T00:00:00Z'), endDate: new Date('2028-06-01T00:00:00Z') });
+  card._agendaVisibleStartDate = new Date('2028-05-01T00:00:00Z');
+  card._agendaVisibleEndDate = new Date('2028-05-14T23:59:59Z');
   card._eventsByCalendar = {
     'calendar.a': [
-      { entityId: 'calendar.a', summary: 'overlap retained', start: { date: '2027-01-01' }, end: { date: '2027-07-01' } },
-      { entityId: 'calendar.a', summary: 'far future', start: { date: '2028-05-01' }, end: { date: '2028-05-02' } }
+      { entityId: 'calendar.a', summary: 'overlap retained', start: { date: '2028-04-01' }, end: { date: '2028-06-01' } },
+      { entityId: 'calendar.a', summary: 'far past', start: { date: '2026-06-01' }, end: { date: '2026-06-02' } }
     ]
   };
   card._calendarEventMetadata = {
@@ -7637,7 +7701,44 @@ test('persisted snapshot span stays bounded after multi-year agenda expansion', 
   });
   const spanDays = (new Date(snapshot.coveredRange.end) - new Date(snapshot.coveredRange.start)) / (24 * 60 * 60 * 1000);
   assert.equal(spanDays <= 210, true);
+  assert.equal(new Date(snapshot.coveredRange.start) <= card._agendaVisibleStartDate, true);
+  assert.equal(new Date(snapshot.coveredRange.end) >= card._agendaVisibleEndDate, true);
   assert.deepEqual(snapshot.eventsByCalendar['calendar.a'].map(event => event.summary), ['overlap retained']);
+});
+
+test('agenda cache retention has useful current-view fallback before DOM visible dates exist', async () => {
+  const { createEventCacheSnapshot } = await import('./src/events/event-cache.js');
+  const card = makeCard({ entities: ['calendar.a'] });
+  card._hass = { user: { id: 'user-1' } };
+  card._viewMode = 'agenda';
+  card._currentDate = new Date('2026-06-15T12:00:00Z');
+  card.getVisibleDateRange = () => ({ startDate: new Date('2025-01-01T00:00:00Z'), endDate: new Date('2028-01-01T00:00:00Z') });
+  card._eventsByCalendar = {
+    'calendar.a': [
+      { entityId: 'calendar.a', summary: 'current fallback', start: { date: '2026-06-10' }, end: { date: '2026-06-20' } },
+      { entityId: 'calendar.a', summary: 'far future', start: { date: '2028-01-01' }, end: { date: '2028-01-02' } }
+    ]
+  };
+  card._calendarEventMetadata = {
+    'calendar.a': {
+      range: { startDate: new Date('2025-01-01T00:00:00Z'), endDate: new Date('2028-01-01T00:00:00Z') },
+      lastSuccessfulRefresh: Date.parse('2026-06-15T12:00:00Z')
+    }
+  };
+  card.recomputeEventState();
+  const retainedRange = card.getEventCacheRetainedRange();
+  const { perCalendarMetadata, coveredRange } = card.getPrunedEventMetadataForCache(retainedRange);
+  const snapshot = createEventCacheSnapshot({
+    configSignature: 'bounded-agenda-fallback',
+    startDate: coveredRange.startDate,
+    endDate: coveredRange.endDate,
+    lastSuccessfulRefresh: card._lastSuccessfulEventRefresh,
+    eventsByCalendar: card.getPrunedEventsByCalendarForCache(card._eventsByCalendar, retainedRange),
+    perCalendarMetadata
+  });
+  const spanDays = (new Date(snapshot.coveredRange.end) - new Date(snapshot.coveredRange.start)) / (24 * 60 * 60 * 1000);
+  assert.equal(spanDays <= 210, true);
+  assert.deepEqual(snapshot.eventsByCalendar['calendar.a'].map(event => event.summary), ['current fallback']);
 });
 
 test('normal hass update does not queue redundant refresh while forced setConfig fetch is active', async () => {
@@ -7692,6 +7793,20 @@ test('active fetch renders already-covered view without queuing duplicate fetch'
   await card.ensureEventsForCurrentRange({ renderIfCovered: true });
   assert.equal(rendered, 1);
   assert.equal(card._pendingEventRefreshAfterCurrentFetch, false);
+});
+
+test('force ensure queues follow-up refresh during active fetch even when visible range is covered', async () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  card._hass = { user: { id: 'user-1' }, states: {} };
+  card._fetching = true;
+  card._activeEventFetchRange = { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') };
+  card._loadedEventRange = { startDate: new Date('2026-03-01T00:00:00Z'), endDate: new Date('2026-03-31T00:00:00Z') };
+  card.getVisibleDateRange = () => ({ startDate: new Date('2026-03-10T00:00:00Z'), endDate: new Date('2026-03-17T00:00:00Z') });
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-03-01T00:00:00Z'), endDate: new Date('2026-04-01T00:00:00Z') });
+  card.ensureEventsForCurrentRange = originalEnsureEventsForCurrentRange.bind(card);
+  await card.ensureEventsForCurrentRange({ force: true, renderIfCovered: true });
+  assert.equal(card._pendingEventRefreshAfterCurrentFetch, true);
+  assert.equal(card._pendingEventRenderAfterCurrentFetch, true);
 });
 
 test('view change requiring refresh renders even when fetched events are identical', async () => {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -5967,7 +5967,7 @@ test('event normalizer module preserves identity, all-day detection, and start d
 
   assert.equal(
     getEventIdentityKey('calendar.work', rawEvent),
-    'calendar.work|abc'
+    'calendar.work|abc|2026-06-23|2026-06-24'
   );
   assert.deepEqual(normalizeCalendarEvent(rawEvent, { entityId: 'calendar.work', color: '#123456' }), {
     ...rawEvent,
@@ -6506,8 +6506,11 @@ test('event fetcher normalizes with calendar colors and de-duplicates chunk over
   const hass = {
     callWS: ({ start_date_time }) => Promise.resolve(
       start_date_time === '2026-01-01T00:00:00.000Z'
-        ? [{ uid: '1', summary: 'First' }, { uid: '2', summary: 'Second' }]
-        : [{ uid: '1', summary: 'First duplicate' }]
+        ? [
+            { uid: '1', summary: 'First', start: { dateTime: '2026-01-01T10:00:00Z' }, end: { dateTime: '2026-01-01T11:00:00Z' } },
+            { uid: '2', summary: 'Second', start: { dateTime: '2026-01-02T10:00:00Z' }, end: { dateTime: '2026-01-02T11:00:00Z' } }
+          ]
+        : [{ uid: '1', summary: 'First duplicate', start: { dateTime: '2026-01-01T10:00:00Z' }, end: { dateTime: '2026-01-01T11:00:00Z' } }]
     )
   };
   const normalizedContexts = [];
@@ -7537,17 +7540,18 @@ test('event identity is HA recurrence-aware across merge and chunk deduplication
   assert.deepEqual(result.events.map(event => event.summary), ['first', 'second']);
 });
 
-test('non-recurring UID identity collapses moved conflicts consistently across fetch and merge', async () => {
+test('UID-only occurrences use start and end for fetch and merge identity', async () => {
   const { fetchEventsForCalendar, mergeEvents } = await import('./src/events/event-fetcher.js');
   const { getEventIdentityKey, normalizeCalendarEvent } = await import('./src/events/event-normalizer.js');
-  const oldCopy = { uid: 'single-event', summary: 'old copy', start: { dateTime: '2026-01-01T10:00:00Z' }, end: { dateTime: '2026-01-01T11:00:00Z' } };
-  const movedCopy = { uid: 'single-event', summary: 'moved copy', start: { dateTime: '2026-01-02T10:00:00Z' }, end: { dateTime: '2026-01-02T11:00:00Z' } };
+  const first = { uid: 'same-uid', summary: 'first occurrence', start: { dateTime: '2026-01-01T10:00:00Z' }, end: { dateTime: '2026-01-01T11:00:00Z' } };
+  const second = { uid: 'same-uid', summary: 'second occurrence', start: { dateTime: '2026-01-02T10:00:00Z' }, end: { dateTime: '2026-01-02T11:00:00Z' } };
+  const duplicateSecond = { ...second, summary: 'second duplicate' };
 
   const result = await fetchEventsForCalendar({
     hass: {
       callWS: async ({ start_date_time }) => start_date_time === '2026-01-01T00:00:00.000Z'
-        ? [oldCopy]
-        : [movedCopy],
+        ? [first, second]
+        : [duplicateSecond],
       callApi: async () => []
     },
     entityId: 'calendar.a',
@@ -7562,25 +7566,18 @@ test('non-recurring UID identity collapses moved conflicts consistently across f
     fetchedRange: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-01-02T23:59:59.999Z') }
   });
   assert.equal(result.success, true);
-  assert.deepEqual(result.events.map(event => event.summary), ['moved copy']);
+  assert.deepEqual(result.events.map(event => event.summary), ['first occurrence', 'second duplicate']);
 
   const merged = mergeEvents([
-    { ...oldCopy, entityId: 'calendar.a' }
+    { ...first, entityId: 'calendar.a' },
+    { ...second, entityId: 'calendar.a' }
   ], [
-    { ...movedCopy, entityId: 'calendar.a' }
+    { ...duplicateSecond, entityId: 'calendar.a' }
   ], {
     getEventIdentityKey,
     getEventStartDate: event => new Date(event.start.dateTime)
   });
-  assert.deepEqual(merged.map(event => event.summary), ['moved copy']);
-
-  const card = makeCard({ entities: ['calendar.a'] });
-  const reconciled = card.reconcileEventsForFetchedRange([
-    { ...oldCopy, entityId: 'calendar.a' }
-  ], [
-    { ...movedCopy, entityId: 'calendar.a' }
-  ], { startDate: new Date('2026-01-02T00:00:00Z'), endDate: new Date('2026-01-02T23:59:59.999Z') });
-  assert.deepEqual(reconciled.map(event => event.summary), ['moved copy']);
+  assert.deepEqual(merged.map(event => event.summary), ['first occurrence', 'second duplicate']);
 });
 
 test('range union remains conservative when an extension leaves an unfetched gap', () => {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -6478,7 +6478,7 @@ test('event fetcher falls back to REST URL and reports failure after failed fetc
     });
 
     assert.deepEqual(restEvents, { success: true, events: [{ summary: 'REST event' }] });
-    assert.equal(restUrl, 'calendars/calendar.work?start=2026-01-01T00:00:00Z&end=2026-01-31T23:59:59Z');
+    assert.equal(restUrl, 'calendars/calendar.work?start=2026-01-01T12%3A34%3A56.000Z&end=2026-01-31T12%3A34%3A56.000Z');
 
     const failedEvents = await fetchEventsForChunk({
       hass: {
@@ -7295,6 +7295,116 @@ test('trailing boundary overlap deletes stale cached events through chunking wit
   assert.equal(card._calendarEventMetadata['calendar.a'].range.endDate.toISOString(), '2026-01-25T23:59:59.999Z');
 });
 
+test('REST fallback uses exact leading chunk interval for overlap reconciliation', async () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const cachedStart = new Date('2026-01-10T12:00:00Z');
+  const cachedEnd = new Date('2026-01-20T12:00:00Z');
+  const restUrls = [];
+  card._hass = {
+    user: { id: 'user-1' },
+    states: {},
+    callWS: async () => { throw new Error('websocket unavailable'); },
+    callApi: async (method, url) => {
+      assert.equal(method, 'GET');
+      restUrls.push(url);
+      return [];
+    }
+  };
+  card.formatLocalDate = () => '1999-12-31';
+  card._eventsByCalendar = {
+    'calendar.a': [
+      { entityId: 'calendar.a', uid: 'inside-leading', summary: 'inside leading', start: { dateTime: '2026-01-10T10:00:00Z' }, end: { dateTime: '2026-01-10T11:00:00Z' } },
+      { entityId: 'calendar.a', uid: 'outside-leading', summary: 'outside leading', start: { dateTime: '2026-01-11T10:00:00Z' }, end: { dateTime: '2026-01-11T11:00:00Z' } }
+    ]
+  };
+  card._calendarEventMetadata = {
+    'calendar.a': { range: { startDate: cachedStart, endDate: cachedEnd }, lastSuccessfulRefresh: 1 }
+  };
+  card.recomputeEventState();
+  card._lastFetch = Date.now();
+  card.getVisibleDateRange = () => ({ startDate: new Date('2026-01-09T00:00:00Z'), endDate: new Date('2026-01-10T18:00:00Z') });
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-01-01T12:00:00Z'), endDate: cachedEnd });
+  card.persistEventCacheSnapshot = () => {};
+  card.render = () => {};
+  card.ensureEventsForCurrentRange = originalEnsureEventsForCurrentRange.bind(card);
+
+  await card.ensureEventsForCurrentRange();
+
+  assert.equal(restUrls.length, 1);
+  assert.equal(restUrls[0], 'calendars/calendar.a?start=2026-01-01T00%3A00%3A00.000Z&end=2026-01-10T23%3A59%3A59.999Z');
+  const summaries = card._eventsByCalendar['calendar.a'].map(event => event.summary);
+  assert.equal(summaries.includes('inside leading'), false);
+  assert.equal(summaries.includes('outside leading'), true);
+});
+
+test('REST fallback uses exact trailing chunk interval for overlap reconciliation', async () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const cachedStart = new Date('2026-01-10T12:00:00Z');
+  const cachedEnd = new Date('2026-01-20T12:00:00Z');
+  const restUrls = [];
+  card._hass = {
+    user: { id: 'user-1' },
+    states: {},
+    callWS: async () => { throw new Error('websocket unavailable'); },
+    callApi: async (method, url) => {
+      assert.equal(method, 'GET');
+      restUrls.push(url);
+      return [];
+    }
+  };
+  card.formatLocalDate = () => '1999-12-31';
+  card._eventsByCalendar = {
+    'calendar.a': [
+      { entityId: 'calendar.a', uid: 'outside-trailing', summary: 'outside trailing', start: { dateTime: '2026-01-19T10:00:00Z' }, end: { dateTime: '2026-01-19T11:00:00Z' } },
+      { entityId: 'calendar.a', uid: 'inside-trailing', summary: 'inside trailing', start: { dateTime: '2026-01-20T18:00:00Z' }, end: { dateTime: '2026-01-20T19:00:00Z' } }
+    ]
+  };
+  card._calendarEventMetadata = {
+    'calendar.a': { range: { startDate: cachedStart, endDate: cachedEnd }, lastSuccessfulRefresh: 1 }
+  };
+  card.recomputeEventState();
+  card._lastFetch = Date.now();
+  card.getVisibleDateRange = () => ({ startDate: new Date('2026-01-20T08:00:00Z'), endDate: new Date('2026-01-21T00:00:00Z') });
+  card.getEventFetchRange = () => ({ startDate: cachedStart, endDate: new Date('2026-01-25T12:00:00Z') });
+  card.persistEventCacheSnapshot = () => {};
+  card.render = () => {};
+  card.ensureEventsForCurrentRange = originalEnsureEventsForCurrentRange.bind(card);
+
+  await card.ensureEventsForCurrentRange();
+
+  assert.equal(restUrls.length, 1);
+  assert.equal(restUrls[0], 'calendars/calendar.a?start=2026-01-20T00%3A00%3A00.000Z&end=2026-01-25T23%3A59%3A59.999Z');
+  const summaries = card._eventsByCalendar['calendar.a'].map(event => event.summary);
+  assert.equal(summaries.includes('outside trailing'), true);
+  assert.equal(summaries.includes('inside trailing'), false);
+});
+
+test('recurrence identity distinguishes occurrences and replaces moved fetched occurrences', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  assert.equal(card.getEventLogicalIdentityKey('calendar.a', { uid: 'series', recurrence_id: '2026-01-01T10:00:00Z' }), 'calendar.a|series|2026-01-01T10:00:00Z');
+  assert.notEqual(
+    card.getEventLogicalIdentityKey('calendar.a', { uid: 'series', recurrence_id: '2026-01-01T10:00:00Z' }),
+    card.getEventLogicalIdentityKey('calendar.a', { uid: 'series', recurrence_id: '2026-01-02T10:00:00Z' })
+  );
+  assert.equal(card.getEventLogicalIdentityKey('calendar.a', { recurrence_id: '2026-01-03T10:00:00Z' }), 'calendar.a|recurrence|2026-01-03T10:00:00Z');
+
+  const reconciled = card.reconcileEventsForFetchedRange([
+    { entityId: 'calendar.a', uid: 'series', recurrence_id: '2026-01-01T10:00:00Z', summary: 'stale moved', start: { dateTime: '2026-01-10T10:00:00Z' }, end: { dateTime: '2026-01-10T11:00:00Z' } },
+    { entityId: 'calendar.a', uid: 'series', recurrence_id: '2026-01-02T10:00:00Z', summary: 'other occurrence', start: { dateTime: '2026-01-12T12:00:00Z' }, end: { dateTime: '2026-01-12T13:00:00Z' } },
+    { entityId: 'calendar.a', recurrence_id: '2026-01-03T10:00:00Z', summary: 'uid absent stale', start: { dateTime: '2026-01-10T14:00:00Z' }, end: { dateTime: '2026-01-10T15:00:00Z' } }
+  ], [
+    { entityId: 'calendar.a', uid: 'series', recurrence_id: '2026-01-01T10:00:00Z', summary: 'moved fresh', start: { dateTime: '2026-01-11T10:00:00Z' }, end: { dateTime: '2026-01-11T11:00:00Z' } },
+    { entityId: 'calendar.a', recurrence_id: '2026-01-03T10:00:00Z', summary: 'uid absent fresh', start: { dateTime: '2026-01-11T14:00:00Z' }, end: { dateTime: '2026-01-11T15:00:00Z' } }
+  ], { startDate: new Date('2026-01-10T00:00:00Z'), endDate: new Date('2026-01-11T23:59:59Z') });
+
+  const summaries = reconciled.map(event => event.summary);
+  assert.equal(summaries.includes('stale moved'), false);
+  assert.equal(summaries.includes('moved fresh'), true);
+  assert.equal(summaries.includes('other occurrence'), true);
+  assert.equal(summaries.includes('uid absent stale'), false);
+  assert.equal(summaries.includes('uid absent fresh'), true);
+});
+
 test('range union remains conservative when an extension leaves an unfetched gap', () => {
   const card = makeCard({ entities: ['calendar.a'] });
   const existing = { startDate: new Date('2026-01-10T12:00:00Z'), endDate: new Date('2026-01-20T12:00:00Z') };
@@ -7999,15 +8109,15 @@ test('next agenda navigation invalidates stale visible anchor before successful 
   const card = makeCard({ entities: ['calendar.a'], default_view: 'agenda' });
   card._hass = { user: { id: 'user-1' }, states: {} };
   card._viewMode = 'agenda';
-  card._agendaStartDate = new Date('2026-10-01T00:00:00Z');
-  card._agendaEndDate = new Date('2026-10-14T23:59:59Z');
-  card._agendaVisibleStartDate = new Date('2026-01-01T00:00:00Z');
-  card._agendaVisibleEndDate = new Date('2026-01-14T23:59:59Z');
-  card._currentDate = new Date('2026-01-01T00:00:00Z');
-  card.getAgendaViewportDayCapacity = () => 13;
+  card._agendaStartDate = new Date('2026-01-01T00:00:00Z');
+  card._agendaEndDate = new Date('2028-12-31T23:59:59Z');
+  card._agendaVisibleStartDate = new Date('2028-05-01T00:00:00Z');
+  card._agendaVisibleEndDate = new Date('2028-05-14T23:59:59Z');
+  card._currentDate = new Date('2028-05-01T00:00:00Z');
+  card.getAgendaViewportDayCapacity = () => 14;
   card.getAgendaVisibleDateRangeFromDom = () => null;
   card.fetchEventsByCalendarInRange = async () => ({
-    'calendar.a': { success: true, events: [{ entityId: 'calendar.a', summary: 'next target', start: { date: '2026-10-15' }, end: { date: '2026-10-16' } }] }
+    'calendar.a': { success: true, events: [{ entityId: 'calendar.a', summary: 'next target', start: { date: '2028-05-15' }, end: { date: '2028-05-16' } }] }
   });
   let renderCount = 0;
   let persistedRange = null;
@@ -8023,9 +8133,11 @@ test('next agenda navigation invalidates stale visible anchor before successful 
   await new Promise(resolve => setTimeout(resolve, 0));
 
   assert.ok(persistedRange);
-  assert.equal(persistedRange.startDate <= card._agendaStartDate, true);
-  assert.equal(persistedRange.endDate >= card._agendaEndDate, true);
-  assert.equal(persistedRange.startDate > new Date('2026-06-01T00:00:00Z'), true);
+  const spanDays = (persistedRange.endDate - persistedRange.startDate) / (24 * 60 * 60 * 1000);
+  assert.equal(spanDays <= 210, true);
+  assert.equal(persistedRange.startDate <= card._agendaVisibleStartDate, true);
+  assert.equal(persistedRange.endDate >= card._agendaVisibleEndDate, true);
+  assert.equal(persistedRange.startDate > new Date('2028-01-01T00:00:00Z'), true);
   assert.equal(card._currentDate.toISOString(), card._agendaStartDate.toISOString());
 });
 
@@ -8033,14 +8145,14 @@ test('previous agenda navigation invalidates stale visible anchor before success
   const card = makeCard({ entities: ['calendar.a'], default_view: 'agenda' });
   card._hass = { user: { id: 'user-1' }, states: {} };
   card._viewMode = 'agenda';
-  card._agendaStartDate = new Date('2026-10-01T00:00:00Z');
-  card._agendaEndDate = new Date('2026-10-14T23:59:59Z');
-  card._agendaVisibleStartDate = new Date('2026-01-01T00:00:00Z');
-  card._agendaVisibleEndDate = new Date('2026-01-14T23:59:59Z');
-  card._currentDate = new Date('2026-01-01T00:00:00Z');
+  card._agendaStartDate = new Date('2026-01-01T00:00:00Z');
+  card._agendaEndDate = new Date('2028-12-31T23:59:59Z');
+  card._agendaVisibleStartDate = new Date('2028-05-01T00:00:00Z');
+  card._agendaVisibleEndDate = new Date('2028-05-14T23:59:59Z');
+  card._currentDate = new Date('2028-05-01T00:00:00Z');
   card.getAgendaViewportDayCapacity = () => 14;
   card.fetchEventsByCalendarInRange = async () => ({
-    'calendar.a': { success: true, events: [{ entityId: 'calendar.a', summary: 'previous target', start: { date: '2026-09-17' }, end: { date: '2026-09-18' } }] }
+    'calendar.a': { success: true, events: [{ entityId: 'calendar.a', summary: 'previous target', start: { date: '2025-12-18' }, end: { date: '2025-12-19' } }] }
   });
   let renderCount = 0;
   let persistedRange = null;
@@ -8056,9 +8168,11 @@ test('previous agenda navigation invalidates stale visible anchor before success
   await new Promise(resolve => setTimeout(resolve, 0));
 
   assert.ok(persistedRange);
-  assert.equal(persistedRange.startDate <= card._agendaStartDate, true);
-  assert.equal(persistedRange.endDate >= card._agendaEndDate, true);
-  assert.equal(persistedRange.startDate > new Date('2026-06-01T00:00:00Z'), true);
+  const spanDays = (persistedRange.endDate - persistedRange.startDate) / (24 * 60 * 60 * 1000);
+  assert.equal(spanDays <= 210, true);
+  assert.equal(persistedRange.startDate <= card._agendaVisibleStartDate, true);
+  assert.equal(persistedRange.endDate >= card._agendaVisibleEndDate, true);
+  assert.equal(persistedRange.endDate < new Date('2026-06-01T00:00:00Z'), true);
   assert.equal(card._currentDate.toISOString(), card._agendaStartDate.toISOString());
 });
 

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -6896,10 +6896,10 @@ test('partial calendar refresh preserves failed calendar and successful empty cl
   assert.equal(card._events.length, 1);
   assert.equal(card._lastEventRefreshFailed, true);
   assert.equal(Number.isFinite(card._lastSuccessfulEventRefresh), true);
-  assert.equal(persisted, false);
+  assert.equal(persisted, true);
 });
 
-test('partial refresh keeps prior success timestamp stale and skips mixed cache persistence', async () => {
+test('partial refresh keeps prior success timestamp stale and persists mixed cache state', async () => {
   const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
   card._hass = {};
   card.getEventFetchRange = () => ({ startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') });
@@ -6925,7 +6925,7 @@ test('partial refresh keeps prior success timestamp stale and skips mixed cache 
   assert.equal(card._calendarEventMetadata['calendar.b'].lastSuccessfulRefresh, Date.parse('2026-01-01T12:00:00Z'));
   assert.equal(card._lastEventRefreshFailed, true);
   assert.equal(card.shouldShowEventRefreshWarning(Date.parse('2026-01-01T12:30:01Z')), true);
-  assert.equal(persisted, false);
+  assert.equal(persisted, true);
 });
 
 
@@ -7283,6 +7283,157 @@ test('cache pruning bounds snapshot events while preserving overlapping multi-da
     ]
   }, range);
   assert.deepEqual(pruned['calendar.a'].map(event => event.summary), ['overlaps retained window', 'visible']);
+});
+
+test('mixed partial cache reload keeps successful empty and stale last-known-good calendars', async () => {
+  const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
+  card._hass = { user: { id: 'user-1' } };
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') });
+  card._eventsByCalendar = {
+    'calendar.a': [{ entityId: 'calendar.a', summary: 'old a', start: { date: '2026-01-02' }, end: { date: '2026-01-03' } }],
+    'calendar.b': [{ entityId: 'calendar.b', summary: 'stale b', start: { date: '2026-01-04' }, end: { date: '2026-01-05' } }]
+  };
+  card._calendarEventMetadata = {
+    'calendar.a': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: Date.parse('2026-01-01T12:00:00Z') },
+    'calendar.b': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: Date.parse('2026-01-01T12:00:00Z') }
+  };
+  card.recomputeEventState();
+  card.fetchEventsByCalendarInRange = async () => ({
+    'calendar.a': { success: true, events: [] },
+    'calendar.b': { success: false, events: [] }
+  });
+  card.render = () => {};
+  await card.updateEvents();
+
+  const retainedRange = card.getEventCacheRetainedRange();
+  const { perCalendarMetadata, coveredRange } = card.getPrunedEventMetadataForCache(retainedRange);
+  const reload = makeCard({ entities: ['calendar.a', 'calendar.b'] });
+  reload.applyEventsByCalendar(card.getPrunedEventsByCalendarForCache(card._eventsByCalendar, retainedRange), {
+    startDate: coveredRange.startDate,
+    endDate: coveredRange.endDate,
+    lastSuccessfulRefresh: card._lastSuccessfulEventRefresh,
+    successfulEntityIds: ['calendar.a', 'calendar.b'],
+    source: 'cache',
+    requestId: 0,
+    perCalendarMetadata
+  });
+
+  assert.deepEqual(reload._eventsByCalendar['calendar.a'], []);
+  assert.equal(reload._eventsByCalendar['calendar.b'][0].summary, 'stale b');
+  assert.equal(reload._calendarEventMetadata['calendar.b'].lastSuccessfulRefresh, Date.parse('2026-01-01T12:00:00Z'));
+  assert.equal(reload._calendarEventMetadata['calendar.b'].refreshFailed, false);
+});
+
+test('mixed partial cache reload keeps newer successful calendar data', async () => {
+  const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
+  card._hass = { user: { id: 'user-1' } };
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') });
+  card._eventsByCalendar = {
+    'calendar.a': [{ entityId: 'calendar.a', summary: 'old a', start: { date: '2026-01-02' }, end: { date: '2026-01-03' } }],
+    'calendar.b': [{ entityId: 'calendar.b', summary: 'stale b', start: { date: '2026-01-04' }, end: { date: '2026-01-05' } }]
+  };
+  card._calendarEventMetadata = {
+    'calendar.a': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: Date.parse('2026-01-01T12:00:00Z') },
+    'calendar.b': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: Date.parse('2026-01-01T12:00:00Z') }
+  };
+  card.recomputeEventState();
+  card.fetchEventsByCalendarInRange = async () => ({
+    'calendar.a': { success: true, events: [{ entityId: 'calendar.a', summary: 'new a', start: { date: '2026-01-06' }, end: { date: '2026-01-07' } }] },
+    'calendar.b': { success: false, events: [] }
+  });
+  card.render = () => {};
+  await card.updateEvents();
+
+  const retainedRange = card.getEventCacheRetainedRange();
+  const { perCalendarMetadata, coveredRange } = card.getPrunedEventMetadataForCache(retainedRange);
+  const reload = makeCard({ entities: ['calendar.a', 'calendar.b'] });
+  reload.applyEventsByCalendar(card.getPrunedEventsByCalendarForCache(card._eventsByCalendar, retainedRange), {
+    startDate: coveredRange.startDate,
+    endDate: coveredRange.endDate,
+    lastSuccessfulRefresh: card._lastSuccessfulEventRefresh,
+    successfulEntityIds: ['calendar.a', 'calendar.b'],
+    source: 'cache',
+    requestId: 0,
+    perCalendarMetadata
+  });
+
+  assert.equal(reload._eventsByCalendar['calendar.a'][0].summary, 'new a');
+  assert.equal(reload._eventsByCalendar['calendar.b'][0].summary, 'stale b');
+});
+
+test('mixed per-calendar cache metadata survives snapshot normalization and hydration', async () => {
+  const { createEventCacheSnapshot } = await import('./src/events/event-cache.js');
+  const snapshot = createEventCacheSnapshot({
+    configSignature: 'mixed-metadata',
+    startDate: new Date('2026-01-01T00:00:00Z'),
+    endDate: new Date('2026-04-01T00:00:00Z'),
+    lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z'),
+    eventsByCalendar: { 'calendar.a': [], 'calendar.b': [] },
+    perCalendarMetadata: {
+      'calendar.a': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z'), refreshFailed: true },
+      'calendar.b': { range: { startDate: new Date('2026-03-01T00:00:00Z'), endDate: new Date('2026-04-01T00:00:00Z') }, lastSuccessfulRefresh: Date.parse('2026-01-05T12:00:00Z') }
+    }
+  });
+  const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
+  card.applyEventsByCalendar(snapshot.eventsByCalendar, {
+    startDate: new Date(snapshot.coveredRange.start),
+    endDate: new Date(snapshot.coveredRange.end),
+    lastSuccessfulRefresh: snapshot.lastSuccessfulRefresh,
+    successfulEntityIds: ['calendar.a', 'calendar.b'],
+    source: 'cache',
+    requestId: 0,
+    perCalendarMetadata: snapshot.perCalendarMetadata
+  });
+  assert.equal(card._calendarEventMetadata['calendar.a'].range.endDate.toISOString(), '2026-02-01T00:00:00.000Z');
+  assert.equal(card._calendarEventMetadata['calendar.b'].range.startDate.toISOString(), '2026-03-01T00:00:00.000Z');
+  assert.equal(card._calendarEventMetadata['calendar.a'].lastSuccessfulRefresh, Date.parse('2026-01-10T12:00:00Z'));
+  assert.equal(card._calendarEventMetadata['calendar.b'].lastSuccessfulRefresh, Date.parse('2026-01-05T12:00:00Z'));
+  assert.equal(card._calendarEventMetadata['calendar.a'].refreshFailed, false);
+});
+
+test('persisted snapshot span is bounded despite multi-year in-memory coverage', async () => {
+  const { createEventCacheSnapshot } = await import('./src/events/event-cache.js');
+  const card = makeCard({ entities: ['calendar.a'] });
+  card._hass = { user: { id: 'user-1' } };
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-06-01T00:00:00Z'), endDate: new Date('2026-06-30T00:00:00Z') });
+  card._eventsByCalendar = {
+    'calendar.a': [
+      { entityId: 'calendar.a', summary: 'overlap', start: { date: '2026-02-15' }, end: { date: '2026-06-02' } },
+      { entityId: 'calendar.a', summary: 'outside', start: { date: '2024-01-01' }, end: { date: '2024-01-02' } }
+    ]
+  };
+  card._calendarEventMetadata = {
+    'calendar.a': {
+      range: { startDate: new Date('2024-01-01T00:00:00Z'), endDate: new Date('2028-01-01T00:00:00Z') },
+      lastSuccessfulRefresh: Date.parse('2026-06-01T12:00:00Z')
+    }
+  };
+  card.recomputeEventState();
+  const retainedRange = card.getEventCacheRetainedRange();
+  const { perCalendarMetadata, coveredRange } = card.getPrunedEventMetadataForCache(retainedRange);
+  const snapshot = createEventCacheSnapshot({
+    configSignature: 'bounded',
+    startDate: coveredRange.startDate,
+    endDate: coveredRange.endDate,
+    lastSuccessfulRefresh: card._lastSuccessfulEventRefresh,
+    eventsByCalendar: card.getPrunedEventsByCalendarForCache(card._eventsByCalendar, retainedRange),
+    perCalendarMetadata
+  });
+  const spanDays = (new Date(snapshot.coveredRange.end) - new Date(snapshot.coveredRange.start)) / (24 * 60 * 60 * 1000);
+  assert.equal(spanDays <= 210, true);
+  assert.deepEqual(snapshot.eventsByCalendar['calendar.a'].map(event => event.summary), ['overlap']);
+  assert.equal(snapshot.perCalendarMetadata['calendar.a'].range.startDate.toISOString(), retainedRange.startDate.toISOString());
+  assert.equal(snapshot.perCalendarMetadata['calendar.a'].range.endDate.toISOString(), retainedRange.endDate.toISOString());
+});
+
+test('normal hass update does not queue redundant refresh while forced setConfig fetch is active', async () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  card._hass = { user: { id: 'user-1' }, states: {} };
+  card._fetching = true;
+  card._loadedEventRange = null;
+  card._pendingEventRefreshAfterCurrentFetch = false;
+  await card.ensureEventsForCurrentRange();
+  assert.equal(card._pendingEventRefreshAfterCurrentFetch, false);
 });
 
 test('stale warning is visible at the exact thirty-minute boundary', () => {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -5967,7 +5967,7 @@ test('event normalizer module preserves identity, all-day detection, and start d
 
   assert.equal(
     getEventIdentityKey('calendar.work', rawEvent),
-    'calendar.work|abc||2026-06-23|2026-06-24|Holiday'
+    'calendar.work|abc'
   );
   assert.deepEqual(normalizeCalendarEvent(rawEvent, { entityId: 'calendar.work', color: '#123456' }), {
     ...rawEvent,
@@ -7386,7 +7386,7 @@ test('recurrence identity distinguishes occurrences and replaces moved fetched o
     card.getEventLogicalIdentityKey('calendar.a', { uid: 'series', recurrence_id: '2026-01-01T10:00:00Z' }),
     card.getEventLogicalIdentityKey('calendar.a', { uid: 'series', recurrence_id: '2026-01-02T10:00:00Z' })
   );
-  assert.equal(card.getEventLogicalIdentityKey('calendar.a', { recurrence_id: '2026-01-03T10:00:00Z' }), 'calendar.a|recurrence|2026-01-03T10:00:00Z');
+  assert.equal(card.getEventLogicalIdentityKey('calendar.a', { recurrence_id: '2026-01-03T10:00:00Z', summary: 'No UID', start: { dateTime: '2026-01-03T10:00:00Z' }, end: { dateTime: '2026-01-03T11:00:00Z' } }), 'calendar.a|2026-01-03T10:00:00Z|2026-01-03T10:00:00Z|2026-01-03T11:00:00Z|No UID');
 
   const reconciled = card.reconcileEventsForFetchedRange([
     { entityId: 'calendar.a', uid: 'series', recurrence_id: '2026-01-01T10:00:00Z', summary: 'stale moved', start: { dateTime: '2026-01-10T10:00:00Z' }, end: { dateTime: '2026-01-10T11:00:00Z' } },
@@ -7403,6 +7403,75 @@ test('recurrence identity distinguishes occurrences and replaces moved fetched o
   assert.equal(summaries.includes('other occurrence'), true);
   assert.equal(summaries.includes('uid absent stale'), false);
   assert.equal(summaries.includes('uid absent fresh'), true);
+});
+
+test('stable identity replaces stale event copies even when old dates are outside fetched range', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const reconciled = card.reconcileEventsForFetchedRange([
+    { entityId: 'calendar.a', uid: 'moved-uid', summary: 'old outside uid', start: { dateTime: '2026-01-01T10:00:00Z' }, end: { dateTime: '2026-01-01T11:00:00Z' } },
+    { entityId: 'calendar.a', uid: 'series', recurrence_id: '2026-01-08T10:00:00Z', summary: 'old outside occurrence', start: { dateTime: '2026-01-02T10:00:00Z' }, end: { dateTime: '2026-01-02T11:00:00Z' } },
+    { entityId: 'calendar.a', uid: 'outside-other', summary: 'unrelated outside', start: { dateTime: '2026-01-03T10:00:00Z' }, end: { dateTime: '2026-01-03T11:00:00Z' } },
+    { entityId: 'calendar.a', uid: 'cross-boundary-other', summary: 'legit cross-boundary', start: { dateTime: '2026-01-07T10:00:00Z' }, end: { dateTime: '2026-01-10T11:00:00Z' } }
+  ], [
+    { entityId: 'calendar.a', uid: 'moved-uid', summary: 'fresh renamed uid', start: { dateTime: '2026-01-10T10:00:00Z' }, end: { dateTime: '2026-01-10T12:00:00Z' } },
+    { entityId: 'calendar.a', uid: 'series', recurrence_id: '2026-01-08T10:00:00Z', summary: 'fresh moved occurrence', start: { dateTime: '2026-01-10T13:00:00Z' }, end: { dateTime: '2026-01-10T14:00:00Z' } }
+  ], { startDate: new Date('2026-01-10T00:00:00Z'), endDate: new Date('2026-01-10T23:59:59Z') });
+
+  const summaries = reconciled.map(event => event.summary);
+  assert.equal(summaries.includes('old outside uid'), false);
+  assert.equal(summaries.includes('old outside occurrence'), false);
+  assert.equal(summaries.filter(summary => summary === 'fresh renamed uid').length, 1);
+  assert.equal(summaries.filter(summary => summary === 'fresh moved occurrence').length, 1);
+  assert.equal(summaries.includes('unrelated outside'), true);
+  assert.equal(summaries.includes('legit cross-boundary'), true);
+});
+
+test('event identity is HA recurrence-aware across merge and chunk deduplication paths', async () => {
+  const { fetchEventsForCalendar, mergeEvents } = await import('./src/events/event-fetcher.js');
+  const { getEventIdentityKey, normalizeCalendarEvent } = await import('./src/events/event-normalizer.js');
+  const occurrenceA = { uid: 'series', recurrence_id: '2026-01-01T10:00:00Z', summary: 'first', start: { dateTime: '2026-01-01T10:00:00Z' }, end: { dateTime: '2026-01-01T11:00:00Z' } };
+  const occurrenceB = { uid: 'series', recurrence_id: '2026-01-08T10:00:00Z', summary: 'second', start: { dateTime: '2026-01-08T10:00:00Z' }, end: { dateTime: '2026-01-08T11:00:00Z' } };
+  const uidlessA = { recurrence_id: 'same-rid', summary: 'uidless a', start: { dateTime: '2026-01-02T10:00:00Z' }, end: { dateTime: '2026-01-02T11:00:00Z' } };
+  const uidlessB = { recurrence_id: 'same-rid', summary: 'uidless b', start: { dateTime: '2026-01-03T10:00:00Z' }, end: { dateTime: '2026-01-03T11:00:00Z' } };
+  const legacy = { uid: 'legacy-series', recurring_event_id: 'legacy-rid', summary: 'legacy', start: { dateTime: '2026-01-04T10:00:00Z' }, end: { dateTime: '2026-01-04T11:00:00Z' } };
+
+  assert.notEqual(getEventIdentityKey('calendar.a', occurrenceA), getEventIdentityKey('calendar.a', occurrenceB));
+  assert.notEqual(getEventIdentityKey('calendar.a', uidlessA), getEventIdentityKey('calendar.a', uidlessB));
+  assert.equal(getEventIdentityKey('calendar.a', legacy), 'calendar.a|legacy-series|legacy-rid');
+
+  const merged = mergeEvents([
+    { ...occurrenceA, entityId: 'calendar.a', summary: 'stale first' },
+    { ...uidlessA, entityId: 'calendar.a' }
+  ], [
+    { ...occurrenceA, entityId: 'calendar.a', summary: 'fresh first' },
+    { ...occurrenceB, entityId: 'calendar.a' },
+    { ...uidlessB, entityId: 'calendar.a' }
+  ], {
+    getEventIdentityKey,
+    getEventStartDate: event => new Date(event.start.dateTime)
+  });
+  assert.deepEqual(merged.map(event => event.summary), ['fresh first', 'uidless a', 'uidless b', 'second']);
+
+  const result = await fetchEventsForCalendar({
+    hass: {
+      callWS: async ({ start_date_time }) => start_date_time === '2026-01-01T00:00:00.000Z'
+        ? [occurrenceA, occurrenceB, occurrenceA]
+        : [occurrenceB],
+      callApi: async () => []
+    },
+    entityId: 'calendar.a',
+    chunks: [
+      { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-01-15T23:59:59.999Z') },
+      { startDate: new Date('2026-01-15T00:00:00Z'), endDate: new Date('2026-01-31T23:59:59.999Z') }
+    ],
+    formatLocalDate: date => date.toISOString().slice(0, 10),
+    getCalendarColor: () => '#123456',
+    getEventIdentityKey,
+    normalizeCalendarEvent,
+    fetchedRange: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-01-31T23:59:59.999Z') }
+  });
+  assert.equal(result.success, true);
+  assert.deepEqual(result.events.map(event => event.summary), ['first', 'second']);
 });
 
 test('range union remains conservative when an extension leaves an unfetched gap', () => {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -7408,10 +7408,11 @@ test('recurrence identity distinguishes occurrences and replaces moved fetched o
   assert.equal(summaries.includes('uid absent fresh'), true);
 });
 
-test('stable identity replaces stale event copies even when old dates are outside fetched range', () => {
+test('UID-only reconciliation preserves outside occurrences and only prunes authoritative overlap', () => {
   const card = makeCard({ entities: ['calendar.a'] });
   const reconciled = card.reconcileEventsForFetchedRange([
     { entityId: 'calendar.a', uid: 'moved-uid', summary: 'old outside uid', start: { dateTime: '2026-01-01T10:00:00Z' }, end: { dateTime: '2026-01-01T11:00:00Z' } },
+    { entityId: 'calendar.a', uid: 'moved-uid', summary: 'absent overlapping uid', start: { dateTime: '2026-01-10T09:00:00Z' }, end: { dateTime: '2026-01-10T09:30:00Z' } },
     { entityId: 'calendar.a', uid: 'series', recurrence_id: '2026-01-08T10:00:00Z', summary: 'old outside occurrence', start: { dateTime: '2026-01-02T10:00:00Z' }, end: { dateTime: '2026-01-02T11:00:00Z' } },
     { entityId: 'calendar.a', uid: 'outside-other', summary: 'unrelated outside', start: { dateTime: '2026-01-03T10:00:00Z' }, end: { dateTime: '2026-01-03T11:00:00Z' } },
     { entityId: 'calendar.a', uid: 'exact-boundary-before', summary: 'exact boundary before', start: { dateTime: '2026-01-07T10:00:00Z' }, end: { dateTime: '2026-01-10T00:00:00Z' } }
@@ -7421,7 +7422,8 @@ test('stable identity replaces stale event copies even when old dates are outsid
   ], { startDate: new Date('2026-01-10T00:00:00Z'), endDate: new Date('2026-01-10T23:59:59Z') });
 
   const summaries = reconciled.map(event => event.summary);
-  assert.equal(summaries.includes('old outside uid'), false);
+  assert.equal(summaries.includes('old outside uid'), true);
+  assert.equal(summaries.includes('absent overlapping uid'), false);
   assert.equal(summaries.includes('old outside occurrence'), false);
   assert.equal(summaries.filter(summary => summary === 'fresh renamed uid').length, 1);
   assert.equal(summaries.filter(summary => summary === 'fresh moved occurrence').length, 1);

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -5967,7 +5967,7 @@ test('event normalizer module preserves identity, all-day detection, and start d
 
   assert.equal(
     getEventIdentityKey('calendar.work', rawEvent),
-    'calendar.work|abc'
+    'calendar.work|abc|2026-06-23|2026-06-24'
   );
   assert.deepEqual(normalizeCalendarEvent(rawEvent, { entityId: 'calendar.work', color: '#123456' }), {
     ...rawEvent,
@@ -7186,7 +7186,7 @@ test('leading boundary overlap reconciles deleted moved unchanged and outside ca
       { entityId: 'calendar.a', uid: 'move', summary: 'moved old', start: { dateTime: '2026-01-10T10:00:00Z' }, end: { dateTime: '2026-01-10T11:00:00Z' } },
       { entityId: 'calendar.a', uid: 'same', summary: 'same', start: { dateTime: '2026-01-10T11:00:00Z' }, end: { dateTime: '2026-01-10T11:30:00Z' } },
       { entityId: 'calendar.a', uid: 'outside', summary: 'outside', start: { dateTime: '2026-01-15T10:00:00Z' }, end: { dateTime: '2026-01-15T11:00:00Z' } },
-      { entityId: 'calendar.a', uid: 'cross', summary: 'cross boundary', start: { dateTime: '2026-01-09T00:00:00Z' }, end: { dateTime: '2026-01-11T00:00:00Z' } }
+      { entityId: 'calendar.a', uid: 'cross', summary: 'deleted cross boundary', start: { dateTime: '2026-01-09T00:00:00Z' }, end: { dateTime: '2026-01-11T00:00:00Z' } }
     ]
   };
   card._calendarEventMetadata = {
@@ -7211,7 +7211,7 @@ test('leading boundary overlap reconciles deleted moved unchanged and outside ca
   assert.equal(summaries.includes('moved new'), true);
   assert.equal(summaries.filter(summary => summary === 'same').length, 1);
   assert.equal(summaries.includes('outside'), true);
-  assert.equal(summaries.includes('cross boundary'), true);
+  assert.equal(summaries.includes('deleted cross boundary'), false);
   assert.equal(card._calendarEventMetadata['calendar.a'].range.startDate.toISOString(), '2026-01-01T00:00:00.000Z');
   assert.equal(card._calendarEventMetadata['calendar.a'].range.endDate.toISOString(), cachedEnd.toISOString());
 });
@@ -7411,7 +7411,7 @@ test('stable identity replaces stale event copies even when old dates are outsid
     { entityId: 'calendar.a', uid: 'moved-uid', summary: 'old outside uid', start: { dateTime: '2026-01-01T10:00:00Z' }, end: { dateTime: '2026-01-01T11:00:00Z' } },
     { entityId: 'calendar.a', uid: 'series', recurrence_id: '2026-01-08T10:00:00Z', summary: 'old outside occurrence', start: { dateTime: '2026-01-02T10:00:00Z' }, end: { dateTime: '2026-01-02T11:00:00Z' } },
     { entityId: 'calendar.a', uid: 'outside-other', summary: 'unrelated outside', start: { dateTime: '2026-01-03T10:00:00Z' }, end: { dateTime: '2026-01-03T11:00:00Z' } },
-    { entityId: 'calendar.a', uid: 'cross-boundary-other', summary: 'legit cross-boundary', start: { dateTime: '2026-01-07T10:00:00Z' }, end: { dateTime: '2026-01-10T11:00:00Z' } }
+    { entityId: 'calendar.a', uid: 'exact-boundary-before', summary: 'exact boundary before', start: { dateTime: '2026-01-07T10:00:00Z' }, end: { dateTime: '2026-01-10T00:00:00Z' } }
   ], [
     { entityId: 'calendar.a', uid: 'moved-uid', summary: 'fresh renamed uid', start: { dateTime: '2026-01-10T10:00:00Z' }, end: { dateTime: '2026-01-10T12:00:00Z' } },
     { entityId: 'calendar.a', uid: 'series', recurrence_id: '2026-01-08T10:00:00Z', summary: 'fresh moved occurrence', start: { dateTime: '2026-01-10T13:00:00Z' }, end: { dateTime: '2026-01-10T14:00:00Z' } }
@@ -7423,7 +7423,70 @@ test('stable identity replaces stale event copies even when old dates are outsid
   assert.equal(summaries.filter(summary => summary === 'fresh renamed uid').length, 1);
   assert.equal(summaries.filter(summary => summary === 'fresh moved occurrence').length, 1);
   assert.equal(summaries.includes('unrelated outside'), true);
-  assert.equal(summaries.includes('legit cross-boundary'), true);
+  assert.equal(summaries.includes('exact boundary before'), true);
+});
+
+test('UID-only recurring occurrences keep instance identity and avoid stable cross-range replacement', async () => {
+  const { fetchEventsForCalendar } = await import('./src/events/event-fetcher.js');
+  const { getEventIdentityKey, normalizeCalendarEvent } = await import('./src/events/event-normalizer.js');
+  const occurrenceA = { uid: 'rrule-series', rrule: 'FREQ=WEEKLY', summary: 'week one', start: { dateTime: '2026-01-01T10:00:00Z' }, end: { dateTime: '2026-01-01T11:00:00Z' } };
+  const occurrenceB = { uid: 'rrule-series', rrule: 'FREQ=WEEKLY', summary: 'week two', start: { dateTime: '2026-01-08T10:00:00Z' }, end: { dateTime: '2026-01-08T11:00:00Z' } };
+  assert.notEqual(getEventIdentityKey('calendar.a', occurrenceA), getEventIdentityKey('calendar.a', occurrenceB));
+
+  const result = await fetchEventsForCalendar({
+    hass: {
+      callWS: async ({ start_date_time }) => start_date_time === '2026-01-01T00:00:00.000Z'
+        ? [occurrenceA, occurrenceB]
+        : [occurrenceB],
+      callApi: async () => []
+    },
+    entityId: 'calendar.a',
+    chunks: [
+      { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-01-08T23:59:59.999Z') },
+      { startDate: new Date('2026-01-08T00:00:00Z'), endDate: new Date('2026-01-15T23:59:59.999Z') }
+    ],
+    formatLocalDate: date => date.toISOString().slice(0, 10),
+    getCalendarColor: () => '#123456',
+    getEventIdentityKey,
+    normalizeCalendarEvent,
+    fetchedRange: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-01-15T23:59:59.999Z') }
+  });
+  assert.equal(result.success, true);
+  assert.deepEqual(result.events.map(event => event.summary), ['week one', 'week two']);
+
+  const card = makeCard({ entities: ['calendar.a'] });
+  const reconciled = card.reconcileEventsForFetchedRange([
+    { ...occurrenceA, entityId: 'calendar.a' },
+    { ...occurrenceB, entityId: 'calendar.a' }
+  ], [
+    { ...occurrenceA, entityId: 'calendar.a', summary: 'week one fresh' }
+  ], { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-01-02T00:00:00Z') });
+  const summaries = reconciled.map(event => event.summary);
+  assert.equal(summaries.includes('week one'), false);
+  assert.equal(summaries.includes('week one fresh'), true);
+  assert.equal(summaries.includes('week two'), true);
+});
+
+test('authoritative overlap removes deleted spanning events and preserves returned or boundary events', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const reconciled = card.reconcileEventsForFetchedRange([
+    { entityId: 'calendar.a', uid: 'deleted-span', summary: 'deleted span', start: { dateTime: '2026-01-09T12:00:00Z' }, end: { dateTime: '2026-01-11T12:00:00Z' } },
+    { entityId: 'calendar.a', uid: 'returned-span', summary: 'returned stale', start: { dateTime: '2026-01-09T13:00:00Z' }, end: { dateTime: '2026-01-11T13:00:00Z' } },
+    { entityId: 'calendar.a', uid: 'updated-span', summary: 'updated stale', start: { dateTime: '2026-01-09T14:00:00Z' }, end: { dateTime: '2026-01-11T14:00:00Z' } },
+    { entityId: 'calendar.a', uid: 'outside-before', summary: 'outside before', start: { dateTime: '2026-01-08T10:00:00Z' }, end: { dateTime: '2026-01-10T00:00:00Z' } },
+    { entityId: 'calendar.a', uid: 'outside-after', summary: 'outside after', start: { dateTime: '2026-01-11T00:00:00Z' }, end: { dateTime: '2026-01-12T00:00:00Z' } }
+  ], [
+    { entityId: 'calendar.a', uid: 'returned-span', summary: 'returned stale', start: { dateTime: '2026-01-09T13:00:00Z' }, end: { dateTime: '2026-01-11T13:00:00Z' } },
+    { entityId: 'calendar.a', uid: 'updated-span', summary: 'updated fresh', start: { dateTime: '2026-01-09T15:00:00Z' }, end: { dateTime: '2026-01-11T15:00:00Z' } }
+  ], { startDate: new Date('2026-01-10T00:00:00Z'), endDate: new Date('2026-01-11T00:00:00Z') });
+
+  const summaries = reconciled.map(event => event.summary);
+  assert.equal(summaries.includes('deleted span'), false);
+  assert.equal(summaries.filter(summary => summary === 'returned stale').length, 1);
+  assert.equal(summaries.includes('updated stale'), false);
+  assert.equal(summaries.includes('updated fresh'), true);
+  assert.equal(summaries.includes('outside before'), true);
+  assert.equal(summaries.includes('outside after'), true);
 });
 
 test('event identity is HA recurrence-aware across merge and chunk deduplication paths', async () => {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -7127,6 +7127,87 @@ test('range extensions union trailing and leading successful calendar coverage',
   assert.equal(card._loadedEventRange.endDate.toISOString(), '2026-03-01T00:00:00.000Z');
 });
 
+test('mid-day cached coverage extension fetches leading boundary-day gap', async () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  card._hass = { user: { id: 'user-1' }, states: {} };
+  const cachedStart = new Date('2026-01-10T12:00:00Z');
+  const cachedEnd = new Date('2026-01-20T12:00:00Z');
+  card._eventsByCalendar = { 'calendar.a': [] };
+  card._calendarEventMetadata = {
+    'calendar.a': { range: { startDate: cachedStart, endDate: cachedEnd }, lastSuccessfulRefresh: 1 }
+  };
+  card.recomputeEventState();
+  card._lastFetch = Date.now();
+  card.getVisibleDateRange = () => ({ startDate: new Date('2026-01-09T00:00:00Z'), endDate: new Date('2026-01-10T18:00:00Z') });
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-01-01T00:00:00Z'), endDate: cachedEnd });
+  const fetchedRanges = [];
+  card.fetchEventsByCalendarInRange = async (startDate, endDate) => {
+    fetchedRanges.push({ startDate, endDate });
+    return {
+      'calendar.a': {
+        success: true,
+        events: [{ entityId: 'calendar.a', summary: 'boundary morning', start: { dateTime: '2026-01-10T08:00:00Z' }, end: { dateTime: '2026-01-10T09:00:00Z' } }]
+      }
+    };
+  };
+  card.persistEventCacheSnapshot = () => {};
+  card.render = () => {};
+  card.ensureEventsForCurrentRange = originalEnsureEventsForCurrentRange.bind(card);
+
+  await card.ensureEventsForCurrentRange();
+
+  assert.equal(fetchedRanges.length, 1);
+  assert.equal(fetchedRanges[0].endDate.toISOString(), cachedStart.toISOString());
+  assert.equal(card._eventsByCalendar['calendar.a'].some(event => event.summary === 'boundary morning'), true);
+  assert.equal(card._calendarEventMetadata['calendar.a'].range.startDate.toISOString(), '2026-01-01T00:00:00.000Z');
+  assert.equal(card._calendarEventMetadata['calendar.a'].range.endDate.toISOString(), cachedEnd.toISOString());
+});
+
+test('mid-day cached coverage extension fetches trailing boundary-day gap', async () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  card._hass = { user: { id: 'user-1' }, states: {} };
+  const cachedStart = new Date('2026-01-10T12:00:00Z');
+  const cachedEnd = new Date('2026-01-20T12:00:00Z');
+  card._eventsByCalendar = { 'calendar.a': [] };
+  card._calendarEventMetadata = {
+    'calendar.a': { range: { startDate: cachedStart, endDate: cachedEnd }, lastSuccessfulRefresh: 1 }
+  };
+  card.recomputeEventState();
+  card._lastFetch = Date.now();
+  card.getVisibleDateRange = () => ({ startDate: new Date('2026-01-20T08:00:00Z'), endDate: new Date('2026-01-21T00:00:00Z') });
+  card.getEventFetchRange = () => ({ startDate: cachedStart, endDate: new Date('2026-01-25T00:00:00Z') });
+  const fetchedRanges = [];
+  card.fetchEventsByCalendarInRange = async (startDate, endDate) => {
+    fetchedRanges.push({ startDate, endDate });
+    return {
+      'calendar.a': {
+        success: true,
+        events: [{ entityId: 'calendar.a', summary: 'boundary afternoon', start: { dateTime: '2026-01-20T18:00:00Z' }, end: { dateTime: '2026-01-20T19:00:00Z' } }]
+      }
+    };
+  };
+  card.persistEventCacheSnapshot = () => {};
+  card.render = () => {};
+  card.ensureEventsForCurrentRange = originalEnsureEventsForCurrentRange.bind(card);
+
+  await card.ensureEventsForCurrentRange();
+
+  assert.equal(fetchedRanges.length, 1);
+  assert.equal(fetchedRanges[0].startDate.toISOString(), cachedEnd.toISOString());
+  assert.equal(card._eventsByCalendar['calendar.a'].some(event => event.summary === 'boundary afternoon'), true);
+  assert.equal(card._calendarEventMetadata['calendar.a'].range.startDate.toISOString(), cachedStart.toISOString());
+  assert.equal(card._calendarEventMetadata['calendar.a'].range.endDate.toISOString(), '2026-01-25T00:00:00.000Z');
+});
+
+test('range union remains conservative when an extension leaves an unfetched gap', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const existing = { startDate: new Date('2026-01-10T12:00:00Z'), endDate: new Date('2026-01-20T12:00:00Z') };
+  const incomingWithGap = { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-01-10T00:00:00Z') };
+  const unioned = card.unionEventRanges(existing, incomingWithGap);
+  assert.equal(unioned.startDate.toISOString(), incomingWithGap.startDate.toISOString());
+  assert.equal(unioned.endDate.toISOString(), incomingWithGap.endDate.toISOString());
+});
+
 test('partial range extension renders applied success even when completeness is false', async () => {
   const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
   card._hass = { user: { id: 'user-1' } };
@@ -7146,6 +7227,78 @@ test('partial range extension renders applied success even when completeness is 
   assert.equal(complete, false);
   assert.equal(card._eventsByCalendar['calendar.a'][0].summary, 'extended a');
   assert.equal(renderCount, 1);
+});
+
+test('leading extension success renders once when trailing segment fully fails', async () => {
+  const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
+  card._hass = { user: { id: 'user-1' }, states: {} };
+  card._eventsByCalendar = { 'calendar.a': [], 'calendar.b': [] };
+  card._calendarEventMetadata = {
+    'calendar.a': { range: { startDate: new Date('2026-01-10T00:00:00Z'), endDate: new Date('2026-01-20T00:00:00Z') }, lastSuccessfulRefresh: 1 },
+    'calendar.b': { range: { startDate: new Date('2026-01-10T00:00:00Z'), endDate: new Date('2026-01-20T00:00:00Z') }, lastSuccessfulRefresh: 1 }
+  };
+  card.recomputeEventState();
+  card._lastFetch = Date.now();
+  card.getVisibleDateRange = () => ({ startDate: new Date('2026-01-05T00:00:00Z'), endDate: new Date('2026-01-25T00:00:00Z') });
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') });
+  card.fetchEventsByCalendarInRange = async (startDate) => {
+    if (startDate < new Date('2026-01-10T00:00:00Z')) {
+      return {
+        'calendar.a': { success: true, events: [{ entityId: 'calendar.a', summary: 'leading a', start: { date: '2026-01-05' }, end: { date: '2026-01-06' } }] },
+        'calendar.b': { success: true, events: [] }
+      };
+    }
+    return {
+      'calendar.a': { success: false, events: [] },
+      'calendar.b': { success: false, events: [] }
+    };
+  };
+  card.persistEventCacheSnapshot = () => {};
+  let renderCount = 0;
+  card.render = () => { renderCount += 1; };
+  card.ensureEventsForCurrentRange = originalEnsureEventsForCurrentRange.bind(card);
+
+  await card.ensureEventsForCurrentRange();
+
+  assert.equal(renderCount, 1);
+  assert.equal(card._eventsByCalendar['calendar.a'].some(event => event.summary === 'leading a'), true);
+  assert.equal(card.isDateRangeCoveredByLoadedEvents(new Date('2026-01-01T00:00:00Z'), new Date('2026-02-01T00:00:00Z')), false);
+});
+
+test('trailing extension success renders once when leading segment fully fails', async () => {
+  const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
+  card._hass = { user: { id: 'user-1' }, states: {} };
+  card._eventsByCalendar = { 'calendar.a': [], 'calendar.b': [] };
+  card._calendarEventMetadata = {
+    'calendar.a': { range: { startDate: new Date('2026-01-10T00:00:00Z'), endDate: new Date('2026-01-20T00:00:00Z') }, lastSuccessfulRefresh: 1 },
+    'calendar.b': { range: { startDate: new Date('2026-01-10T00:00:00Z'), endDate: new Date('2026-01-20T00:00:00Z') }, lastSuccessfulRefresh: 1 }
+  };
+  card.recomputeEventState();
+  card._lastFetch = Date.now();
+  card.getVisibleDateRange = () => ({ startDate: new Date('2026-01-05T00:00:00Z'), endDate: new Date('2026-01-25T00:00:00Z') });
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') });
+  card.fetchEventsByCalendarInRange = async (startDate) => {
+    if (startDate < new Date('2026-01-10T00:00:00Z')) {
+      return {
+        'calendar.a': { success: false, events: [] },
+        'calendar.b': { success: false, events: [] }
+      };
+    }
+    return {
+      'calendar.a': { success: true, events: [{ entityId: 'calendar.a', summary: 'trailing a', start: { date: '2026-01-25' }, end: { date: '2026-01-26' } }] },
+      'calendar.b': { success: true, events: [] }
+    };
+  };
+  card.persistEventCacheSnapshot = () => {};
+  let renderCount = 0;
+  card.render = () => { renderCount += 1; };
+  card.ensureEventsForCurrentRange = originalEnsureEventsForCurrentRange.bind(card);
+
+  await card.ensureEventsForCurrentRange();
+
+  assert.equal(renderCount, 1);
+  assert.equal(card._eventsByCalendar['calendar.a'].some(event => event.summary === 'trailing a'), true);
+  assert.equal(card.isDateRangeCoveredByLoadedEvents(new Date('2026-01-01T00:00:00Z'), new Date('2026-02-01T00:00:00Z')), false);
 });
 
 test('visible stale warning clears immediately after unchanged successful refresh', async () => {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -6452,7 +6452,7 @@ test('event fetcher sends WebSocket calendar event payload unchanged', async () 
   assert.deepEqual(result, [{ summary: 'WS event' }]);
 });
 
-test('event fetcher falls back to REST URL and returns empty array after failed fetches', async () => {
+test('event fetcher falls back to REST URL and reports failure after failed fetches', async () => {
   const { fetchEventsForChunk } = await import('./src/events/event-fetcher.js');
   const chunk = {
     startDate: new Date('2026-01-01T12:34:56Z'),
@@ -6476,7 +6476,7 @@ test('event fetcher falls back to REST URL and returns empty array after failed 
       formatLocalDate: date => date.toISOString().slice(0, 10)
     });
 
-    assert.deepEqual(restEvents, [{ summary: 'REST event' }]);
+    assert.deepEqual(restEvents, { success: true, events: [{ summary: 'REST event' }] });
     assert.equal(restUrl, 'calendars/calendar.work?start=2026-01-01T00:00:00Z&end=2026-01-31T23:59:59Z');
 
     const failedEvents = await fetchEventsForChunk({
@@ -6489,7 +6489,8 @@ test('event fetcher falls back to REST URL and returns empty array after failed 
       formatLocalDate: date => date.toISOString().slice(0, 10)
     });
 
-    assert.deepEqual(failedEvents, []);
+    assert.equal(failedEvents.success, false);
+    assert.deepEqual(failedEvents.events, []);
   } finally {
     console.error = originalConsoleError;
   }
@@ -6510,7 +6511,7 @@ test('event fetcher normalizes with calendar colors and de-duplicates chunk over
   };
   const normalizedContexts = [];
 
-  const events = await fetchEventsForCalendar({
+  const result = await fetchEventsForCalendar({
     hass,
     entityId: 'calendar.work',
     colorIndex: 3,
@@ -6524,7 +6525,8 @@ test('event fetcher normalizes with calendar colors and de-duplicates chunk over
     }
   });
 
-  assert.deepEqual(events.map(event => event.summary), ['First', 'Second']);
+  assert.equal(result.success, true);
+  assert.deepEqual(result.events.map(event => event.summary), ['First', 'Second']);
   assert.deepEqual(normalizedContexts, [
     { entityId: 'calendar.work', color: 'calendar.work:3:color' },
     { entityId: 'calendar.work', color: 'calendar.work:3:color' }
@@ -6848,3 +6850,65 @@ test('custom colors persist with hidden calendars and reset on unrelated config 
   assert.deepEqual(Array.from(card._hiddenCalendars), []);
 });
 
+
+
+test('event cache signature ignores visual-only settings and changes for fetch-time inputs', async () => {
+  const { buildEventCacheConfigSignature } = await import('./src/events/event-cache.js');
+  const base = buildEventCacheConfigSignature({ entities: ['calendar.a', 'calendar.b'], timeZone: 'UTC', colors: { 'calendar.a': '#fff' } });
+  const same = buildEventCacheConfigSignature({ entities: ['calendar.a', 'calendar.b'], timeZone: 'UTC', colors: { 'calendar.a': '#fff' }, fonts: 'ignored' });
+  const differentOrder = buildEventCacheConfigSignature({ entities: ['calendar.b', 'calendar.a'], timeZone: 'UTC', colors: { 'calendar.a': '#fff' } });
+  const differentColor = buildEventCacheConfigSignature({ entities: ['calendar.a', 'calendar.b'], timeZone: 'UTC', colors: { 'calendar.a': '#000' } });
+  assert.equal(base, same);
+  assert.notEqual(base, differentOrder);
+  assert.notEqual(base, differentColor);
+});
+
+test('event cache ignores corrupt or incompatible snapshots', async () => {
+  const { normalizeEventCacheSnapshot, EVENT_CACHE_SCHEMA_VERSION } = await import('./src/events/event-cache.js');
+  assert.equal(normalizeEventCacheSnapshot(null, { configSignature: 'a' }), null);
+  assert.equal(normalizeEventCacheSnapshot({ schemaVersion: 999 }, { configSignature: 'a' }), null);
+  assert.equal(normalizeEventCacheSnapshot({ schemaVersion: EVENT_CACHE_SCHEMA_VERSION, configSignature: 'b', coveredRange: { start: 'x', end: 'y' }, lastSuccessfulRefresh: 1, eventsByCalendar: {} }, { configSignature: 'a' }), null);
+  assert.deepEqual(normalizeEventCacheSnapshot({ schemaVersion: EVENT_CACHE_SCHEMA_VERSION, configSignature: 'a', coveredRange: { start: 'x', end: 'y' }, lastSuccessfulRefresh: 1, eventsByCalendar: { 'calendar.a': [{ summary: 'ok' }], bad: 'nope' } }, { configSignature: 'a' }).eventsByCalendar, { 'calendar.a': [{ summary: 'ok' }], bad: [] });
+});
+
+test('partial calendar refresh preserves failed calendar and successful empty clears old events', async () => {
+  const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
+  card._hass = {};
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') });
+  card.fetchEventsByCalendarInRange = async () => ({
+    'calendar.a': { success: true, events: [] },
+    'calendar.b': { success: false, events: [] }
+  });
+  card._eventsByCalendar = {
+    'calendar.a': [{ entityId: 'calendar.a', summary: 'old a', start: { date: '2026-01-02' }, end: { date: '2026-01-03' } }],
+    'calendar.b': [{ entityId: 'calendar.b', summary: 'old b', start: { date: '2026-01-02' }, end: { date: '2026-01-03' } }]
+  };
+  card._events = Object.values(card._eventsByCalendar).flat();
+  card.persistEventCacheSnapshot = () => {};
+  card.render = () => {};
+
+  await card.updateEvents();
+  assert.deepEqual(card._eventsByCalendar['calendar.a'], []);
+  assert.equal(card._eventsByCalendar['calendar.b'][0].summary, 'old b');
+  assert.equal(card._events.length, 1);
+});
+
+test('failed refresh preserves last-known-good events and stale warning timing', async () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  card._hass = {};
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') });
+  card.fetchEventsByCalendarInRange = async () => ({ 'calendar.a': { success: false, events: [] } });
+  card._eventsByCalendar = { 'calendar.a': [{ entityId: 'calendar.a', summary: 'old', start: { date: '2026-01-02' }, end: { date: '2026-01-03' } }] };
+  card._events = card._eventsByCalendar['calendar.a'];
+  card._lastSuccessfulEventRefresh = Date.parse('2026-01-01T12:00:00Z');
+  card.render = () => {};
+
+  await card.updateEvents();
+  assert.equal(card._events[0].summary, 'old');
+  assert.equal(card.shouldShowEventRefreshWarning(Date.parse('2026-01-01T12:29:59Z')), false);
+  assert.equal(card.shouldShowEventRefreshWarning(Date.parse('2026-01-01T12:30:01Z')), true);
+
+  card.applyEventsByCalendar({ 'calendar.a': [] }, { startDate: new Date(), endDate: new Date(), lastSuccessfulRefresh: Date.now() });
+  card._lastEventRefreshFailed = false;
+  assert.equal(card.shouldShowEventRefreshWarning(Date.now() + 31 * 60 * 1000), false);
+});

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -6868,7 +6868,9 @@ test('event cache ignores corrupt or incompatible snapshots', async () => {
   assert.equal(normalizeEventCacheSnapshot(null, { configSignature: 'a' }), null);
   assert.equal(normalizeEventCacheSnapshot({ schemaVersion: 999 }, { configSignature: 'a' }), null);
   assert.equal(normalizeEventCacheSnapshot({ schemaVersion: EVENT_CACHE_SCHEMA_VERSION, configSignature: 'b', coveredRange: { start: 'x', end: 'y' }, lastSuccessfulRefresh: 1, eventsByCalendar: {} }, { configSignature: 'a' }), null);
-  assert.deepEqual(normalizeEventCacheSnapshot({ schemaVersion: EVENT_CACHE_SCHEMA_VERSION, configSignature: 'a', coveredRange: { start: 'x', end: 'y' }, lastSuccessfulRefresh: 1, eventsByCalendar: { 'calendar.a': [{ summary: 'ok' }], bad: 'nope' } }, { configSignature: 'a' }).eventsByCalendar, { 'calendar.a': [{ summary: 'ok' }], bad: [] });
+  assert.equal(normalizeEventCacheSnapshot({ schemaVersion: EVENT_CACHE_SCHEMA_VERSION, configSignature: 'a', coveredRange: { start: 'x', end: 'y' }, lastSuccessfulRefresh: 1, eventsByCalendar: { 'calendar.a': [{ summary: 'ok' }] } }, { configSignature: 'a' }), null);
+  assert.equal(normalizeEventCacheSnapshot({ schemaVersion: EVENT_CACHE_SCHEMA_VERSION, configSignature: 'a', coveredRange: { start: '2026-02-01T00:00:00Z', end: '2026-01-01T00:00:00Z' }, lastSuccessfulRefresh: 1, eventsByCalendar: { 'calendar.a': [{ summary: 'ok' }] } }, { configSignature: 'a' }), null);
+  assert.deepEqual(normalizeEventCacheSnapshot({ schemaVersion: EVENT_CACHE_SCHEMA_VERSION, configSignature: 'a', coveredRange: { start: '2026-01-01T00:00:00Z', end: '2026-02-01T00:00:00Z' }, lastSuccessfulRefresh: 1, eventsByCalendar: { 'calendar.a': [{ summary: 'ok' }], bad: 'nope' } }, { configSignature: 'a' }).eventsByCalendar, { 'calendar.a': [{ summary: 'ok' }], bad: [] });
 });
 
 test('partial calendar refresh preserves failed calendar and successful empty clears old events', async () => {
@@ -6893,7 +6895,7 @@ test('partial calendar refresh preserves failed calendar and successful empty cl
   assert.equal(card._eventsByCalendar['calendar.b'][0].summary, 'old b');
   assert.equal(card._events.length, 1);
   assert.equal(card._lastEventRefreshFailed, true);
-  assert.equal(card._lastSuccessfulEventRefresh, null);
+  assert.equal(Number.isFinite(card._lastSuccessfulEventRefresh), true);
   assert.equal(persisted, false);
 });
 
@@ -6917,10 +6919,145 @@ test('partial refresh keeps prior success timestamp stale and skips mixed cache 
   await card.updateEvents();
   assert.equal(card._eventsByCalendar['calendar.a'][0].summary, 'new a');
   assert.equal(card._eventsByCalendar['calendar.b'][0].summary, 'cached b');
-  assert.equal(card._lastSuccessfulEventRefresh, Date.parse('2026-01-01T12:00:00Z'));
+  assert.equal(card._calendarEventMetadata['calendar.b'].lastSuccessfulRefresh, Date.parse('2026-01-01T12:00:00Z'));
   assert.equal(card._lastEventRefreshFailed, true);
   assert.equal(card.shouldShowEventRefreshWarning(Date.parse('2026-01-01T12:30:01Z')), true);
   assert.equal(persisted, false);
+});
+
+
+test('partial refresh does not expand coverage for failed calendars', async () => {
+  const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
+  card._hass = { user: { id: 'user-1' } };
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-02-01T00:00:00Z'), endDate: new Date('2026-03-01T00:00:00Z') });
+  card.fetchEventsByCalendarInRange = async () => ({
+    'calendar.a': { success: true, events: [{ entityId: 'calendar.a', summary: 'new a', start: { date: '2026-02-02' }, end: { date: '2026-02-03' } }] },
+    'calendar.b': { success: false, events: [] }
+  });
+  card._eventsByCalendar = { 'calendar.a': [], 'calendar.b': [] };
+  card._calendarEventMetadata = {
+    'calendar.a': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: 1 },
+    'calendar.b': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: 1 }
+  };
+  card.recomputeEventState();
+  card.render = () => {};
+  card.persistEventCacheSnapshot = () => {};
+
+  await card.updateEvents();
+  assert.equal(card._eventsByCalendar['calendar.a'][0].summary, 'new a');
+  assert.equal(card._calendarEventMetadata['calendar.b'].range.endDate.toISOString(), '2026-02-01T00:00:00.000Z');
+  assert.equal(card.isDateRangeCoveredByLoadedEvents(new Date('2026-02-02T00:00:00Z'), new Date('2026-02-03T00:00:00Z')), false);
+});
+
+test('cache hydration does not overwrite newer network-success calendars', async () => {
+  const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
+  card._hass = { user: { id: 'user-1' } };
+  card.applyEventsByCalendar({
+    'calendar.a': [{ entityId: 'calendar.a', summary: 'network a', start: { date: '2026-01-02' }, end: { date: '2026-01-03' } }]
+  }, {
+    startDate: new Date('2026-01-01T00:00:00Z'),
+    endDate: new Date('2026-02-01T00:00:00Z'),
+    lastSuccessfulRefresh: 2,
+    successfulEntityIds: ['calendar.a'],
+    failedEntityIds: ['calendar.b'],
+    source: 'network',
+    requestId: 5
+  });
+
+  card.applyEventsByCalendar({
+    'calendar.a': [{ entityId: 'calendar.a', summary: 'cache a', start: { date: '2026-01-02' }, end: { date: '2026-01-03' } }],
+    'calendar.b': [{ entityId: 'calendar.b', summary: 'cache b', start: { date: '2026-01-04' }, end: { date: '2026-01-05' } }]
+  }, {
+    startDate: new Date('2026-01-01T00:00:00Z'),
+    endDate: new Date('2026-02-01T00:00:00Z'),
+    lastSuccessfulRefresh: 1,
+    successfulEntityIds: ['calendar.a', 'calendar.b'],
+    source: 'cache',
+    requestId: 4
+  });
+
+  assert.equal(card._eventsByCalendar['calendar.a'][0].summary, 'network a');
+  assert.equal(card._eventsByCalendar['calendar.b'][0].summary, 'cache b');
+});
+
+test('range extension partial failure keeps successful extension and failed calendar metadata', async () => {
+  const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
+  card._hass = { user: { id: 'user-1' } };
+  card.fetchEventsByCalendarInRange = async () => ({
+    'calendar.a': { success: true, events: [{ entityId: 'calendar.a', summary: 'extended a', start: { date: '2026-02-02' }, end: { date: '2026-02-03' } }] },
+    'calendar.b': { success: false, events: [] }
+  });
+  card._eventsByCalendar = {
+    'calendar.a': [{ entityId: 'calendar.a', summary: 'old a', start: { date: '2026-01-02' }, end: { date: '2026-01-03' } }],
+    'calendar.b': [{ entityId: 'calendar.b', summary: 'old b', start: { date: '2026-01-02' }, end: { date: '2026-01-03' } }]
+  };
+  card._calendarEventMetadata = {
+    'calendar.a': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: 1 },
+    'calendar.b': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: 1 }
+  };
+  card.recomputeEventState();
+
+  const extended = await card.extendEventsForRange(new Date('2026-02-02T00:00:00Z'), new Date('2026-03-01T00:00:00Z'), { render: false });
+  assert.equal(extended, false);
+  assert.equal(card._eventsByCalendar['calendar.a'].some(event => event.summary === 'extended a'), true);
+  assert.equal(card._eventsByCalendar['calendar.b'][0].summary, 'old b');
+  assert.equal(card._calendarEventMetadata['calendar.b'].range.endDate.toISOString(), '2026-02-01T00:00:00.000Z');
+});
+
+test('malformed non-array calendar payloads are fetch failures', async () => {
+  const { fetchEventsForChunk } = await import('./src/events/event-fetcher.js');
+  const result = await fetchEventsForChunk({
+    hass: { callWS: async () => ({ bad: true }), callApi: async () => ({ bad: true }) },
+    entityId: 'calendar.a',
+    chunk: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-01-02T00:00:00Z') },
+    formatLocalDate: localDateKey
+  });
+  assert.equal(result.success, false);
+});
+
+test('event cache signature isolates Home Assistant users', async () => {
+  const { buildEventCacheConfigSignature } = await import('./src/events/event-cache.js');
+  const userA = buildEventCacheConfigSignature({ entities: ['calendar.a'], timeZone: 'UTC', colors: {}, userScope: 'user-a' });
+  const userB = buildEventCacheConfigSignature({ entities: ['calendar.a'], timeZone: 'UTC', colors: {}, userScope: 'user-b' });
+  assert.notEqual(userA, userB);
+});
+
+test('stale refresh warning schedules the threshold render and clears after success', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const originalNow = Date.now;
+  const originalSetTimeout = global.setTimeout;
+  const originalClearTimeout = global.clearTimeout;
+  let scheduledDelay = null;
+  let callback = null;
+  Date.now = () => Date.parse('2026-01-01T12:29:00Z');
+  global.setTimeout = (fn, delay) => { callback = fn; scheduledDelay = delay; return 123; };
+  global.clearTimeout = () => {};
+  try {
+    card._calendarEventMetadata = {
+      'calendar.a': { lastSuccessfulRefresh: Date.parse('2026-01-01T12:00:00Z'), refreshFailed: true }
+    };
+    let rendered = false;
+    card.render = () => { rendered = true; };
+    card.recomputeEventState();
+    assert.equal(scheduledDelay, 60 * 1000);
+    assert.equal(card.shouldShowEventRefreshWarning(Date.parse('2026-01-01T12:30:01Z')), true);
+    callback();
+    assert.equal(rendered, true);
+    card.applyEventsByCalendar({ 'calendar.a': [] }, {
+      startDate: new Date('2026-01-01T00:00:00Z'),
+      endDate: new Date('2026-02-01T00:00:00Z'),
+      lastSuccessfulRefresh: Date.parse('2026-01-01T12:31:00Z'),
+      successfulEntityIds: ['calendar.a'],
+      source: 'network',
+      requestId: 1
+    });
+    assert.equal(card.shouldShowEventRefreshWarning(Date.parse('2026-01-01T13:02:00Z')), false);
+  } finally {
+    Date.now = originalNow;
+    global.setTimeout = originalSetTimeout;
+    global.clearTimeout = originalClearTimeout;
+    card.clearEventRefreshWarningTimer();
+  }
 });
 
 test('failed refresh preserves last-known-good events and stale warning timing', async () => {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -7163,6 +7163,59 @@ test('mid-day cached coverage extension fetches leading boundary-day gap', async
   assert.equal(card._calendarEventMetadata['calendar.a'].range.endDate.toISOString(), cachedEnd.toISOString());
 });
 
+test('leading boundary overlap reconciles deleted moved unchanged and outside cached events through chunking', async () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const cachedStart = new Date('2026-01-10T12:00:00Z');
+  const cachedEnd = new Date('2026-01-20T12:00:00Z');
+  const apiCalls = [];
+  card._hass = {
+    user: { id: 'user-1' },
+    states: {},
+    callWS: async (message) => {
+      apiCalls.push(message);
+      return [
+        { uid: 'move', summary: 'moved new', start: { dateTime: '2026-01-10T13:00:00Z' }, end: { dateTime: '2026-01-10T14:00:00Z' } },
+        { uid: 'same', summary: 'same', start: { dateTime: '2026-01-10T11:00:00Z' }, end: { dateTime: '2026-01-10T11:30:00Z' } }
+      ];
+    },
+    callApi: async () => []
+  };
+  card._eventsByCalendar = {
+    'calendar.a': [
+      { entityId: 'calendar.a', uid: 'delete', summary: 'deleted stale', start: { dateTime: '2026-01-10T08:00:00Z' }, end: { dateTime: '2026-01-10T09:00:00Z' } },
+      { entityId: 'calendar.a', uid: 'move', summary: 'moved old', start: { dateTime: '2026-01-10T10:00:00Z' }, end: { dateTime: '2026-01-10T11:00:00Z' } },
+      { entityId: 'calendar.a', uid: 'same', summary: 'same', start: { dateTime: '2026-01-10T11:00:00Z' }, end: { dateTime: '2026-01-10T11:30:00Z' } },
+      { entityId: 'calendar.a', uid: 'outside', summary: 'outside', start: { dateTime: '2026-01-15T10:00:00Z' }, end: { dateTime: '2026-01-15T11:00:00Z' } },
+      { entityId: 'calendar.a', uid: 'cross', summary: 'cross boundary', start: { dateTime: '2026-01-09T00:00:00Z' }, end: { dateTime: '2026-01-11T00:00:00Z' } }
+    ]
+  };
+  card._calendarEventMetadata = {
+    'calendar.a': { range: { startDate: cachedStart, endDate: cachedEnd }, lastSuccessfulRefresh: 1 }
+  };
+  card.recomputeEventState();
+  card._lastFetch = Date.now();
+  card.getVisibleDateRange = () => ({ startDate: new Date('2026-01-09T00:00:00Z'), endDate: new Date('2026-01-10T18:00:00Z') });
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-01-01T12:00:00Z'), endDate: cachedEnd });
+  card.persistEventCacheSnapshot = () => {};
+  card.render = () => {};
+  card.ensureEventsForCurrentRange = originalEnsureEventsForCurrentRange.bind(card);
+
+  await card.ensureEventsForCurrentRange();
+
+  assert.equal(apiCalls.length, 1);
+  assert.equal(apiCalls[0].start_date_time, '2026-01-01T00:00:00.000Z');
+  assert.equal(apiCalls[0].end_date_time, '2026-01-10T23:59:59.999Z');
+  const summaries = card._eventsByCalendar['calendar.a'].map(event => event.summary);
+  assert.equal(summaries.includes('deleted stale'), false);
+  assert.equal(summaries.includes('moved old'), false);
+  assert.equal(summaries.includes('moved new'), true);
+  assert.equal(summaries.filter(summary => summary === 'same').length, 1);
+  assert.equal(summaries.includes('outside'), true);
+  assert.equal(summaries.includes('cross boundary'), true);
+  assert.equal(card._calendarEventMetadata['calendar.a'].range.startDate.toISOString(), '2026-01-01T00:00:00.000Z');
+  assert.equal(card._calendarEventMetadata['calendar.a'].range.endDate.toISOString(), cachedEnd.toISOString());
+});
+
 test('mid-day cached coverage extension fetches trailing boundary-day gap', async () => {
   const card = makeCard({ entities: ['calendar.a'] });
   card._hass = { user: { id: 'user-1' }, states: {} };
@@ -7199,13 +7252,59 @@ test('mid-day cached coverage extension fetches trailing boundary-day gap', asyn
   assert.equal(card._calendarEventMetadata['calendar.a'].range.endDate.toISOString(), '2026-01-25T00:00:00.000Z');
 });
 
+test('trailing boundary overlap deletes stale cached events through chunking without gaps', async () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const cachedStart = new Date('2026-01-10T12:00:00Z');
+  const cachedEnd = new Date('2026-01-20T12:00:00Z');
+  const apiCalls = [];
+  card._hass = {
+    user: { id: 'user-1' },
+    states: {},
+    callWS: async (message) => {
+      apiCalls.push(message);
+      return [];
+    },
+    callApi: async () => []
+  };
+  card._eventsByCalendar = {
+    'calendar.a': [
+      { entityId: 'calendar.a', uid: 'delete-trailing', summary: 'deleted trailing', start: { dateTime: '2026-01-20T18:00:00Z' }, end: { dateTime: '2026-01-20T19:00:00Z' } },
+      { entityId: 'calendar.a', uid: 'outside-before', summary: 'outside before', start: { dateTime: '2026-01-19T18:00:00Z' }, end: { dateTime: '2026-01-19T19:00:00Z' } }
+    ]
+  };
+  card._calendarEventMetadata = {
+    'calendar.a': { range: { startDate: cachedStart, endDate: cachedEnd }, lastSuccessfulRefresh: 1 }
+  };
+  card.recomputeEventState();
+  card._lastFetch = Date.now();
+  card.getVisibleDateRange = () => ({ startDate: new Date('2026-01-20T08:00:00Z'), endDate: new Date('2026-01-21T00:00:00Z') });
+  card.getEventFetchRange = () => ({ startDate: cachedStart, endDate: new Date('2026-01-25T12:00:00Z') });
+  card.persistEventCacheSnapshot = () => {};
+  card.render = () => {};
+  card.ensureEventsForCurrentRange = originalEnsureEventsForCurrentRange.bind(card);
+
+  await card.ensureEventsForCurrentRange();
+
+  assert.equal(apiCalls.length, 1);
+  assert.equal(apiCalls[0].start_date_time, '2026-01-20T00:00:00.000Z');
+  assert.equal(apiCalls[0].end_date_time, '2026-01-25T23:59:59.999Z');
+  const summaries = card._eventsByCalendar['calendar.a'].map(event => event.summary);
+  assert.equal(summaries.includes('deleted trailing'), false);
+  assert.equal(summaries.includes('outside before'), true);
+  assert.equal(card._calendarEventMetadata['calendar.a'].range.startDate.toISOString(), cachedStart.toISOString());
+  assert.equal(card._calendarEventMetadata['calendar.a'].range.endDate.toISOString(), '2026-01-25T23:59:59.999Z');
+});
+
 test('range union remains conservative when an extension leaves an unfetched gap', () => {
   const card = makeCard({ entities: ['calendar.a'] });
   const existing = { startDate: new Date('2026-01-10T12:00:00Z'), endDate: new Date('2026-01-20T12:00:00Z') };
   const incomingWithGap = { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-01-10T00:00:00Z') };
   const unioned = card.unionEventRanges(existing, incomingWithGap);
-  assert.equal(unioned.startDate.toISOString(), incomingWithGap.startDate.toISOString());
-  assert.equal(unioned.endDate.toISOString(), incomingWithGap.endDate.toISOString());
+  assert.equal(unioned.startDate.toISOString(), existing.startDate.toISOString());
+  assert.equal(unioned.endDate.toISOString(), existing.endDate.toISOString());
+  assert.equal(unioned.disjointRanges.length, 2);
+  assert.equal(unioned.disjointRanges[1].startDate.toISOString(), incomingWithGap.startDate.toISOString());
+  assert.equal(unioned.disjointRanges[1].endDate.toISOString(), incomingWithGap.endDate.toISOString());
 });
 
 test('partial range extension renders applied success even when completeness is false', async () => {
@@ -7826,6 +7925,8 @@ test('persisted snapshot span stays bounded after multi-year agenda expansion', 
   const card = makeCard({ entities: ['calendar.a'] });
   card._hass = { user: { id: 'user-1' } };
   card._viewMode = 'agenda';
+  card._agendaStartDate = new Date('2028-04-15T00:00:00Z');
+  card._agendaEndDate = new Date('2028-06-15T23:59:59Z');
   card.getVisibleDateRange = () => ({ startDate: new Date('2026-06-01T00:00:00Z'), endDate: new Date('2028-06-01T00:00:00Z') });
   card._agendaVisibleStartDate = new Date('2028-05-01T00:00:00Z');
   card._agendaVisibleEndDate = new Date('2028-05-14T23:59:59Z');
@@ -7892,6 +7993,73 @@ test('agenda cache retention has useful current-view fallback before DOM visible
   const spanDays = (new Date(snapshot.coveredRange.end) - new Date(snapshot.coveredRange.start)) / (24 * 60 * 60 * 1000);
   assert.equal(spanDays <= 210, true);
   assert.deepEqual(snapshot.eventsByCalendar['calendar.a'].map(event => event.summary), ['current fallback']);
+});
+
+test('next agenda navigation invalidates stale visible anchor before successful fetch persists', async () => {
+  const card = makeCard({ entities: ['calendar.a'], default_view: 'agenda' });
+  card._hass = { user: { id: 'user-1' }, states: {} };
+  card._viewMode = 'agenda';
+  card._agendaStartDate = new Date('2026-10-01T00:00:00Z');
+  card._agendaEndDate = new Date('2026-10-14T23:59:59Z');
+  card._agendaVisibleStartDate = new Date('2026-01-01T00:00:00Z');
+  card._agendaVisibleEndDate = new Date('2026-01-14T23:59:59Z');
+  card._currentDate = new Date('2026-01-01T00:00:00Z');
+  card.getAgendaViewportDayCapacity = () => 13;
+  card.getAgendaVisibleDateRangeFromDom = () => null;
+  card.fetchEventsByCalendarInRange = async () => ({
+    'calendar.a': { success: true, events: [{ entityId: 'calendar.a', summary: 'next target', start: { date: '2026-10-15' }, end: { date: '2026-10-16' } }] }
+  });
+  let renderCount = 0;
+  let persistedRange = null;
+  card.render = () => { renderCount += 1; };
+  card.persistEventCacheSnapshot = () => {
+    assert.equal(renderCount, 0);
+    persistedRange = card.getEventCacheRetainedRange();
+    return true;
+  };
+  card.ensureEventsForCurrentRange = originalEnsureEventsForCurrentRange.bind(card);
+
+  card.navigateToNextPeriod();
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  assert.ok(persistedRange);
+  assert.equal(persistedRange.startDate <= card._agendaStartDate, true);
+  assert.equal(persistedRange.endDate >= card._agendaEndDate, true);
+  assert.equal(persistedRange.startDate > new Date('2026-06-01T00:00:00Z'), true);
+  assert.equal(card._currentDate.toISOString(), card._agendaStartDate.toISOString());
+});
+
+test('previous agenda navigation invalidates stale visible anchor before successful fetch persists', async () => {
+  const card = makeCard({ entities: ['calendar.a'], default_view: 'agenda' });
+  card._hass = { user: { id: 'user-1' }, states: {} };
+  card._viewMode = 'agenda';
+  card._agendaStartDate = new Date('2026-10-01T00:00:00Z');
+  card._agendaEndDate = new Date('2026-10-14T23:59:59Z');
+  card._agendaVisibleStartDate = new Date('2026-01-01T00:00:00Z');
+  card._agendaVisibleEndDate = new Date('2026-01-14T23:59:59Z');
+  card._currentDate = new Date('2026-01-01T00:00:00Z');
+  card.getAgendaViewportDayCapacity = () => 14;
+  card.fetchEventsByCalendarInRange = async () => ({
+    'calendar.a': { success: true, events: [{ entityId: 'calendar.a', summary: 'previous target', start: { date: '2026-09-17' }, end: { date: '2026-09-18' } }] }
+  });
+  let renderCount = 0;
+  let persistedRange = null;
+  card.render = () => { renderCount += 1; };
+  card.persistEventCacheSnapshot = () => {
+    assert.equal(renderCount, 0);
+    persistedRange = card.getEventCacheRetainedRange();
+    return true;
+  };
+  card.ensureEventsForCurrentRange = originalEnsureEventsForCurrentRange.bind(card);
+
+  card.navigateToPreviousPeriod();
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  assert.ok(persistedRange);
+  assert.equal(persistedRange.startDate <= card._agendaStartDate, true);
+  assert.equal(persistedRange.endDate >= card._agendaEndDate, true);
+  assert.equal(persistedRange.startDate > new Date('2026-06-01T00:00:00Z'), true);
+  assert.equal(card._currentDate.toISOString(), card._agendaStartDate.toISOString());
 });
 
 test('normal hass update does not queue redundant refresh while forced setConfig fetch is active', async () => {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -7060,6 +7060,160 @@ test('stale refresh warning schedules the threshold render and clears after succ
   }
 });
 
+
+test('late cache hydration preserves newer network failure state while filling failed calendar events', () => {
+  const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
+  card._hass = { user: { id: 'user-1' } };
+  card.applyEventsByCalendar({
+    'calendar.a': [{ entityId: 'calendar.a', summary: 'network a', start: { date: '2026-01-02' }, end: { date: '2026-01-03' } }]
+  }, {
+    startDate: new Date('2026-01-01T00:00:00Z'),
+    endDate: new Date('2026-02-01T00:00:00Z'),
+    lastSuccessfulRefresh: Date.parse('2026-01-01T12:05:00Z'),
+    successfulEntityIds: ['calendar.a'],
+    failedEntityIds: ['calendar.b'],
+    source: 'network',
+    requestId: 5
+  });
+
+  card.applyEventsByCalendar({
+    'calendar.a': [{ entityId: 'calendar.a', summary: 'cache a', start: { date: '2026-01-02' }, end: { date: '2026-01-03' } }],
+    'calendar.b': [{ entityId: 'calendar.b', summary: 'cache b', start: { date: '2026-01-04' }, end: { date: '2026-01-05' } }]
+  }, {
+    startDate: new Date('2026-01-01T00:00:00Z'),
+    endDate: new Date('2026-02-01T00:00:00Z'),
+    lastSuccessfulRefresh: Date.parse('2026-01-01T12:00:00Z'),
+    successfulEntityIds: ['calendar.a', 'calendar.b'],
+    source: 'cache',
+    requestId: 4
+  });
+
+  assert.equal(card._eventsByCalendar['calendar.a'][0].summary, 'network a');
+  assert.equal(card._eventsByCalendar['calendar.b'][0].summary, 'cache b');
+  assert.equal(card._calendarEventMetadata['calendar.b'].refreshFailed, true);
+  assert.equal(card._calendarEventMetadata['calendar.b'].lastNetworkFailureRequest, 5);
+});
+
+test('range extensions union trailing and leading successful calendar coverage', async () => {
+  const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
+  card._hass = { user: { id: 'user-1' } };
+  card._eventsByCalendar = { 'calendar.a': [], 'calendar.b': [] };
+  card._calendarEventMetadata = {
+    'calendar.a': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: 1 },
+    'calendar.b': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: 1 }
+  };
+  card.recomputeEventState();
+  card.fetchEventsByCalendarInRange = async (startDate) => ({
+    'calendar.a': { success: true, events: [{ entityId: 'calendar.a', summary: `a ${startDate.toISOString()}`, start: { date: '2026-01-01' }, end: { date: '2026-01-02' } }] },
+    'calendar.b': { success: true, events: [] }
+  });
+  card.render = () => {};
+  card.persistEventCacheSnapshot = () => {};
+
+  await card.extendEventsForRange(new Date('2026-02-01T00:00:00Z'), new Date('2026-03-01T00:00:00Z'), { render: false });
+  assert.equal(card._calendarEventMetadata['calendar.a'].range.startDate.toISOString(), '2026-01-01T00:00:00.000Z');
+  assert.equal(card._calendarEventMetadata['calendar.a'].range.endDate.toISOString(), '2026-03-01T00:00:00.000Z');
+  assert.equal(card._loadedEventRange.startDate.toISOString(), '2026-01-01T00:00:00.000Z');
+  assert.equal(card._loadedEventRange.endDate.toISOString(), '2026-03-01T00:00:00.000Z');
+
+  await card.extendEventsForRange(new Date('2025-12-01T00:00:00Z'), new Date('2026-01-01T00:00:00Z'), { render: false });
+  assert.equal(card._calendarEventMetadata['calendar.a'].range.startDate.toISOString(), '2025-12-01T00:00:00.000Z');
+  assert.equal(card._calendarEventMetadata['calendar.a'].range.endDate.toISOString(), '2026-03-01T00:00:00.000Z');
+  assert.equal(card._loadedEventRange.startDate.toISOString(), '2025-12-01T00:00:00.000Z');
+  assert.equal(card._loadedEventRange.endDate.toISOString(), '2026-03-01T00:00:00.000Z');
+});
+
+test('partial range extension renders applied success even when completeness is false', async () => {
+  const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
+  card._hass = { user: { id: 'user-1' } };
+  card.fetchEventsByCalendarInRange = async () => ({
+    'calendar.a': { success: true, events: [{ entityId: 'calendar.a', summary: 'extended a', start: { date: '2026-02-02' }, end: { date: '2026-02-03' } }] },
+    'calendar.b': { success: false, events: [] }
+  });
+  card._eventsByCalendar = { 'calendar.a': [], 'calendar.b': [] };
+  card._calendarEventMetadata = {
+    'calendar.a': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: 1 },
+    'calendar.b': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: 1 }
+  };
+  let renderCount = 0;
+  card.render = () => { renderCount += 1; };
+
+  const complete = await card.extendEventsForRange(new Date('2026-02-01T00:00:00Z'), new Date('2026-03-01T00:00:00Z'), { render: false });
+  assert.equal(complete, false);
+  assert.equal(card._eventsByCalendar['calendar.a'][0].summary, 'extended a');
+  assert.equal(renderCount, 1);
+});
+
+test('visible stale warning clears immediately after unchanged successful refresh', async () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const event = { entityId: 'calendar.a', summary: 'same', start: { date: '2026-01-02' }, end: { date: '2026-01-03' } };
+  card._hass = { user: { id: 'user-1' } };
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') });
+  card.fetchEventsByCalendarInRange = async () => ({ 'calendar.a': { success: true, events: [event] } });
+  card._eventsByCalendar = { 'calendar.a': [event] };
+  card._calendarDataSignatures['calendar.a'] = card.getCalendarDataSignature([event]);
+  card._calendarEventMetadata = {
+    'calendar.a': {
+      range: card.getEventFetchRange(),
+      lastSuccessfulRefresh: Date.parse('2026-01-01T12:00:00Z'),
+      refreshFailed: true
+    }
+  };
+  card._lastUnchangedDataRender = Date.parse('2026-01-01T12:30:30Z');
+  card.recomputeEventState();
+  assert.equal(card.shouldShowEventRefreshWarning(Date.parse('2026-01-01T12:31:00Z')), true);
+  const originalNow = Date.now;
+  Date.now = () => Date.parse('2026-01-01T12:31:00Z');
+  let renderCount = 0;
+  card.render = () => { renderCount += 1; };
+  card.persistEventCacheSnapshot = () => {};
+  try {
+    await card.updateEvents();
+  } finally {
+    Date.now = originalNow;
+  }
+  assert.equal(card.shouldShowEventRefreshWarning(Date.parse('2026-01-01T13:02:00Z')), false);
+  assert.equal(renderCount, 1);
+});
+
+test('flush barrier rejects queued stale persistent writes before they open storage', async () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  card._hass = { user: { id: 'user-1' } };
+  card.applyEventsByCalendar({ 'calendar.a': [] }, {
+    startDate: new Date('2026-01-01T00:00:00Z'),
+    endDate: new Date('2026-02-01T00:00:00Z'),
+    lastSuccessfulRefresh: Date.parse('2026-01-01T12:00:00Z'),
+    successfulEntityIds: ['calendar.a'],
+    source: 'network',
+    requestId: 1
+  });
+  let releaseQueue;
+  card._eventCacheMutationQueue = new Promise(resolve => { releaseQueue = resolve; });
+  const staleWrite = card.persistEventCacheSnapshot({ generation: card._eventWriteGeneration });
+  const flush = card.flushEventCache({ refresh: false });
+  releaseQueue();
+  assert.equal(await staleWrite, false);
+  assert.equal(await flush, false);
+  assert.deepEqual(card._eventsByCalendar, {});
+});
+
+test('prolonged initial calendar failure without prior success shows stale warning', async () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  card._hass = { user: { id: 'user-1' } };
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') });
+  card.fetchEventsByCalendarInRange = async () => ({ 'calendar.a': { success: false, events: [] } });
+  const originalNow = Date.now;
+  Date.now = () => Date.parse('2026-01-01T12:00:00Z');
+  card.render = () => {};
+  try {
+    await card.updateEvents();
+  } finally {
+    Date.now = originalNow;
+  }
+  assert.equal(card.shouldShowEventRefreshWarning(Date.parse('2026-01-01T12:29:59Z')), false);
+  assert.equal(card.shouldShowEventRefreshWarning(Date.parse('2026-01-01T12:30:01Z')), true);
+});
+
 test('failed refresh preserves last-known-good events and stale warning timing', async () => {
   const card = makeCard({ entities: ['calendar.a'] });
   card._hass = {};

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -65,6 +65,7 @@ require('./skylight-calendar-card.js');
 const Card = customElements.get('skylight-calendar-card');
 const DaylightCard = customElements.get('daylight-calendar-card');
 const originalCardRender = Card.prototype.render;
+const originalEnsureEventsForCurrentRange = Card.prototype.ensureEventsForCurrentRange;
 Card.prototype.render = function() {};
 Card.prototype.renderPreservingAgendaScroll = function() {};
 Card.prototype.ensureEventsForCurrentRange = function() {};
@@ -6868,9 +6869,9 @@ test('event cache ignores corrupt or incompatible snapshots', async () => {
   assert.equal(normalizeEventCacheSnapshot(null, { configSignature: 'a' }), null);
   assert.equal(normalizeEventCacheSnapshot({ schemaVersion: 999 }, { configSignature: 'a' }), null);
   assert.equal(normalizeEventCacheSnapshot({ schemaVersion: EVENT_CACHE_SCHEMA_VERSION, configSignature: 'b', coveredRange: { start: 'x', end: 'y' }, lastSuccessfulRefresh: 1, eventsByCalendar: {} }, { configSignature: 'a' }), null);
-  assert.equal(normalizeEventCacheSnapshot({ schemaVersion: EVENT_CACHE_SCHEMA_VERSION, configSignature: 'a', coveredRange: { start: 'x', end: 'y' }, lastSuccessfulRefresh: 1, eventsByCalendar: { 'calendar.a': [{ summary: 'ok' }] } }, { configSignature: 'a' }), null);
-  assert.equal(normalizeEventCacheSnapshot({ schemaVersion: EVENT_CACHE_SCHEMA_VERSION, configSignature: 'a', coveredRange: { start: '2026-02-01T00:00:00Z', end: '2026-01-01T00:00:00Z' }, lastSuccessfulRefresh: 1, eventsByCalendar: { 'calendar.a': [{ summary: 'ok' }] } }, { configSignature: 'a' }), null);
-  assert.deepEqual(normalizeEventCacheSnapshot({ schemaVersion: EVENT_CACHE_SCHEMA_VERSION, configSignature: 'a', coveredRange: { start: '2026-01-01T00:00:00Z', end: '2026-02-01T00:00:00Z' }, lastSuccessfulRefresh: 1, eventsByCalendar: { 'calendar.a': [{ summary: 'ok' }], bad: 'nope' } }, { configSignature: 'a' }).eventsByCalendar, { 'calendar.a': [{ summary: 'ok' }], bad: [] });
+  assert.equal(normalizeEventCacheSnapshot({ schemaVersion: EVENT_CACHE_SCHEMA_VERSION, configSignature: 'a', coveredRange: { start: 'x', end: 'y' }, lastSuccessfulRefresh: 1, eventsByCalendar: { 'calendar.a': [{ summary: 'ok', start: { date: '2026-01-01' } }] } }, { configSignature: 'a' }), null);
+  assert.equal(normalizeEventCacheSnapshot({ schemaVersion: EVENT_CACHE_SCHEMA_VERSION, configSignature: 'a', coveredRange: { start: '2026-02-01T00:00:00Z', end: '2026-01-01T00:00:00Z' }, lastSuccessfulRefresh: 1, eventsByCalendar: { 'calendar.a': [{ summary: 'ok', start: { date: '2026-01-01' } }] } }, { configSignature: 'a' }), null);
+  assert.deepEqual(normalizeEventCacheSnapshot({ schemaVersion: EVENT_CACHE_SCHEMA_VERSION, configSignature: 'a', coveredRange: { start: '2026-01-01T00:00:00Z', end: '2026-02-01T00:00:00Z' }, lastSuccessfulRefresh: 1, eventsByCalendar: { 'calendar.a': [{ summary: 'ok', start: { date: '2026-01-01' } }], bad: 'nope' } }, { configSignature: 'a' }).eventsByCalendar, { 'calendar.a': [{ summary: 'ok', start: { date: '2026-01-01' } }] });
 });
 
 test('partial calendar refresh preserves failed calendar and successful empty clears old events', async () => {
@@ -7324,6 +7325,123 @@ test('mixed partial cache reload keeps successful empty and stale last-known-goo
   assert.equal(reload._calendarEventMetadata['calendar.b'].refreshFailed, false);
 });
 
+test('mixed cache hydration skips calendars without valid per-calendar metadata', async () => {
+  const { createEventCacheSnapshot } = await import('./src/events/event-cache.js');
+  const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
+  const snapshot = createEventCacheSnapshot({
+    configSignature: 'mixed-authoritative',
+    startDate: new Date('2026-01-01T00:00:00Z'),
+    endDate: new Date('2026-02-01T00:00:00Z'),
+    lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z'),
+    eventsByCalendar: {
+      'calendar.a': [{ entityId: 'calendar.a', summary: 'new a', start: { date: '2026-01-02' }, end: { date: '2026-01-03' } }],
+      'calendar.b': []
+    },
+    perCalendarMetadata: {
+      'calendar.a': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z') }
+    }
+  });
+  const hydratable = card.getHydratableEventCacheSnapshotData(snapshot, 0);
+  assert.deepEqual(hydratable.successfulEntityIds, ['calendar.a']);
+  card.applyEventsByCalendar(hydratable.eventsByCalendar, {
+    startDate: new Date(snapshot.coveredRange.start),
+    endDate: new Date(snapshot.coveredRange.end),
+    lastSuccessfulRefresh: snapshot.lastSuccessfulRefresh,
+    successfulEntityIds: hydratable.successfulEntityIds,
+    source: 'cache',
+    requestId: 0,
+    perCalendarMetadata: hydratable.perCalendarMetadata
+  });
+  assert.equal(card._eventsByCalendar['calendar.a'][0].summary, 'new a');
+  assert.equal(card._eventsByCalendar['calendar.b'], undefined);
+  assert.equal(card._calendarEventMetadata['calendar.b']?.lastSuccessfulRefresh, undefined);
+});
+
+test('mixed cache hydration skips calendars whose LKG metadata was pruned outside retained window', async () => {
+  const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
+  card._hass = { user: { id: 'user-1' } };
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-06-01T00:00:00Z'), endDate: new Date('2026-06-30T00:00:00Z') });
+  card._eventsByCalendar = {
+    'calendar.a': [{ entityId: 'calendar.a', summary: 'new a', start: { date: '2026-06-10' }, end: { date: '2026-06-11' } }],
+    'calendar.b': [{ entityId: 'calendar.b', summary: 'old b', start: { date: '2024-01-01' }, end: { date: '2024-01-02' } }]
+  };
+  card._calendarEventMetadata = {
+    'calendar.a': { range: { startDate: new Date('2026-06-01T00:00:00Z'), endDate: new Date('2026-06-30T00:00:00Z') }, lastSuccessfulRefresh: Date.parse('2026-06-01T12:00:00Z') },
+    'calendar.b': { range: { startDate: new Date('2024-01-01T00:00:00Z'), endDate: new Date('2024-01-31T00:00:00Z') }, lastSuccessfulRefresh: Date.parse('2024-01-01T12:00:00Z') }
+  };
+  card.recomputeEventState();
+  const retainedRange = card.getEventCacheRetainedRange();
+  const { perCalendarMetadata, coveredRange } = card.getPrunedEventMetadataForCache(retainedRange);
+  const reload = makeCard({ entities: ['calendar.a', 'calendar.b'] });
+  const hydratable = reload.getHydratableEventCacheSnapshotData({
+    coveredRange: { start: coveredRange.startDate.toISOString(), end: coveredRange.endDate.toISOString() },
+    lastSuccessfulRefresh: card._lastSuccessfulEventRefresh,
+    eventsByCalendar: card.getPrunedEventsByCalendarForCache(card._eventsByCalendar, retainedRange),
+    perCalendarMetadata
+  }, 0);
+  assert.deepEqual(hydratable.successfulEntityIds, ['calendar.a']);
+  assert.equal(hydratable.perCalendarMetadata['calendar.b'], undefined);
+});
+
+test('genuine persisted empty array with valid metadata hydrates as successful empty', async () => {
+  const { createEventCacheSnapshot } = await import('./src/events/event-cache.js');
+  const card = makeCard({ entities: ['calendar.a'] });
+  const snapshot = createEventCacheSnapshot({
+    configSignature: 'empty-authoritative',
+    startDate: new Date('2026-01-01T00:00:00Z'),
+    endDate: new Date('2026-02-01T00:00:00Z'),
+    lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z'),
+    eventsByCalendar: { 'calendar.a': [] },
+    perCalendarMetadata: {
+      'calendar.a': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z') }
+    }
+  });
+  const hydratable = card.getHydratableEventCacheSnapshotData(snapshot, 0);
+  assert.deepEqual(hydratable.successfulEntityIds, ['calendar.a']);
+  assert.deepEqual(hydratable.eventsByCalendar['calendar.a'], []);
+});
+
+test('corrupt cached calendar payloads are not treated as successful empty', async () => {
+  const { normalizeEventCacheSnapshot, EVENT_CACHE_SCHEMA_VERSION } = await import('./src/events/event-cache.js');
+  const snapshot = normalizeEventCacheSnapshot({
+    schemaVersion: EVENT_CACHE_SCHEMA_VERSION,
+    configSignature: 'corrupt-calendar',
+    coveredRange: { start: '2026-01-01T00:00:00Z', end: '2026-02-01T00:00:00Z' },
+    lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z'),
+    eventsByCalendar: { 'calendar.a': 'not-array' },
+    perCalendarMetadata: {
+      'calendar.a': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z') }
+    }
+  }, { configSignature: 'corrupt-calendar' });
+  const card = makeCard({ entities: ['calendar.a'] });
+  const hydratable = card.getHydratableEventCacheSnapshotData(snapshot, 0);
+  assert.deepEqual(snapshot.eventsByCalendar, {});
+  assert.deepEqual(hydratable.successfulEntityIds, []);
+});
+
+test('malformed cached events without usable dates are ignored while valid empty survives', async () => {
+  const { normalizeEventCacheSnapshot, EVENT_CACHE_SCHEMA_VERSION } = await import('./src/events/event-cache.js');
+  const snapshot = normalizeEventCacheSnapshot({
+    schemaVersion: EVENT_CACHE_SCHEMA_VERSION,
+    configSignature: 'malformed-events',
+    coveredRange: { start: '2026-01-01T00:00:00Z', end: '2026-02-01T00:00:00Z' },
+    lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z'),
+    eventsByCalendar: {
+      'calendar.a': [{ summary: 'missing dates' }],
+      'calendar.b': []
+    },
+    perCalendarMetadata: {
+      'calendar.a': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z') },
+      'calendar.b': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z') }
+    }
+  }, { configSignature: 'malformed-events' });
+  const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
+  const hydratable = card.getHydratableEventCacheSnapshotData(snapshot, 0);
+  assert.deepEqual(snapshot.eventsByCalendar['calendar.a'], []);
+  assert.deepEqual(hydratable.eventsByCalendar['calendar.b'], []);
+  assert.deepEqual(hydratable.successfulEntityIds, ['calendar.a', 'calendar.b']);
+});
+
 test('mixed partial cache reload keeps newer successful calendar data', async () => {
   const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
   card._hass = { user: { id: 'user-1' } };
@@ -7431,8 +7549,52 @@ test('normal hass update does not queue redundant refresh while forced setConfig
   card._hass = { user: { id: 'user-1' }, states: {} };
   card._fetching = true;
   card._loadedEventRange = null;
+  card._activeEventFetchRange = { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') };
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') });
+  card.ensureEventsForCurrentRange = originalEnsureEventsForCurrentRange.bind(card);
   card._pendingEventRefreshAfterCurrentFetch = false;
   await card.ensureEventsForCurrentRange();
+  assert.equal(card._pendingEventRefreshAfterCurrentFetch, false);
+});
+
+test('active fetch queues follow-up when switched view needs uncovered range', async () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  card._hass = { user: { id: 'user-1' }, states: {} };
+  card._fetching = true;
+  card._activeEventFetchRange = { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') };
+  card._loadedEventRange = { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-01-31T00:00:00Z') };
+  card.getVisibleDateRange = () => ({ startDate: new Date('2026-03-10T00:00:00Z'), endDate: new Date('2026-03-17T00:00:00Z') });
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-03-01T00:00:00Z'), endDate: new Date('2026-04-01T00:00:00Z') });
+  card.ensureEventsForCurrentRange = originalEnsureEventsForCurrentRange.bind(card);
+  await card.ensureEventsForCurrentRange({ renderIfCovered: true });
+  assert.equal(card._pendingEventRefreshAfterCurrentFetch, true);
+});
+
+test('active fetch queues Today navigation when new range differs from active fetch', async () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  card._hass = { user: { id: 'user-1' }, states: {} };
+  card._fetching = true;
+  card._activeEventFetchRange = { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') };
+  card.getVisibleDateRange = () => ({ startDate: new Date('2026-07-09T00:00:00Z'), endDate: new Date('2026-07-16T00:00:00Z') });
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-07-01T00:00:00Z'), endDate: new Date('2026-08-15T00:00:00Z') });
+  card.ensureEventsForCurrentRange = originalEnsureEventsForCurrentRange.bind(card);
+  await card.ensureEventsForCurrentRange();
+  assert.equal(card._pendingEventRefreshAfterCurrentFetch, true);
+});
+
+test('active fetch renders already-covered view without queuing duplicate fetch', async () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  card._hass = { user: { id: 'user-1' }, states: {} };
+  card._fetching = true;
+  card._activeEventFetchRange = { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') };
+  card._loadedEventRange = { startDate: new Date('2026-03-01T00:00:00Z'), endDate: new Date('2026-03-31T00:00:00Z') };
+  card.getVisibleDateRange = () => ({ startDate: new Date('2026-03-10T00:00:00Z'), endDate: new Date('2026-03-17T00:00:00Z') });
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-03-01T00:00:00Z'), endDate: new Date('2026-04-01T00:00:00Z') });
+  let rendered = 0;
+  card.render = () => { rendered += 1; };
+  card.ensureEventsForCurrentRange = originalEnsureEventsForCurrentRange.bind(card);
+  await card.ensureEventsForCurrentRange({ renderIfCovered: true });
+  assert.equal(rendered, 1);
   assert.equal(card._pendingEventRefreshAfterCurrentFetch, false);
 });
 

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -6869,9 +6869,9 @@ test('event cache ignores corrupt or incompatible snapshots', async () => {
   assert.equal(normalizeEventCacheSnapshot(null, { configSignature: 'a' }), null);
   assert.equal(normalizeEventCacheSnapshot({ schemaVersion: 999 }, { configSignature: 'a' }), null);
   assert.equal(normalizeEventCacheSnapshot({ schemaVersion: EVENT_CACHE_SCHEMA_VERSION, configSignature: 'b', coveredRange: { start: 'x', end: 'y' }, lastSuccessfulRefresh: 1, eventsByCalendar: {} }, { configSignature: 'a' }), null);
-  assert.equal(normalizeEventCacheSnapshot({ schemaVersion: EVENT_CACHE_SCHEMA_VERSION, configSignature: 'a', coveredRange: { start: 'x', end: 'y' }, lastSuccessfulRefresh: 1, eventsByCalendar: { 'calendar.a': [{ summary: 'ok', start: { date: '2026-01-01' } }] } }, { configSignature: 'a' }), null);
-  assert.equal(normalizeEventCacheSnapshot({ schemaVersion: EVENT_CACHE_SCHEMA_VERSION, configSignature: 'a', coveredRange: { start: '2026-02-01T00:00:00Z', end: '2026-01-01T00:00:00Z' }, lastSuccessfulRefresh: 1, eventsByCalendar: { 'calendar.a': [{ summary: 'ok', start: { date: '2026-01-01' } }] } }, { configSignature: 'a' }), null);
-  assert.deepEqual(normalizeEventCacheSnapshot({ schemaVersion: EVENT_CACHE_SCHEMA_VERSION, configSignature: 'a', coveredRange: { start: '2026-01-01T00:00:00Z', end: '2026-02-01T00:00:00Z' }, lastSuccessfulRefresh: 1, eventsByCalendar: { 'calendar.a': [{ summary: 'ok', start: { date: '2026-01-01' } }], bad: 'nope' } }, { configSignature: 'a' }).eventsByCalendar, { 'calendar.a': [{ summary: 'ok', start: { date: '2026-01-01' } }] });
+  assert.equal(normalizeEventCacheSnapshot({ schemaVersion: EVENT_CACHE_SCHEMA_VERSION, configSignature: 'a', coveredRange: { start: 'x', end: 'y' }, lastSuccessfulRefresh: 1, eventsByCalendar: { 'calendar.a': [{ entityId: 'calendar.a', summary: 'ok', start: { date: '2026-01-01' }, end: { date: '2026-01-02' } }] } }, { configSignature: 'a' }), null);
+  assert.equal(normalizeEventCacheSnapshot({ schemaVersion: EVENT_CACHE_SCHEMA_VERSION, configSignature: 'a', coveredRange: { start: '2026-02-01T00:00:00Z', end: '2026-01-01T00:00:00Z' }, lastSuccessfulRefresh: 1, eventsByCalendar: { 'calendar.a': [{ entityId: 'calendar.a', summary: 'ok', start: { date: '2026-01-01' }, end: { date: '2026-01-02' } }] } }, { configSignature: 'a' }), null);
+  assert.deepEqual(normalizeEventCacheSnapshot({ schemaVersion: EVENT_CACHE_SCHEMA_VERSION, configSignature: 'a', coveredRange: { start: '2026-01-01T00:00:00Z', end: '2026-02-01T00:00:00Z' }, lastSuccessfulRefresh: 1, eventsByCalendar: { 'calendar.a': [{ entityId: 'calendar.a', summary: 'ok', start: { date: '2026-01-01' }, end: { date: '2026-01-02' } }], bad: 'nope' } }, { configSignature: 'a' }).eventsByCalendar, { 'calendar.a': [{ entityId: 'calendar.a', summary: 'ok', start: { date: '2026-01-01' }, end: { date: '2026-01-02' } }] });
 });
 
 test('partial calendar refresh preserves failed calendar and successful empty clears old events', async () => {
@@ -7419,7 +7419,7 @@ test('corrupt cached calendar payloads are not treated as successful empty', asy
   assert.deepEqual(hydratable.successfulEntityIds, []);
 });
 
-test('malformed cached events without usable dates are ignored while valid empty survives', async () => {
+test('malformed cached event arrays are rejected while valid empty survives', async () => {
   const { normalizeEventCacheSnapshot, EVENT_CACHE_SCHEMA_VERSION } = await import('./src/events/event-cache.js');
   const snapshot = normalizeEventCacheSnapshot({
     schemaVersion: EVENT_CACHE_SCHEMA_VERSION,
@@ -7427,7 +7427,7 @@ test('malformed cached events without usable dates are ignored while valid empty
     coveredRange: { start: '2026-01-01T00:00:00Z', end: '2026-02-01T00:00:00Z' },
     lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z'),
     eventsByCalendar: {
-      'calendar.a': [{ summary: 'missing dates' }],
+      'calendar.a': [{ entityId: 'calendar.a', summary: 'missing dates' }],
       'calendar.b': []
     },
     perCalendarMetadata: {
@@ -7437,9 +7437,70 @@ test('malformed cached events without usable dates are ignored while valid empty
   }, { configSignature: 'malformed-events' });
   const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
   const hydratable = card.getHydratableEventCacheSnapshotData(snapshot, 0);
-  assert.deepEqual(snapshot.eventsByCalendar['calendar.a'], []);
+  assert.equal(snapshot.eventsByCalendar['calendar.a'], undefined);
   assert.deepEqual(hydratable.eventsByCalendar['calendar.b'], []);
-  assert.deepEqual(hydratable.successfulEntityIds, ['calendar.a', 'calendar.b']);
+  assert.deepEqual(hydratable.successfulEntityIds, ['calendar.b']);
+});
+
+test('mixed valid and malformed cached event array is omitted instead of partially hydrated', async () => {
+  const { normalizeEventCacheSnapshot, EVENT_CACHE_SCHEMA_VERSION } = await import('./src/events/event-cache.js');
+  const snapshot = normalizeEventCacheSnapshot({
+    schemaVersion: EVENT_CACHE_SCHEMA_VERSION,
+    configSignature: 'mixed-malformed-events',
+    coveredRange: { start: '2026-01-01T00:00:00Z', end: '2026-02-01T00:00:00Z' },
+    lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z'),
+    eventsByCalendar: {
+      'calendar.a': [
+        { entityId: 'calendar.a', summary: 'valid', start: { date: '2026-01-02' }, end: { date: '2026-01-03' } },
+        { entityId: 'calendar.a', summary: 'malformed', start: { date: '2026-01-04' } }
+      ]
+    },
+    perCalendarMetadata: {
+      'calendar.a': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z') }
+    }
+  }, { configSignature: 'mixed-malformed-events' });
+  const card = makeCard({ entities: ['calendar.a'] });
+  const hydratable = card.getHydratableEventCacheSnapshotData(snapshot, 0);
+  assert.equal(snapshot.eventsByCalendar['calendar.a'], undefined);
+  assert.deepEqual(hydratable.successfulEntityIds, []);
+});
+
+test('cached event missing end is rejected safely without render-time replacement', async () => {
+  const { normalizeEventCacheSnapshot, EVENT_CACHE_SCHEMA_VERSION } = await import('./src/events/event-cache.js');
+  const snapshot = normalizeEventCacheSnapshot({
+    schemaVersion: EVENT_CACHE_SCHEMA_VERSION,
+    configSignature: 'missing-end',
+    coveredRange: { start: '2026-01-01T00:00:00Z', end: '2026-02-01T00:00:00Z' },
+    lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z'),
+    eventsByCalendar: {
+      'calendar.a': [{ entityId: 'calendar.a', summary: 'missing end', start: { date: '2026-01-02' } }]
+    },
+    perCalendarMetadata: {
+      'calendar.a': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z') }
+    }
+  }, { configSignature: 'missing-end' });
+  const card = makeCard({ entities: ['calendar.a'] });
+  const hydratable = card.getHydratableEventCacheSnapshotData(snapshot, 0);
+  assert.deepEqual(hydratable.successfulEntityIds, []);
+});
+
+test('cached event with mismatched entity id is rejected for its containing calendar', async () => {
+  const { normalizeEventCacheSnapshot, EVENT_CACHE_SCHEMA_VERSION } = await import('./src/events/event-cache.js');
+  const snapshot = normalizeEventCacheSnapshot({
+    schemaVersion: EVENT_CACHE_SCHEMA_VERSION,
+    configSignature: 'mismatched-entity',
+    coveredRange: { start: '2026-01-01T00:00:00Z', end: '2026-02-01T00:00:00Z' },
+    lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z'),
+    eventsByCalendar: {
+      'calendar.a': [{ entityId: 'calendar.b', summary: 'wrong calendar', start: { date: '2026-01-02' }, end: { date: '2026-01-03' } }]
+    },
+    perCalendarMetadata: {
+      'calendar.a': { range: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-02-01T00:00:00Z') }, lastSuccessfulRefresh: Date.parse('2026-01-10T12:00:00Z') }
+    }
+  }, { configSignature: 'mismatched-entity' });
+  const card = makeCard({ entities: ['calendar.a'] });
+  const hydratable = card.getHydratableEventCacheSnapshotData(snapshot, 0);
+  assert.deepEqual(hydratable.successfulEntityIds, []);
 });
 
 test('mixed partial cache reload keeps newer successful calendar data', async () => {
@@ -7513,6 +7574,7 @@ test('persisted snapshot span is bounded despite multi-year in-memory coverage',
   const { createEventCacheSnapshot } = await import('./src/events/event-cache.js');
   const card = makeCard({ entities: ['calendar.a'] });
   card._hass = { user: { id: 'user-1' } };
+  card.getVisibleDateRange = () => ({ startDate: new Date('2026-06-01T00:00:00Z'), endDate: new Date('2026-06-30T00:00:00Z') });
   card.getEventFetchRange = () => ({ startDate: new Date('2026-06-01T00:00:00Z'), endDate: new Date('2026-06-30T00:00:00Z') });
   card._eventsByCalendar = {
     'calendar.a': [
@@ -7542,6 +7604,40 @@ test('persisted snapshot span is bounded despite multi-year in-memory coverage',
   assert.deepEqual(snapshot.eventsByCalendar['calendar.a'].map(event => event.summary), ['overlap']);
   assert.equal(snapshot.perCalendarMetadata['calendar.a'].range.startDate.toISOString(), retainedRange.startDate.toISOString());
   assert.equal(snapshot.perCalendarMetadata['calendar.a'].range.endDate.toISOString(), retainedRange.endDate.toISOString());
+});
+
+test('persisted snapshot span stays bounded after multi-year agenda expansion', async () => {
+  const { createEventCacheSnapshot } = await import('./src/events/event-cache.js');
+  const card = makeCard({ entities: ['calendar.a'] });
+  card._hass = { user: { id: 'user-1' } };
+  card._viewMode = 'agenda';
+  card.getVisibleDateRange = () => ({ startDate: new Date('2026-06-01T00:00:00Z'), endDate: new Date('2028-06-01T00:00:00Z') });
+  card._eventsByCalendar = {
+    'calendar.a': [
+      { entityId: 'calendar.a', summary: 'overlap retained', start: { date: '2027-01-01' }, end: { date: '2027-07-01' } },
+      { entityId: 'calendar.a', summary: 'far future', start: { date: '2028-05-01' }, end: { date: '2028-05-02' } }
+    ]
+  };
+  card._calendarEventMetadata = {
+    'calendar.a': {
+      range: { startDate: new Date('2024-01-01T00:00:00Z'), endDate: new Date('2029-01-01T00:00:00Z') },
+      lastSuccessfulRefresh: Date.parse('2026-06-01T12:00:00Z')
+    }
+  };
+  card.recomputeEventState();
+  const retainedRange = card.getEventCacheRetainedRange();
+  const { perCalendarMetadata, coveredRange } = card.getPrunedEventMetadataForCache(retainedRange);
+  const snapshot = createEventCacheSnapshot({
+    configSignature: 'bounded-agenda',
+    startDate: coveredRange.startDate,
+    endDate: coveredRange.endDate,
+    lastSuccessfulRefresh: card._lastSuccessfulEventRefresh,
+    eventsByCalendar: card.getPrunedEventsByCalendarForCache(card._eventsByCalendar, retainedRange),
+    perCalendarMetadata
+  });
+  const spanDays = (new Date(snapshot.coveredRange.end) - new Date(snapshot.coveredRange.start)) / (24 * 60 * 60 * 1000);
+  assert.equal(spanDays <= 210, true);
+  assert.deepEqual(snapshot.eventsByCalendar['calendar.a'].map(event => event.summary), ['overlap retained']);
 });
 
 test('normal hass update does not queue redundant refresh while forced setConfig fetch is active', async () => {
@@ -7596,6 +7692,64 @@ test('active fetch renders already-covered view without queuing duplicate fetch'
   await card.ensureEventsForCurrentRange({ renderIfCovered: true });
   assert.equal(rendered, 1);
   assert.equal(card._pendingEventRefreshAfterCurrentFetch, false);
+});
+
+test('view change requiring refresh renders even when fetched events are identical', async () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  card._hass = { user: { id: 'user-1' }, states: {} };
+  const events = [{ entityId: 'calendar.a', summary: 'same', start: { date: '2026-03-10' }, end: { date: '2026-03-11' } }];
+  card._eventsByCalendar = { 'calendar.a': events };
+  card._calendarDataSignatures = { 'calendar.a': card.getCalendarDataSignature(events) };
+  card._loadedEventRange = null;
+  card.getVisibleDateRange = () => ({ startDate: new Date('2026-03-10T00:00:00Z'), endDate: new Date('2026-03-17T00:00:00Z') });
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-03-01T00:00:00Z'), endDate: new Date('2026-04-01T00:00:00Z') });
+  card.fetchEventsByCalendarInRange = async () => ({ 'calendar.a': { success: true, events } });
+  card.persistEventCacheSnapshot = () => {};
+  let rendered = 0;
+  card.render = () => { rendered += 1; };
+  card.ensureEventsForCurrentRange = originalEnsureEventsForCurrentRange.bind(card);
+  await card.ensureEventsForCurrentRange({ renderIfCovered: true });
+  assert.equal(rendered, 1);
+});
+
+test('today navigation requiring refresh renders even when fetched events are identical', async () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  card._hass = { user: { id: 'user-1' }, states: {} };
+  const events = [{ entityId: 'calendar.a', summary: 'same', start: { date: '2026-07-09' }, end: { date: '2026-07-10' } }];
+  card._eventsByCalendar = { 'calendar.a': events };
+  card._calendarDataSignatures = { 'calendar.a': card.getCalendarDataSignature(events) };
+  card._loadedEventRange = null;
+  card.getVisibleDateRange = () => ({ startDate: new Date('2026-07-09T00:00:00Z'), endDate: new Date('2026-07-16T00:00:00Z') });
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-07-01T00:00:00Z'), endDate: new Date('2026-08-15T00:00:00Z') });
+  card.fetchEventsByCalendarInRange = async () => ({ 'calendar.a': { success: true, events } });
+  card.persistEventCacheSnapshot = () => {};
+  let rendered = 0;
+  card.render = () => { rendered += 1; };
+  card.ensureEventsForCurrentRange = originalEnsureEventsForCurrentRange.bind(card);
+  await card.ensureEventsForCurrentRange({ renderIfCovered: true });
+  assert.equal(rendered, 1);
+});
+
+test('active fetch covering requested range preserves pending render intent without duplicate fetch', async () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  card._hass = { user: { id: 'user-1' }, states: {} };
+  card._fetching = true;
+  card._activeEventFetchRange = { startDate: new Date('2026-03-01T00:00:00Z'), endDate: new Date('2026-04-01T00:00:00Z') };
+  card._loadedEventRange = { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-01-31T00:00:00Z') };
+  card.getVisibleDateRange = () => ({ startDate: new Date('2026-03-10T00:00:00Z'), endDate: new Date('2026-03-17T00:00:00Z') });
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-03-01T00:00:00Z'), endDate: new Date('2026-04-01T00:00:00Z') });
+  card.ensureEventsForCurrentRange = originalEnsureEventsForCurrentRange.bind(card);
+  await card.ensureEventsForCurrentRange({ renderIfCovered: true });
+  assert.equal(card._pendingEventRefreshAfterCurrentFetch, false);
+  assert.equal(card._pendingEventRenderAfterCurrentFetch, true);
+  let rendered = 0;
+  card.render = () => { rendered += 1; };
+  card._fetching = false;
+  if (card._pendingEventRenderAfterCurrentFetch) {
+    card._pendingEventRenderAfterCurrentFetch = false;
+    card.render();
+  }
+  assert.equal(rendered, 1);
 });
 
 test('stale warning is visible at the exact thirty-minute boundary', () => {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -5967,7 +5967,7 @@ test('event normalizer module preserves identity, all-day detection, and start d
 
   assert.equal(
     getEventIdentityKey('calendar.work', rawEvent),
-    'calendar.work|abc|2026-06-23|2026-06-24'
+    'calendar.work|abc'
   );
   assert.deepEqual(normalizeCalendarEvent(rawEvent, { entityId: 'calendar.work', color: '#123456' }), {
     ...rawEvent,
@@ -6527,7 +6527,7 @@ test('event fetcher normalizes with calendar colors and de-duplicates chunk over
   });
 
   assert.equal(result.success, true);
-  assert.deepEqual(result.events.map(event => event.summary), ['First', 'Second']);
+  assert.deepEqual(result.events.map(event => event.summary), ['First duplicate', 'Second']);
   assert.deepEqual(normalizedContexts, [
     { entityId: 'calendar.work', color: 'calendar.work:3:color' },
     { entityId: 'calendar.work', color: 'calendar.work:3:color' }
@@ -7535,6 +7535,52 @@ test('event identity is HA recurrence-aware across merge and chunk deduplication
   });
   assert.equal(result.success, true);
   assert.deepEqual(result.events.map(event => event.summary), ['first', 'second']);
+});
+
+test('non-recurring UID identity collapses moved conflicts consistently across fetch and merge', async () => {
+  const { fetchEventsForCalendar, mergeEvents } = await import('./src/events/event-fetcher.js');
+  const { getEventIdentityKey, normalizeCalendarEvent } = await import('./src/events/event-normalizer.js');
+  const oldCopy = { uid: 'single-event', summary: 'old copy', start: { dateTime: '2026-01-01T10:00:00Z' }, end: { dateTime: '2026-01-01T11:00:00Z' } };
+  const movedCopy = { uid: 'single-event', summary: 'moved copy', start: { dateTime: '2026-01-02T10:00:00Z' }, end: { dateTime: '2026-01-02T11:00:00Z' } };
+
+  const result = await fetchEventsForCalendar({
+    hass: {
+      callWS: async ({ start_date_time }) => start_date_time === '2026-01-01T00:00:00.000Z'
+        ? [oldCopy]
+        : [movedCopy],
+      callApi: async () => []
+    },
+    entityId: 'calendar.a',
+    chunks: [
+      { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-01-01T23:59:59.999Z') },
+      { startDate: new Date('2026-01-02T00:00:00Z'), endDate: new Date('2026-01-02T23:59:59.999Z') }
+    ],
+    formatLocalDate: date => date.toISOString().slice(0, 10),
+    getCalendarColor: () => '#123456',
+    getEventIdentityKey,
+    normalizeCalendarEvent,
+    fetchedRange: { startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-01-02T23:59:59.999Z') }
+  });
+  assert.equal(result.success, true);
+  assert.deepEqual(result.events.map(event => event.summary), ['moved copy']);
+
+  const merged = mergeEvents([
+    { ...oldCopy, entityId: 'calendar.a' }
+  ], [
+    { ...movedCopy, entityId: 'calendar.a' }
+  ], {
+    getEventIdentityKey,
+    getEventStartDate: event => new Date(event.start.dateTime)
+  });
+  assert.deepEqual(merged.map(event => event.summary), ['moved copy']);
+
+  const card = makeCard({ entities: ['calendar.a'] });
+  const reconciled = card.reconcileEventsForFetchedRange([
+    { ...oldCopy, entityId: 'calendar.a' }
+  ], [
+    { ...movedCopy, entityId: 'calendar.a' }
+  ], { startDate: new Date('2026-01-02T00:00:00Z'), endDate: new Date('2026-01-02T23:59:59.999Z') });
+  assert.deepEqual(reconciled.map(event => event.summary), ['moved copy']);
 });
 
 test('range union remains conservative when an extension leaves an unfetched gap', () => {

--- a/src/editor/daylight-calendar-card-editor.js
+++ b/src/editor/daylight-calendar-card-editor.js
@@ -38,6 +38,7 @@ import {
 } from '../renderers/editor-renderer.js';
 import { getEntityFriendlyName as getEntityFriendlyNameHelper } from '../ha/ha-state-helpers.js';
 import { getDaylightCalendarCardVersion } from '../version.js';
+import { clearAllEventCacheSnapshots } from '../events/event-cache.js';
 import { normalizeDashboardPath, normalizeEnumValue } from '../utils/normalization-utils.js';
 import { detectStaleSkylightResource, STALE_RESOURCE_TROUBLESHOOTING_URL } from '../utils/stale-resource-utils.js';
 import '../components/daylight-color-picker.js';
@@ -82,6 +83,7 @@ export class SkylightCalendarCardEditor extends HTMLElement {
     this._config = createDefaultStubConfig();
     this._hass = null;
     this._rendered = false;
+    this._eventCacheFlushStatus = '';
     this._lastCalendarEntitiesKey = '';
     this._colorPickerState = { field: null, mapKey: null, color: '#3f51b5' };
     this._combineBackgroundMode = DEFAULT_COMBINE_BACKGROUND;
@@ -1116,6 +1118,11 @@ export class SkylightCalendarCardEditor extends HTMLElement {
       <p class="helper">Loaded version: ${this.escapeHtml(getDaylightCalendarCardVersion())}</p>
       <p class="helper">Resource file: skylight-calendar-card.js</p>
       <p class="helper">If this version does not match the version shown in HACS, Home Assistant may be loading a cached or stale resource.</p>
+      <div class="diagnostic-action">
+        <button type="button" data-event-cache-action="flush">Flush event cache</button>
+        <p class="helper">Clears persistent Daylight calendar event snapshots only. Hidden calendars and custom event colors are not changed.</p>
+        ${this._eventCacheFlushStatus ? `<p class="helper">${this.escapeHtml(this._eventCacheFlushStatus)}</p>` : ''}
+      </div>
       ${staleResourceDiagnostics}
     `);
 
@@ -1513,6 +1520,10 @@ export class SkylightCalendarCardEditor extends HTMLElement {
       button.addEventListener('click', (event) => this.handleVirtualCalendarAction(event));
     });
 
+    this.querySelectorAll('[data-event-cache-action="flush"]').forEach((button) => {
+      button.addEventListener('click', () => this.handleFlushEventCache());
+    });
+
     this.querySelectorAll('[data-virtual-calendar-field]').forEach((input) => {
       input.addEventListener('change', (event) => this.handleVirtualCalendarInput(event));
     });
@@ -1539,6 +1550,15 @@ export class SkylightCalendarCardEditor extends HTMLElement {
     });
 
     this._rendered = true;
+  }
+
+  async handleFlushEventCache() {
+    const cleared = await clearAllEventCacheSnapshots();
+    this._eventCacheFlushStatus = cleared
+      ? 'Event cache cleared. The card will load fresh calendar data.'
+      : 'Event cache is unavailable or could not be cleared; normal loading is unaffected.';
+    window.dispatchEvent(new CustomEvent('daylight-calendar-card-flush-event-cache'));
+    this.render();
   }
 
   refreshCalendarEntities() {

--- a/src/events/event-cache.js
+++ b/src/events/event-cache.js
@@ -1,6 +1,6 @@
 import { toStableString } from './event-fetcher.js';
 
-export const EVENT_CACHE_SCHEMA_VERSION = 1;
+export const EVENT_CACHE_SCHEMA_VERSION = 2;
 const DB_NAME = 'daylight-calendar-card-events';
 const DB_VERSION = 1;
 const STORE_NAME = 'eventSnapshots';
@@ -79,9 +79,18 @@ export function normalizeEventCacheSnapshot(snapshot, { configSignature } = {}) 
   if (!Number.isFinite(snapshot.lastSuccessfulRefresh)) return null;
   if (!snapshot.eventsByCalendar || typeof snapshot.eventsByCalendar !== 'object') return null;
 
+  const isValidCachedEvent = (event) => {
+    if (!event || typeof event !== 'object') return false;
+    const rawStart = event?.start?.dateTime || event?.start?.date || event?.start;
+    const rawEnd = event?.end?.dateTime || event?.end?.date || event?.end;
+    const start = rawStart ? new Date(rawStart) : null;
+    const end = rawEnd ? new Date(rawEnd) : start;
+    return !!start && Number.isFinite(start.getTime()) && (!rawEnd || Number.isFinite(end.getTime()));
+  };
   const eventsByCalendar = {};
   Object.entries(snapshot.eventsByCalendar).forEach(([entityId, events]) => {
-    eventsByCalendar[entityId] = Array.isArray(events) ? events.filter((event) => event && typeof event === 'object') : [];
+    if (!Array.isArray(events)) return;
+    eventsByCalendar[entityId] = events.filter(isValidCachedEvent);
   });
 
   return {

--- a/src/events/event-cache.js
+++ b/src/events/event-cache.js
@@ -79,14 +79,22 @@ export function normalizeEventCacheSnapshot(snapshot, { configSignature } = {}) 
   if (!Number.isFinite(snapshot.lastSuccessfulRefresh)) return null;
   if (!snapshot.eventsByCalendar || typeof snapshot.eventsByCalendar !== 'object') return null;
 
+  const getSupportedEventDateValue = (value) => {
+    if (typeof value === 'string') return { kind: 'string', value };
+    if (!value || typeof value !== 'object' || value instanceof Date) return null;
+    if (typeof value.dateTime === 'string' && value.date === undefined) return { kind: 'dateTime', value: value.dateTime };
+    if (typeof value.date === 'string' && value.dateTime === undefined) return { kind: 'date', value: value.date };
+    return null;
+  };
   const isValidCachedEvent = (event, entityId) => {
     if (!event || typeof event !== 'object') return false;
     if (event.entityId !== entityId) return false;
-    const rawStart = event?.start?.dateTime || event?.start?.date || event?.start;
-    const rawEnd = event?.end?.dateTime || event?.end?.date || event?.end;
-    const start = rawStart ? new Date(rawStart) : null;
-    const end = rawEnd ? new Date(rawEnd) : null;
-    return !!start && !!end && Number.isFinite(start.getTime()) && Number.isFinite(end.getTime());
+    const startValue = getSupportedEventDateValue(event.start);
+    const endValue = getSupportedEventDateValue(event.end);
+    if (!startValue || !endValue || startValue.kind !== endValue.kind) return false;
+    const start = new Date(startValue.value);
+    const end = new Date(endValue.value);
+    return Number.isFinite(start.getTime()) && Number.isFinite(end.getTime()) && end >= start;
   };
   const eventsByCalendar = {};
   Object.entries(snapshot.eventsByCalendar).forEach(([entityId, events]) => {

--- a/src/events/event-cache.js
+++ b/src/events/event-cache.js
@@ -25,14 +25,14 @@ const openEventCacheDb = () => new Promise((resolve, reject) => {
 
 const transact = async (mode, callback) => {
   const db = await openEventCacheDb();
-  if (!db) return null;
+  if (!db) return { available: false, value: null };
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE_NAME, mode);
     const store = tx.objectStore(STORE_NAME);
     let callbackResult;
     tx.oncomplete = () => {
       db.close?.();
-      resolve(callbackResult);
+      resolve({ available: true, value: callbackResult });
     };
     tx.onerror = () => {
       db.close?.();
@@ -43,8 +43,8 @@ const transact = async (mode, callback) => {
   });
 };
 
-export function buildEventCacheConfigSignature({ entities = [], timeZone = null, colors = {} } = {}) {
-  return toStableString({ entities, timeZone: timeZone || null, colors: colors || {} });
+export function buildEventCacheConfigSignature({ entities = [], timeZone = null, colors = {}, userScope = null } = {}) {
+  return toStableString({ entities, timeZone: timeZone || null, colors: colors || {}, userScope: userScope || null });
 }
 
 export function buildEventCacheKey(configSignature) {
@@ -56,6 +56,9 @@ export function normalizeEventCacheSnapshot(snapshot, { configSignature } = {}) 
   if (snapshot.schemaVersion !== EVENT_CACHE_SCHEMA_VERSION) return null;
   if (configSignature && snapshot.configSignature !== configSignature) return null;
   if (!snapshot.coveredRange || !snapshot.coveredRange.start || !snapshot.coveredRange.end) return null;
+  const coveredStart = new Date(snapshot.coveredRange.start);
+  const coveredEnd = new Date(snapshot.coveredRange.end);
+  if (!Number.isFinite(coveredStart.getTime()) || !Number.isFinite(coveredEnd.getTime()) || coveredStart > coveredEnd) return null;
   if (!Number.isFinite(snapshot.lastSuccessfulRefresh)) return null;
   if (!snapshot.eventsByCalendar || typeof snapshot.eventsByCalendar !== 'object') return null;
 
@@ -70,15 +73,16 @@ export function normalizeEventCacheSnapshot(snapshot, { configSignature } = {}) 
     updatedAt: Number(snapshot.updatedAt) || snapshot.lastSuccessfulRefresh,
     lastSuccessfulRefresh: snapshot.lastSuccessfulRefresh,
     coveredRange: {
-      start: snapshot.coveredRange.start,
-      end: snapshot.coveredRange.end
+      start: coveredStart.toISOString(),
+      end: coveredEnd.toISOString()
     },
     configSignature: snapshot.configSignature,
-    eventsByCalendar
+    eventsByCalendar,
+    perCalendarMetadata: snapshot.perCalendarMetadata && typeof snapshot.perCalendarMetadata === 'object' ? snapshot.perCalendarMetadata : {}
   };
 }
 
-export function createEventCacheSnapshot({ configSignature, startDate, endDate, eventsByCalendar, lastSuccessfulRefresh = Date.now() }) {
+export function createEventCacheSnapshot({ configSignature, startDate, endDate, eventsByCalendar, lastSuccessfulRefresh = Date.now(), perCalendarMetadata = {} }) {
   return normalizeEventCacheSnapshot({
     schemaVersion: EVENT_CACHE_SCHEMA_VERSION,
     key: buildEventCacheKey(configSignature),
@@ -89,21 +93,23 @@ export function createEventCacheSnapshot({ configSignature, startDate, endDate, 
       end: endDate instanceof Date ? endDate.toISOString() : endDate
     },
     configSignature,
-    eventsByCalendar
+    eventsByCalendar,
+    perCalendarMetadata
   }, { configSignature });
 }
 
 export async function readEventCacheSnapshot(configSignature) {
   try {
     const key = buildEventCacheKey(configSignature);
-    const snapshot = await transact('readonly', (store, setResult) => {
+    const result = await transact('readonly', (store, setResult) => {
       const request = store.get(key);
       request.onsuccess = () => setResult(request.result || null);
     });
-    return normalizeEventCacheSnapshot(snapshot, { configSignature });
+    if (!result.available) return { available: false, snapshot: null };
+    return { available: true, snapshot: normalizeEventCacheSnapshot(result.value, { configSignature }) };
   } catch (error) {
     console.warn('Failed to read Daylight event cache:', error);
-    return null;
+    return { available: false, snapshot: null, error };
   }
 }
 
@@ -111,7 +117,7 @@ export async function writeEventCacheSnapshot(snapshot) {
   const normalized = normalizeEventCacheSnapshot(snapshot, { configSignature: snapshot?.configSignature });
   if (!normalized) return false;
   try {
-    await transact('readwrite', (store) => {
+    const result = await transact('readwrite', (store) => {
       store.put(normalized);
       const getAllRequest = store.getAll();
       getAllRequest.onsuccess = () => {
@@ -121,7 +127,7 @@ export async function writeEventCacheSnapshot(snapshot) {
         entries.slice(MAX_CACHE_ENTRIES).forEach((entry) => store.delete(entry.key));
       };
     });
-    return true;
+    return !!result.available;
   } catch (error) {
     console.warn('Failed to write Daylight event cache:', error);
     return false;
@@ -130,7 +136,7 @@ export async function writeEventCacheSnapshot(snapshot) {
 
 export async function clearAllEventCacheSnapshots() {
   try {
-    await transact('readwrite', (store) => {
+    const result = await transact('readwrite', (store) => {
       const getAllKeysRequest = store.getAllKeys();
       getAllKeysRequest.onsuccess = () => {
         (getAllKeysRequest.result || [])
@@ -138,7 +144,7 @@ export async function clearAllEventCacheSnapshots() {
           .forEach((key) => store.delete(key));
       };
     });
-    return true;
+    return !!result.available;
   } catch (error) {
     console.warn('Failed to clear Daylight event cache:', error);
     return false;

--- a/src/events/event-cache.js
+++ b/src/events/event-cache.js
@@ -5,6 +5,23 @@ const DB_NAME = 'daylight-calendar-card-events';
 const DB_VERSION = 1;
 const STORE_NAME = 'eventSnapshots';
 const MAX_CACHE_ENTRIES = 12;
+let eventCacheMutationQueue = Promise.resolve();
+let eventCacheMutationEpoch = 0;
+
+export function getEventCacheMutationEpoch() {
+  return eventCacheMutationEpoch;
+}
+
+export function beginEventCacheFlush() {
+  eventCacheMutationEpoch += 1;
+  return eventCacheMutationEpoch;
+}
+
+const queueEventCacheMutation = (callback) => {
+  const run = eventCacheMutationQueue.then(callback, callback);
+  eventCacheMutationQueue = run.catch(() => {});
+  return run;
+};
 
 const openEventCacheDb = () => new Promise((resolve, reject) => {
   const indexedDBRef = globalThis.indexedDB;
@@ -113,40 +130,46 @@ export async function readEventCacheSnapshot(configSignature) {
   }
 }
 
-export async function writeEventCacheSnapshot(snapshot) {
+export async function writeEventCacheSnapshot(snapshot, { epoch = getEventCacheMutationEpoch() } = {}) {
   const normalized = normalizeEventCacheSnapshot(snapshot, { configSignature: snapshot?.configSignature });
   if (!normalized) return false;
-  try {
-    const result = await transact('readwrite', (store) => {
-      store.put(normalized);
-      const getAllRequest = store.getAll();
-      getAllRequest.onsuccess = () => {
-        const entries = (getAllRequest.result || [])
-          .filter((entry) => entry?.key && String(entry.key).startsWith('events:'))
-          .sort((a, b) => (Number(b.updatedAt) || 0) - (Number(a.updatedAt) || 0));
-        entries.slice(MAX_CACHE_ENTRIES).forEach((entry) => store.delete(entry.key));
-      };
-    });
-    return !!result.available;
-  } catch (error) {
-    console.warn('Failed to write Daylight event cache:', error);
-    return false;
-  }
+  return queueEventCacheMutation(async () => {
+    if (epoch !== eventCacheMutationEpoch) return false;
+    try {
+      const result = await transact('readwrite', (store) => {
+        store.put(normalized);
+        const getAllRequest = store.getAll();
+        getAllRequest.onsuccess = () => {
+          const entries = (getAllRequest.result || [])
+            .filter((entry) => entry?.key && String(entry.key).startsWith('events:'))
+            .sort((a, b) => (Number(b.updatedAt) || 0) - (Number(a.updatedAt) || 0));
+          entries.slice(MAX_CACHE_ENTRIES).forEach((entry) => store.delete(entry.key));
+        };
+      });
+      return epoch === eventCacheMutationEpoch && !!result.available;
+    } catch (error) {
+      console.warn('Failed to write Daylight event cache:', error);
+      return false;
+    }
+  });
 }
 
-export async function clearAllEventCacheSnapshots() {
-  try {
-    const result = await transact('readwrite', (store) => {
-      const getAllKeysRequest = store.getAllKeys();
-      getAllKeysRequest.onsuccess = () => {
-        (getAllKeysRequest.result || [])
-          .filter((key) => String(key).startsWith('events:'))
-          .forEach((key) => store.delete(key));
-      };
-    });
-    return !!result.available;
-  } catch (error) {
-    console.warn('Failed to clear Daylight event cache:', error);
-    return false;
-  }
+export async function clearAllEventCacheSnapshots({ epoch = beginEventCacheFlush() } = {}) {
+  return queueEventCacheMutation(async () => {
+    if (epoch !== eventCacheMutationEpoch) return false;
+    try {
+      const result = await transact('readwrite', (store) => {
+        const getAllKeysRequest = store.getAllKeys();
+        getAllKeysRequest.onsuccess = () => {
+          (getAllKeysRequest.result || [])
+            .filter((key) => String(key).startsWith('events:'))
+            .forEach((key) => store.delete(key));
+        };
+      });
+      return epoch === eventCacheMutationEpoch && !!result.available;
+    } catch (error) {
+      console.warn('Failed to clear Daylight event cache:', error);
+      return false;
+    }
+  });
 }

--- a/src/events/event-cache.js
+++ b/src/events/event-cache.js
@@ -79,18 +79,24 @@ export function normalizeEventCacheSnapshot(snapshot, { configSignature } = {}) 
   if (!Number.isFinite(snapshot.lastSuccessfulRefresh)) return null;
   if (!snapshot.eventsByCalendar || typeof snapshot.eventsByCalendar !== 'object') return null;
 
-  const isValidCachedEvent = (event) => {
+  const isValidCachedEvent = (event, entityId) => {
     if (!event || typeof event !== 'object') return false;
+    if (event.entityId !== entityId) return false;
     const rawStart = event?.start?.dateTime || event?.start?.date || event?.start;
     const rawEnd = event?.end?.dateTime || event?.end?.date || event?.end;
     const start = rawStart ? new Date(rawStart) : null;
-    const end = rawEnd ? new Date(rawEnd) : start;
-    return !!start && Number.isFinite(start.getTime()) && (!rawEnd || Number.isFinite(end.getTime()));
+    const end = rawEnd ? new Date(rawEnd) : null;
+    return !!start && !!end && Number.isFinite(start.getTime()) && Number.isFinite(end.getTime());
   };
   const eventsByCalendar = {};
   Object.entries(snapshot.eventsByCalendar).forEach(([entityId, events]) => {
     if (!Array.isArray(events)) return;
-    eventsByCalendar[entityId] = events.filter(isValidCachedEvent);
+    if (events.length === 0) {
+      eventsByCalendar[entityId] = [];
+      return;
+    }
+    if (!events.every(event => isValidCachedEvent(event, entityId))) return;
+    eventsByCalendar[entityId] = events;
   });
 
   return {

--- a/src/events/event-cache.js
+++ b/src/events/event-cache.js
@@ -1,0 +1,146 @@
+import { toStableString } from './event-fetcher.js';
+
+export const EVENT_CACHE_SCHEMA_VERSION = 1;
+const DB_NAME = 'daylight-calendar-card-events';
+const DB_VERSION = 1;
+const STORE_NAME = 'eventSnapshots';
+const MAX_CACHE_ENTRIES = 12;
+
+const openEventCacheDb = () => new Promise((resolve, reject) => {
+  const indexedDBRef = globalThis.indexedDB;
+  if (!indexedDBRef) {
+    resolve(null);
+    return;
+  }
+  const request = indexedDBRef.open(DB_NAME, DB_VERSION);
+  request.onupgradeneeded = () => {
+    const db = request.result;
+    if (!db.objectStoreNames.contains(STORE_NAME)) {
+      db.createObjectStore(STORE_NAME, { keyPath: 'key' });
+    }
+  };
+  request.onsuccess = () => resolve(request.result);
+  request.onerror = () => reject(request.error || new Error('Unable to open event cache'));
+});
+
+const transact = async (mode, callback) => {
+  const db = await openEventCacheDb();
+  if (!db) return null;
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, mode);
+    const store = tx.objectStore(STORE_NAME);
+    let callbackResult;
+    tx.oncomplete = () => {
+      db.close?.();
+      resolve(callbackResult);
+    };
+    tx.onerror = () => {
+      db.close?.();
+      reject(tx.error || new Error('Event cache transaction failed'));
+    };
+    tx.onabort = tx.onerror;
+    callbackResult = callback(store, (value) => { callbackResult = value; });
+  });
+};
+
+export function buildEventCacheConfigSignature({ entities = [], timeZone = null, colors = {} } = {}) {
+  return toStableString({ entities, timeZone: timeZone || null, colors: colors || {} });
+}
+
+export function buildEventCacheKey(configSignature) {
+  return `events:${configSignature}`;
+}
+
+export function normalizeEventCacheSnapshot(snapshot, { configSignature } = {}) {
+  if (!snapshot || typeof snapshot !== 'object') return null;
+  if (snapshot.schemaVersion !== EVENT_CACHE_SCHEMA_VERSION) return null;
+  if (configSignature && snapshot.configSignature !== configSignature) return null;
+  if (!snapshot.coveredRange || !snapshot.coveredRange.start || !snapshot.coveredRange.end) return null;
+  if (!Number.isFinite(snapshot.lastSuccessfulRefresh)) return null;
+  if (!snapshot.eventsByCalendar || typeof snapshot.eventsByCalendar !== 'object') return null;
+
+  const eventsByCalendar = {};
+  Object.entries(snapshot.eventsByCalendar).forEach(([entityId, events]) => {
+    eventsByCalendar[entityId] = Array.isArray(events) ? events.filter((event) => event && typeof event === 'object') : [];
+  });
+
+  return {
+    schemaVersion: EVENT_CACHE_SCHEMA_VERSION,
+    key: snapshot.key || buildEventCacheKey(snapshot.configSignature),
+    updatedAt: Number(snapshot.updatedAt) || snapshot.lastSuccessfulRefresh,
+    lastSuccessfulRefresh: snapshot.lastSuccessfulRefresh,
+    coveredRange: {
+      start: snapshot.coveredRange.start,
+      end: snapshot.coveredRange.end
+    },
+    configSignature: snapshot.configSignature,
+    eventsByCalendar
+  };
+}
+
+export function createEventCacheSnapshot({ configSignature, startDate, endDate, eventsByCalendar, lastSuccessfulRefresh = Date.now() }) {
+  return normalizeEventCacheSnapshot({
+    schemaVersion: EVENT_CACHE_SCHEMA_VERSION,
+    key: buildEventCacheKey(configSignature),
+    updatedAt: Date.now(),
+    lastSuccessfulRefresh,
+    coveredRange: {
+      start: startDate instanceof Date ? startDate.toISOString() : startDate,
+      end: endDate instanceof Date ? endDate.toISOString() : endDate
+    },
+    configSignature,
+    eventsByCalendar
+  }, { configSignature });
+}
+
+export async function readEventCacheSnapshot(configSignature) {
+  try {
+    const key = buildEventCacheKey(configSignature);
+    const snapshot = await transact('readonly', (store, setResult) => {
+      const request = store.get(key);
+      request.onsuccess = () => setResult(request.result || null);
+    });
+    return normalizeEventCacheSnapshot(snapshot, { configSignature });
+  } catch (error) {
+    console.warn('Failed to read Daylight event cache:', error);
+    return null;
+  }
+}
+
+export async function writeEventCacheSnapshot(snapshot) {
+  const normalized = normalizeEventCacheSnapshot(snapshot, { configSignature: snapshot?.configSignature });
+  if (!normalized) return false;
+  try {
+    await transact('readwrite', (store) => {
+      store.put(normalized);
+      const getAllRequest = store.getAll();
+      getAllRequest.onsuccess = () => {
+        const entries = (getAllRequest.result || [])
+          .filter((entry) => entry?.key && String(entry.key).startsWith('events:'))
+          .sort((a, b) => (Number(b.updatedAt) || 0) - (Number(a.updatedAt) || 0));
+        entries.slice(MAX_CACHE_ENTRIES).forEach((entry) => store.delete(entry.key));
+      };
+    });
+    return true;
+  } catch (error) {
+    console.warn('Failed to write Daylight event cache:', error);
+    return false;
+  }
+}
+
+export async function clearAllEventCacheSnapshots() {
+  try {
+    await transact('readwrite', (store) => {
+      const getAllKeysRequest = store.getAllKeys();
+      getAllKeysRequest.onsuccess = () => {
+        (getAllKeysRequest.result || [])
+          .filter((key) => String(key).startsWith('events:'))
+          .forEach((key) => store.delete(key));
+      };
+    });
+    return true;
+  } catch (error) {
+    console.warn('Failed to clear Daylight event cache:', error);
+    return false;
+  }
+}

--- a/src/events/event-fetcher.js
+++ b/src/events/event-fetcher.js
@@ -10,6 +10,9 @@ export async function fetchEventsByCalendarInRange({
   normalizeCalendarEvent
 }) {
   const chunks = getDateRangeChunks(startDate, endDate, 30);
+  const fetchedRange = chunks.length > 0
+    ? { startDate: chunks[0].startDate, endDate: chunks[chunks.length - 1].endDate }
+    : { startDate, endDate };
   const calendarResults = await Promise.all(
     entities.map((entityId, index) => fetchEventsForCalendar({
       hass,
@@ -19,7 +22,8 @@ export async function fetchEventsByCalendarInRange({
       formatLocalDate,
       getCalendarColor,
       getEventIdentityKey,
-      normalizeCalendarEvent
+      normalizeCalendarEvent,
+      fetchedRange
     }))
   );
 
@@ -37,7 +41,8 @@ export async function fetchEventsForCalendar({
   formatLocalDate,
   getCalendarColor,
   getEventIdentityKey,
-  normalizeCalendarEvent
+  normalizeCalendarEvent,
+  fetchedRange = null
 }) {
   const seen = new Set();
   const color = getCalendarColor(entityId, colorIndex);
@@ -48,7 +53,7 @@ export async function fetchEventsForCalendar({
 
   const failedChunks = chunkResults.filter(result => !result?.success);
   if (failedChunks.length > 0) {
-    return { success: false, events: [], failedChunks };
+    return { success: false, events: [], failedChunks, fetchedRange };
   }
 
   const mergedEvents = [];
@@ -64,7 +69,7 @@ export async function fetchEventsForCalendar({
     });
   });
 
-  return { success: true, events: mergedEvents };
+  return { success: true, events: mergedEvents, fetchedRange };
 }
 
 export async function fetchEventsForChunk({ hass, entityId, chunk, formatLocalDate }) {

--- a/src/events/event-fetcher.js
+++ b/src/events/event-fetcher.js
@@ -10,7 +10,7 @@ export async function fetchEventsByCalendarInRange({
   normalizeCalendarEvent
 }) {
   const chunks = getDateRangeChunks(startDate, endDate, 30);
-  const eventsByCalendar = await Promise.all(
+  const calendarResults = await Promise.all(
     entities.map((entityId, index) => fetchEventsForCalendar({
       hass,
       entityId,
@@ -24,7 +24,7 @@ export async function fetchEventsByCalendarInRange({
   );
 
   return entities.reduce((acc, entityId, index) => {
-    acc[entityId] = eventsByCalendar[index] || [];
+    acc[entityId] = calendarResults[index] || { success: false, events: [] };
     return acc;
   }, {});
 }
@@ -42,13 +42,18 @@ export async function fetchEventsForCalendar({
   const seen = new Set();
   const color = getCalendarColor(entityId, colorIndex);
 
-  const chunkEventLists = await Promise.all(
+  const chunkResults = await Promise.all(
     chunks.map(chunk => fetchEventsForChunk({ hass, entityId, chunk, formatLocalDate }))
   );
 
+  const failedChunks = chunkResults.filter(result => !result?.success);
+  if (failedChunks.length > 0) {
+    return { success: false, events: [], failedChunks };
+  }
+
   const mergedEvents = [];
-  chunkEventLists.forEach(events => {
-    if (!events || !Array.isArray(events)) return;
+  chunkResults.forEach(result => {
+    const events = Array.isArray(result?.events) ? result.events : [];
 
     events.forEach(event => {
       const key = getEventIdentityKey(entityId, event);
@@ -59,7 +64,7 @@ export async function fetchEventsForCalendar({
     });
   });
 
-  return mergedEvents;
+  return { success: true, events: mergedEvents };
 }
 
 export async function fetchEventsForChunk({ hass, entityId, chunk, formatLocalDate }) {
@@ -67,15 +72,17 @@ export async function fetchEventsForChunk({ hass, entityId, chunk, formatLocalDa
   const chunkEndStr = chunk.endDate.toISOString();
 
   try {
-    return await fetchEventsViaWebSocket({ hass, entityId, chunkStartStr, chunkEndStr });
+    const events = await fetchEventsViaWebSocket({ hass, entityId, chunkStartStr, chunkEndStr });
+    return { success: true, events: Array.isArray(events) ? events : [] };
   } catch (error) {
     try {
       const startDateOnly = formatLocalDate(chunk.startDate);
       const endDateOnly = formatLocalDate(chunk.endDate);
-      return await hass.callApi('GET', `calendars/${entityId}?start=${startDateOnly}T00:00:00Z&end=${endDateOnly}T23:59:59Z`);
+      const events = await hass.callApi('GET', `calendars/${entityId}?start=${startDateOnly}T00:00:00Z&end=${endDateOnly}T23:59:59Z`);
+      return { success: true, events: Array.isArray(events) ? events : [] };
     } catch (error2) {
       console.error(`Failed to fetch events for ${entityId}:`, error2.message || error2);
-      return [];
+      return { success: false, events: [], error: error2 };
     }
   }
 }

--- a/src/events/event-fetcher.js
+++ b/src/events/event-fetcher.js
@@ -73,13 +73,15 @@ export async function fetchEventsForChunk({ hass, entityId, chunk, formatLocalDa
 
   try {
     const events = await fetchEventsViaWebSocket({ hass, entityId, chunkStartStr, chunkEndStr });
-    return { success: true, events: Array.isArray(events) ? events : [] };
+    if (!Array.isArray(events)) throw new Error('Calendar WebSocket response was not an array');
+    return { success: true, events };
   } catch (error) {
     try {
       const startDateOnly = formatLocalDate(chunk.startDate);
       const endDateOnly = formatLocalDate(chunk.endDate);
       const events = await hass.callApi('GET', `calendars/${entityId}?start=${startDateOnly}T00:00:00Z&end=${endDateOnly}T23:59:59Z`);
-      return { success: true, events: Array.isArray(events) ? events : [] };
+      if (!Array.isArray(events)) throw new Error('Calendar REST response was not an array');
+      return { success: true, events };
     } catch (error2) {
       console.error(`Failed to fetch events for ${entityId}:`, error2.message || error2);
       return { success: false, events: [], error: error2 };

--- a/src/events/event-fetcher.js
+++ b/src/events/event-fetcher.js
@@ -44,7 +44,7 @@ export async function fetchEventsForCalendar({
   normalizeCalendarEvent,
   fetchedRange = null
 }) {
-  const seen = new Set();
+  const mergedRawEventsByKey = new Map();
   const color = getCalendarColor(entityId, colorIndex);
 
   const chunkResults = await Promise.all(
@@ -56,20 +56,20 @@ export async function fetchEventsForCalendar({
     return { success: false, events: [], failedChunks, fetchedRange };
   }
 
-  const mergedEvents = [];
   chunkResults.forEach(result => {
     const events = Array.isArray(result?.events) ? result.events : [];
 
     events.forEach(event => {
       const key = getEventIdentityKey(entityId, event);
-      if (seen.has(key)) return;
-      seen.add(key);
-
-      mergedEvents.push(normalizeCalendarEvent(event, { entityId, color }));
+      mergedRawEventsByKey.set(key, event);
     });
   });
 
-  return { success: true, events: mergedEvents, fetchedRange };
+  return {
+    success: true,
+    events: Array.from(mergedRawEventsByKey.values()).map(event => normalizeCalendarEvent(event, { entityId, color })),
+    fetchedRange
+  };
 }
 
 export async function fetchEventsForChunk({ hass, entityId, chunk, formatLocalDate }) {

--- a/src/events/event-fetcher.js
+++ b/src/events/event-fetcher.js
@@ -82,9 +82,7 @@ export async function fetchEventsForChunk({ hass, entityId, chunk, formatLocalDa
     return { success: true, events };
   } catch (error) {
     try {
-      const startDateOnly = formatLocalDate(chunk.startDate);
-      const endDateOnly = formatLocalDate(chunk.endDate);
-      const events = await hass.callApi('GET', `calendars/${entityId}?start=${startDateOnly}T00:00:00Z&end=${endDateOnly}T23:59:59Z`);
+      const events = await hass.callApi('GET', `calendars/${entityId}?start=${encodeURIComponent(chunkStartStr)}&end=${encodeURIComponent(chunkEndStr)}`);
       if (!Array.isArray(events)) throw new Error('Calendar REST response was not an array');
       return { success: true, events };
     } catch (error2) {

--- a/src/events/event-normalizer.js
+++ b/src/events/event-normalizer.js
@@ -1,9 +1,11 @@
 export const getEventIdentityKey = (entityId, event) => {
   const uid = event?.uid;
   const recurrenceId = event?.recurrence_id || event?.recurring_event_id;
+  const start = event?.start?.dateTime || event?.start?.date || event?.start || '';
+  const end = event?.end?.dateTime || event?.end?.date || event?.end || '';
   if (uid && recurrenceId) return `${entityId}|${uid}|${recurrenceId}`;
-  if (uid) return `${entityId}|${uid}`;
-  return `${entityId}|${recurrenceId || ''}|${event?.start?.dateTime || event?.start?.date || event?.start || ''}|${event?.end?.dateTime || event?.end?.date || event?.end || ''}|${event?.summary || ''}`;
+  if (uid) return `${entityId}|${uid}|${start}|${end}`;
+  return `${entityId}|${recurrenceId || ''}|${start}|${end}|${event?.summary || ''}`;
 };
 
 export const normalizeCalendarEvent = (event, { entityId, color }) => ({

--- a/src/events/event-normalizer.js
+++ b/src/events/event-normalizer.js
@@ -4,7 +4,9 @@ export const getEventIdentityKey = (entityId, event) => {
   const start = event?.start?.dateTime || event?.start?.date || event?.start || '';
   const end = event?.end?.dateTime || event?.end?.date || event?.end || '';
   if (uid && recurrenceId) return `${entityId}|${uid}|${recurrenceId}`;
-  if (uid) return `${entityId}|${uid}|${start}|${end}`;
+  if (uid && event?.rrule) return `${entityId}|${uid}|${start}|${end}`;
+  // Non-recurring UID events are intentionally keyed by UID so later chunks/merges deterministically replace earlier copies.
+  if (uid) return `${entityId}|${uid}`;
   return `${entityId}|${recurrenceId || ''}|${start}|${end}|${event?.summary || ''}`;
 };
 

--- a/src/events/event-normalizer.js
+++ b/src/events/event-normalizer.js
@@ -1,4 +1,10 @@
-export const getEventIdentityKey = (entityId, event) => `${entityId}|${event.uid || ''}|${event.recurring_event_id || ''}|${event.start?.dateTime || event.start?.date || event.start || ''}|${event.end?.dateTime || event.end?.date || event.end || ''}|${event.summary || ''}`;
+export const getEventIdentityKey = (entityId, event) => {
+  const uid = event?.uid;
+  const recurrenceId = event?.recurrence_id || event?.recurring_event_id;
+  if (uid && recurrenceId) return `${entityId}|${uid}|${recurrenceId}`;
+  if (uid) return `${entityId}|${uid}`;
+  return `${entityId}|${recurrenceId || ''}|${event?.start?.dateTime || event?.start?.date || event?.start || ''}|${event?.end?.dateTime || event?.end?.date || event?.end || ''}|${event?.summary || ''}`;
+};
 
 export const normalizeCalendarEvent = (event, { entityId, color }) => ({
   ...event,

--- a/src/events/event-normalizer.js
+++ b/src/events/event-normalizer.js
@@ -4,9 +4,7 @@ export const getEventIdentityKey = (entityId, event) => {
   const start = event?.start?.dateTime || event?.start?.date || event?.start || '';
   const end = event?.end?.dateTime || event?.end?.date || event?.end || '';
   if (uid && recurrenceId) return `${entityId}|${uid}|${recurrenceId}`;
-  if (uid && event?.rrule) return `${entityId}|${uid}|${start}|${end}`;
-  // Non-recurring UID events are intentionally keyed by UID so later chunks/merges deterministically replace earlier copies.
-  if (uid) return `${entityId}|${uid}`;
+  if (uid) return `${entityId}|${uid}|${start}|${end}`;
   return `${entityId}|${recurrenceId || ''}|${start}|${end}|${event?.summary || ''}`;
 };
 

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -1961,8 +1961,12 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getEventLogicalIdentityKey(entityId, event) {
-    const stableId = event?.uid || event?.recurring_event_id;
-    return stableId ? `${entityId}|${stableId}` : this.getEventIdentityKey(entityId, event);
+    const uid = event?.uid;
+    const recurrenceId = event?.recurrence_id || event?.recurring_event_id;
+    if (uid && recurrenceId) return `${entityId}|${uid}|${recurrenceId}`;
+    if (uid) return `${entityId}|${uid}`;
+    if (recurrenceId) return `${entityId}|recurrence|${recurrenceId}`;
+    return this.getEventIdentityKey(entityId, event);
   }
 
   reconcileEventsForFetchedRange(existingEvents = [], incomingEvents = [], fetchedRange = null) {
@@ -2126,6 +2130,25 @@ class SkylightCalendarCard extends HTMLElement {
     const visibleRange = this.getVisibleDateRange?.();
     return this.getValidRange(visibleRange?.startDate, visibleRange?.endDate) ||
       this.getValidRange(this._loadedEventRange?.startDate, this._loadedEventRange?.endDate);
+  }
+
+  setAgendaNavigationViewportAnchor(startDate = this._agendaStartDate) {
+    const agendaWindowRange = this.getValidRange(this._agendaStartDate, this._agendaEndDate);
+    const anchorStart = new Date(startDate || this._agendaStartDate || Date.now());
+    anchorStart.setHours(0, 0, 0, 0);
+    const viewportDays = Math.max(1, Number(this.getAgendaViewportDayCapacity?.() || 14));
+    const anchorEnd = new Date(anchorStart);
+    anchorEnd.setDate(anchorEnd.getDate() + viewportDays);
+    anchorEnd.setHours(23, 59, 59, 999);
+    if (agendaWindowRange) {
+      const clampedStart = new Date(Math.max(anchorStart.getTime(), agendaWindowRange.startDate.getTime()));
+      const clampedEnd = new Date(Math.min(anchorEnd.getTime(), agendaWindowRange.endDate.getTime()));
+      this._agendaVisibleStartDate = clampedStart;
+      this._agendaVisibleEndDate = clampedEnd >= clampedStart ? clampedEnd : new Date(clampedStart);
+      return;
+    }
+    this._agendaVisibleStartDate = anchorStart;
+    this._agendaVisibleEndDate = anchorEnd;
   }
 
   getEventCacheRetainedRange() {
@@ -5645,8 +5668,7 @@ class SkylightCalendarCard extends HTMLElement {
       this._agendaEndDate.setDate(this._agendaEndDate.getDate() - backwardDays);
       this._agendaEndDate.setHours(23, 59, 59, 999);
       this._currentDate = new Date(this._agendaStartDate);
-      this._agendaVisibleStartDate = new Date(this._agendaStartDate);
-      this._agendaVisibleEndDate = new Date(this._agendaEndDate);
+      this.setAgendaNavigationViewportAnchor(this._agendaStartDate);
     } else if (this._viewMode === 'month') {
       if (this._config.rolling_weeks !== null) {
         // In rolling weeks mode, go back by the number of weeks shown
@@ -5713,8 +5735,7 @@ class SkylightCalendarCard extends HTMLElement {
       this._agendaStartDate = targetStart;
       this._agendaEndDate = targetEnd;
       this._currentDate = new Date(this._agendaStartDate);
-      this._agendaVisibleStartDate = new Date(this._agendaStartDate);
-      this._agendaVisibleEndDate = new Date(this._agendaEndDate);
+      this.setAgendaNavigationViewportAnchor(this._agendaStartDate);
     } else if (this._viewMode === 'month') {
       if (this._config.rolling_weeks !== null) {
         // In rolling weeks mode, go forward by the number of weeks shown

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -1948,7 +1948,7 @@ class SkylightCalendarCard extends HTMLElement {
     const eventStart = this.getEventStartDate(event);
     const eventEnd = this.getEventEndDate(event);
     if (!Number.isFinite(eventStart.getTime()) || !Number.isFinite(eventEnd.getTime())) return false;
-    return eventStart <= validRange.endDate && eventEnd >= validRange.startDate;
+    return eventEnd > validRange.startDate && eventStart < validRange.endDate;
   }
 
   isEventContainedInRange(event, range) {
@@ -1965,15 +1965,16 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getStableEventIdentityKey(entityId, event) {
-    return event?.uid ? this.getEventIdentityKey(entityId, event) : null;
+    if (!event?.uid) return null;
+    const recurrenceId = event.recurrence_id || event.recurring_event_id;
+    if (recurrenceId) return `${entityId}|${event.uid}|${recurrenceId}`;
+    if (event.rrule) return null;
+    return `${entityId}|${event.uid}`;
   }
 
   reconcileEventsForFetchedRange(existingEvents = [], incomingEvents = [], fetchedRange = null) {
     const range = this.getValidRange(fetchedRange?.startDate, fetchedRange?.endDate);
     if (!range) return this.mergeEvents(existingEvents, incomingEvents);
-    const incomingLogicalKeys = new Set(
-      (incomingEvents || []).map(event => this.getEventLogicalIdentityKey(event.entityId, event))
-    );
     const incomingStableKeys = new Set(
       (incomingEvents || [])
         .map(event => this.getStableEventIdentityKey(event.entityId, event))
@@ -1982,10 +1983,7 @@ class SkylightCalendarCard extends HTMLElement {
     const retainedExisting = (existingEvents || []).filter((event) => {
       const stableKey = this.getStableEventIdentityKey(event.entityId, event);
       if (stableKey && incomingStableKeys.has(stableKey)) return false;
-      const containedInAuthoritativeRange = this.isEventContainedInRange(event, range);
-      if (containedInAuthoritativeRange) return false;
-      const logicalKey = this.getEventLogicalIdentityKey(event.entityId, event);
-      return !(incomingLogicalKeys.has(logicalKey) && this.doEventRangesOverlap(event, range));
+      return !this.doEventRangesOverlap(event, range);
     });
     return this.mergeEvents(retainedExisting, incomingEvents);
   }

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -1923,11 +1923,14 @@ class SkylightCalendarCard extends HTMLElement {
 
   unionEventRanges(existingRange, incomingRange) {
     const existing = this.getValidRange(existingRange?.startDate, existingRange?.endDate);
-    if (!existing) return incomingRange;
-    if (!incomingRange) return existing;
+    const incoming = this.getValidRange(incomingRange?.startDate, incomingRange?.endDate);
+    if (!existing) return incoming;
+    if (!incoming) return existing;
+    if (incoming.endDate < existing.startDate) return incoming;
+    if (incoming.startDate > existing.endDate) return incoming;
     return {
-      startDate: new Date(Math.min(existing.startDate.getTime(), incomingRange.startDate.getTime())),
-      endDate: new Date(Math.max(existing.endDate.getTime(), incomingRange.endDate.getTime()))
+      startDate: new Date(Math.min(existing.startDate.getTime(), incoming.startDate.getTime())),
+      endDate: new Date(Math.max(existing.endDate.getTime(), incoming.endDate.getTime()))
     };
   }
 
@@ -2095,8 +2098,7 @@ class SkylightCalendarCard extends HTMLElement {
     Object.entries(eventsByCalendar || {}).forEach(([entityId, events]) => {
       pruned[entityId] = (Array.isArray(events) ? events : []).filter((event) => {
         const eventStart = this.getEventStartDate(event);
-        const rawEnd = event?.end?.dateTime || event?.end?.date || event?.end;
-        const eventEnd = rawEnd ? new Date(rawEnd) : eventStart;
+        const eventEnd = this.getEventEndDate(event);
         const safeEnd = Number.isFinite(eventEnd.getTime()) ? eventEnd : eventStart;
         return eventStart <= retainedRange.endDate && safeEnd >= retainedRange.startDate;
       });
@@ -2311,11 +2313,14 @@ class SkylightCalendarCard extends HTMLElement {
     }
   }
 
-  async extendEventsForRange(startDate, endDate, { render = true } = {}) {
-    if (!this._hass) return;
+  async extendEventsForRange(startDate, endDate, { render = true, returnDetails = false } = {}) {
+    const toResult = (complete, dataChanged = false, stateChanged = false) => (
+      returnDetails ? { complete, dataChanged, stateChanged, applied: dataChanged || stateChanged } : complete
+    );
+    if (!this._hass) return toResult(false);
     if (this._fetching) {
       this._pendingEventRefreshAfterCurrentFetch = true;
-      return false;
+      return toResult(false);
     }
 
     const generation = ++this._eventFetchGeneration;
@@ -2330,6 +2335,11 @@ class SkylightCalendarCard extends HTMLElement {
       const successfulEntityIds = [];
       const failedEntityIds = [];
       let anyChanged = false;
+      const stateSignatureBefore = this.toStableString((this._config.entities || []).map(entityId => ({
+        entityId,
+        refreshFailed: !!this._calendarEventMetadata[entityId]?.refreshFailed,
+        firstFailureAt: this._calendarEventMetadata[entityId]?.firstFailureAt ?? null
+      })));
 
       this._config.entities.forEach(entityId => {
         const result = fetchResultsByCalendar[entityId];
@@ -2357,7 +2367,14 @@ class SkylightCalendarCard extends HTMLElement {
           };
         });
         this.recomputeEventState();
-        return false;
+        const stateSignatureAfter = this.toStableString((this._config.entities || []).map(entityId => ({
+          entityId,
+          refreshFailed: !!this._calendarEventMetadata[entityId]?.refreshFailed,
+          firstFailureAt: this._calendarEventMetadata[entityId]?.firstFailureAt ?? null
+        })));
+        const stateChanged = stateSignatureBefore !== stateSignatureAfter;
+        if (!returnDetails && (render || stateChanged) && stateChanged) this.render();
+        return toResult(false, false, stateChanged);
       }
 
       this.applyEventsByCalendar(nextEventsByCalendar, {
@@ -2371,8 +2388,14 @@ class SkylightCalendarCard extends HTMLElement {
         coverageMode: 'union'
       });
       this.persistEventCacheSnapshot({ generation: this._eventWriteGeneration });
-      if ((render || failedEntityIds.length > 0) && (anyChanged || failedEntityIds.length > 0)) this.render();
-      return failedEntityIds.length === 0;
+      const stateSignatureAfter = this.toStableString((this._config.entities || []).map(entityId => ({
+        entityId,
+        refreshFailed: !!this._calendarEventMetadata[entityId]?.refreshFailed,
+        firstFailureAt: this._calendarEventMetadata[entityId]?.firstFailureAt ?? null
+      })));
+      const stateChanged = stateSignatureBefore !== stateSignatureAfter;
+      if (!returnDetails && (render || failedEntityIds.length > 0) && (anyChanged || stateChanged)) this.render();
+      return toResult(failedEntityIds.length === 0, anyChanged, stateChanged);
     } finally {
       this._fetching = false;
       this._activeEventFetchRange = null;
@@ -2444,25 +2467,23 @@ class SkylightCalendarCard extends HTMLElement {
 
     if (startDate < this._loadedEventRange.startDate) {
       const missingStartEnd = new Date(this._loadedEventRange.startDate);
-      missingStartEnd.setDate(missingStartEnd.getDate() - 1);
-      missingStartEnd.setHours(23, 59, 59, 999);
       missingRanges.push({ startDate, endDate: missingStartEnd });
     }
 
     if (endDate > this._loadedEventRange.endDate) {
       const missingEndStart = new Date(this._loadedEventRange.endDate);
-      missingEndStart.setDate(missingEndStart.getDate() + 1);
-      missingEndStart.setHours(0, 0, 0, 0);
       missingRanges.push({ startDate: missingEndStart, endDate });
     }
 
     let allExtended = true;
+    let shouldRenderAfterExtensions = false;
     for (const range of missingRanges) {
-      const extended = await this.extendEventsForRange(range.startDate, range.endDate, { render: false });
-      if (extended === false) allExtended = false;
+      const extended = await this.extendEventsForRange(range.startDate, range.endDate, { render: false, returnDetails: true });
+      if (!extended?.complete) allExtended = false;
+      if (extended?.dataChanged || extended?.stateChanged) shouldRenderAfterExtensions = true;
     }
 
-    if (allExtended) this.render();
+    if (allExtended || shouldRenderAfterExtensions) this.render();
   }
 
   getEventFetchRange() {
@@ -2498,6 +2519,12 @@ class SkylightCalendarCard extends HTMLElement {
 
   getEventStartDate(event) {
     return getNormalizedEventStartDate(event, { parseLocalDate: this.parseLocalDate.bind(this) });
+  }
+
+  getEventEndDate(event) {
+    if (event?.end?.dateTime) return new Date(event.end.dateTime);
+    if (event?.end?.date) return this.parseLocalDate(event.end.date);
+    return new Date(event?.end);
   }
 
   parseLocalDate(dateStr) {

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -255,7 +255,7 @@ const translate = (language, key, params = {}) => {
   return interpolate(strings[key] || fallback, params);
 };
 
-
+const MAX_PERSISTED_EVENT_CACHE_SPAN_DAYS = 210;
 const STALE_RESOURCE_BANNER_ID = 'daylight-calendar-card-stale-resource-warning';
 let staleResourceWarningHandled = false;
 
@@ -379,6 +379,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._eventFetchGeneration = 0;
     this._eventWriteGeneration = 0;
     this._pendingEventRefreshAfterCurrentFetch = false;
+    this._pendingEventRenderAfterCurrentFetch = false;
     this._eventRefreshWarningTimer = null;
     this._eventCacheHydrated = false;
     this._lastSuccessfulEventRefresh = null;
@@ -997,6 +998,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._eventFetchGeneration += 1;
     this._eventWriteGeneration += 1;
     this._pendingEventRefreshAfterCurrentFetch = false;
+    this._pendingEventRenderAfterCurrentFetch = false;
     this._eventCacheHydrated = false;
     this._lastSuccessfulEventRefresh = null;
     this._lastEventRefreshFailed = false;
@@ -2061,12 +2063,16 @@ class SkylightCalendarCard extends HTMLElement {
 
   getEventCacheRetainedRange() {
     const fetchRange = this.getEventFetchRange?.();
-    const validRange = this.getValidRange(fetchRange?.startDate, fetchRange?.endDate) || this.getValidRange(this._loadedEventRange?.startDate, this._loadedEventRange?.endDate);
+    const visibleRange = this.getVisibleDateRange?.();
+    const validRange = this.getValidRange(fetchRange?.startDate, fetchRange?.endDate) ||
+      this.getValidRange(visibleRange?.startDate, visibleRange?.endDate) ||
+      this.getValidRange(this._loadedEventRange?.startDate, this._loadedEventRange?.endDate);
     if (!validRange) return null;
-    const retainedStart = new Date(validRange.startDate);
-    retainedStart.setDate(retainedStart.getDate() - 90);
-    const retainedEnd = new Date(validRange.endDate);
-    retainedEnd.setDate(retainedEnd.getDate() + 90);
+    const maxSpanMs = MAX_PERSISTED_EVENT_CACHE_SPAN_DAYS * 24 * 60 * 60 * 1000;
+    const rangeSpanMs = validRange.endDate.getTime() - validRange.startDate.getTime();
+    const center = validRange.startDate.getTime() + Math.max(0, rangeSpanMs) / 2;
+    const retainedStart = new Date(center - maxSpanMs / 2);
+    const retainedEnd = new Date(center + maxSpanMs / 2);
     return { startDate: retainedStart, endDate: retainedEnd };
   }
 
@@ -2145,6 +2151,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._eventCacheGeneration += 1;
     this._eventFetchGeneration += 1;
     this._eventWriteGeneration += 1;
+    this._pendingEventRenderAfterCurrentFetch = false;
     const clearEpoch = beginEventCacheFlush();
     const cleared = await clearAllEventCacheSnapshots({ epoch: clearEpoch });
     this._eventCacheGeneration += 1;
@@ -2204,7 +2211,7 @@ class SkylightCalendarCard extends HTMLElement {
     return `<div class="event-refresh-warning" role="status">${this.t('eventRefreshStaleWarning', { time: this.formatTime(new Date(oldestFailedRefresh)) })}</div>`;
   }
 
-  async updateEvents({ preserveScroll = false } = {}) {
+  async updateEvents({ preserveScroll = false, renderAfterFetch = false } = {}) {
     if (!this._hass) return;
     if (this._fetching) {
       this._pendingEventRefreshAfterCurrentFetch = true;
@@ -2270,7 +2277,7 @@ class SkylightCalendarCard extends HTMLElement {
       });
       const warningVisibilityChanged = wasWarningVisible !== this.shouldShowEventRefreshWarning(now);
       this.persistEventCacheSnapshot({ generation: this._eventWriteGeneration });
-      if (anyChanged || shouldRenderForUnchangedData || failedEntityIds.length > 0 || warningVisibilityChanged) {
+      if (anyChanged || shouldRenderForUnchangedData || failedEntityIds.length > 0 || warningVisibilityChanged || renderAfterFetch) {
         this._lastUnchangedDataRender = now;
         if (preserveScroll) {
           this.renderPreservingAgendaScroll();
@@ -2281,9 +2288,13 @@ class SkylightCalendarCard extends HTMLElement {
     } finally {
       this._fetching = false;
       this._activeEventFetchRange = null;
+      const shouldRenderAfterFetch = this._pendingEventRenderAfterCurrentFetch;
+      this._pendingEventRenderAfterCurrentFetch = false;
       if (this._pendingEventRefreshAfterCurrentFetch) {
         this._pendingEventRefreshAfterCurrentFetch = false;
-        this.ensureEventsForCurrentRange({ force: true });
+        this.ensureEventsForCurrentRange({ force: true, renderIfCovered: shouldRenderAfterFetch });
+      } else if (shouldRenderAfterFetch) {
+        this.render();
       }
     }
   }
@@ -2353,9 +2364,13 @@ class SkylightCalendarCard extends HTMLElement {
     } finally {
       this._fetching = false;
       this._activeEventFetchRange = null;
+      const shouldRenderAfterFetch = this._pendingEventRenderAfterCurrentFetch;
+      this._pendingEventRenderAfterCurrentFetch = false;
       if (this._pendingEventRefreshAfterCurrentFetch) {
         this._pendingEventRefreshAfterCurrentFetch = false;
-        this.ensureEventsForCurrentRange({ force: true });
+        this.ensureEventsForCurrentRange({ force: true, renderIfCovered: shouldRenderAfterFetch });
+      } else if (shouldRenderAfterFetch) {
+        this.render();
       }
     }
   }
@@ -2384,13 +2399,16 @@ class SkylightCalendarCard extends HTMLElement {
       const activeRange = this.getValidRange(this._activeEventFetchRange?.startDate, this._activeEventFetchRange?.endDate);
       if (force || !activeRange || !isDateRangeCoveredByLoadedEventsHelper(activeRange, startDate, endDate)) {
         this._pendingEventRefreshAfterCurrentFetch = true;
+        if (renderIfCovered) this._pendingEventRenderAfterCurrentFetch = true;
+      } else if (renderIfCovered) {
+        this._pendingEventRenderAfterCurrentFetch = true;
       }
       return;
     }
 
     if (force || shouldRefreshForAge || !this._loadedEventRange) {
       const shouldPreserveScrollDuringRefresh = this._viewMode === 'agenda' && !force && !renderIfCovered;
-      await this.updateEvents({ preserveScroll: shouldPreserveScrollDuringRefresh });
+      await this.updateEvents({ preserveScroll: shouldPreserveScrollDuringRefresh, renderAfterFetch: renderIfCovered });
       return;
     }
 

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -1964,7 +1964,7 @@ class SkylightCalendarCard extends HTMLElement {
     this.scheduleEventRefreshWarningTimer();
   }
 
-  applyEventsByCalendar(eventsByCalendar = {}, { startDate, endDate, lastSuccessfulRefresh = null, successfulEntityIds = null, failedEntityIds = [], source = 'network', requestId = null, coverageMode = 'replace' } = {}) {
+  applyEventsByCalendar(eventsByCalendar = {}, { startDate, endDate, lastSuccessfulRefresh = null, successfulEntityIds = null, failedEntityIds = [], source = 'network', requestId = null, coverageMode = 'replace', perCalendarMetadata = {} } = {}) {
     const range = this.getValidRange(startDate, endDate);
     const successfulSet = successfulEntityIds ? new Set(successfulEntityIds) : new Set(this._config.entities || []);
     const failedSet = new Set(failedEntityIds || []);
@@ -1987,13 +1987,19 @@ class SkylightCalendarCard extends HTMLElement {
       const events = Array.isArray(eventsByCalendar[entityId]) ? eventsByCalendar[entityId] : [];
       this._eventsByCalendar[entityId] = events;
       this._calendarDataSignatures[entityId] = this.getCalendarDataSignature(events);
+      const cachedMetadata = perCalendarMetadata?.[entityId] || {};
+      const cachedRange = this.getValidRange(cachedMetadata.range?.startDate, cachedMetadata.range?.endDate);
+      const effectiveRange = source === 'cache' && cachedRange ? cachedRange : range;
+      const effectiveLastSuccessfulRefresh = source === 'cache' && Number.isFinite(cachedMetadata.lastSuccessfulRefresh)
+        ? cachedMetadata.lastSuccessfulRefresh
+        : lastSuccessfulRefresh;
       const nextRange = coverageMode === 'union'
-        ? this.unionEventRanges(existingMetadata.range, range)
-        : (range || existingMetadata.range || null);
+        ? this.unionEventRanges(existingMetadata.range, effectiveRange)
+        : (effectiveRange || existingMetadata.range || null);
       this._calendarEventMetadata[entityId] = {
         ...existingMetadata,
         range: nextRange,
-        lastSuccessfulRefresh: Number.isFinite(lastSuccessfulRefresh) ? lastSuccessfulRefresh : existingMetadata.lastSuccessfulRefresh,
+        lastSuccessfulRefresh: Number.isFinite(effectiveLastSuccessfulRefresh) ? effectiveLastSuccessfulRefresh : existingMetadata.lastSuccessfulRefresh,
         refreshFailed: hasNewerNetworkFailure ? existingMetadata.refreshFailed : false,
         firstFailureAt: hasNewerNetworkFailure ? existingMetadata.firstFailureAt : null,
         lastNetworkSuccessRequest: source === 'network' ? requestId : existingMetadata.lastNetworkSuccessRequest
@@ -2010,11 +2016,25 @@ class SkylightCalendarCard extends HTMLElement {
     const { available, snapshot } = await readEventCacheSnapshot(configSignature);
     if (generation !== this._eventCacheGeneration || !available || !snapshot) return;
     const cacheEventsByCalendar = {};
+    const cacheMetadataByCalendar = {};
     const successfulEntityIds = [];
     (this._config.entities || []).forEach((entityId) => {
       const metadata = this._calendarEventMetadata[entityId] || {};
       if (metadata.lastNetworkSuccessRequest && metadata.lastNetworkSuccessRequest > requestId) return;
+      const cachedMetadata = snapshot.perCalendarMetadata?.[entityId] || {};
+      const cachedRange = this.getValidRange(
+        cachedMetadata.range?.startDate || snapshot.coveredRange.start,
+        cachedMetadata.range?.endDate || snapshot.coveredRange.end
+      );
+      const cachedLastSuccessfulRefresh = Number.isFinite(cachedMetadata.lastSuccessfulRefresh)
+        ? cachedMetadata.lastSuccessfulRefresh
+        : snapshot.lastSuccessfulRefresh;
+      if (!cachedRange || !Number.isFinite(cachedLastSuccessfulRefresh)) return;
       cacheEventsByCalendar[entityId] = snapshot.eventsByCalendar[entityId] || [];
+      cacheMetadataByCalendar[entityId] = {
+        range: cachedRange,
+        lastSuccessfulRefresh: cachedLastSuccessfulRefresh
+      };
       successfulEntityIds.push(entityId);
     });
     if (successfulEntityIds.length === 0) return;
@@ -2025,18 +2045,26 @@ class SkylightCalendarCard extends HTMLElement {
       lastSuccessfulRefresh: snapshot.lastSuccessfulRefresh,
       successfulEntityIds,
       source: 'cache',
-      requestId
+      requestId,
+      perCalendarMetadata: cacheMetadataByCalendar
     });
     this.render();
   }
 
-  getPrunedEventsByCalendarForCache(eventsByCalendar = {}, range = this._loadedEventRange) {
-    const validRange = this.getValidRange(range?.startDate, range?.endDate);
-    if (!validRange) return eventsByCalendar;
+  getEventCacheRetainedRange() {
+    const fetchRange = this.getEventFetchRange?.();
+    const validRange = this.getValidRange(fetchRange?.startDate, fetchRange?.endDate) || this.getValidRange(this._loadedEventRange?.startDate, this._loadedEventRange?.endDate);
+    if (!validRange) return null;
     const retainedStart = new Date(validRange.startDate);
     retainedStart.setDate(retainedStart.getDate() - 90);
     const retainedEnd = new Date(validRange.endDate);
     retainedEnd.setDate(retainedEnd.getDate() + 90);
+    return { startDate: retainedStart, endDate: retainedEnd };
+  }
+
+  getPrunedEventsByCalendarForCache(eventsByCalendar = {}, range = this.getEventCacheRetainedRange()) {
+    const retainedRange = this.getValidRange(range?.startDate, range?.endDate);
+    if (!retainedRange) return eventsByCalendar;
     const pruned = {};
     Object.entries(eventsByCalendar || {}).forEach(([entityId, events]) => {
       pruned[entityId] = (Array.isArray(events) ? events : []).filter((event) => {
@@ -2044,25 +2072,56 @@ class SkylightCalendarCard extends HTMLElement {
         const rawEnd = event?.end?.dateTime || event?.end?.date || event?.end;
         const eventEnd = rawEnd ? new Date(rawEnd) : eventStart;
         const safeEnd = Number.isFinite(eventEnd.getTime()) ? eventEnd : eventStart;
-        return eventStart <= retainedEnd && safeEnd >= retainedStart;
+        return eventStart <= retainedRange.endDate && safeEnd >= retainedRange.startDate;
       });
     });
     return pruned;
   }
 
+  getPrunedEventMetadataForCache(retainedRange = this.getEventCacheRetainedRange()) {
+    const range = this.getValidRange(retainedRange?.startDate, retainedRange?.endDate);
+    if (!range) return { perCalendarMetadata: {}, coveredRange: null };
+    const perCalendarMetadata = {};
+    let hasRetainedCalendar = false;
+    (this._config.entities || []).forEach((entityId) => {
+      const metadata = this._calendarEventMetadata[entityId] || {};
+      const metadataRange = this.getValidRange(metadata.range?.startDate, metadata.range?.endDate);
+      if (!metadataRange || !Number.isFinite(metadata.lastSuccessfulRefresh)) return;
+      const clippedStart = new Date(Math.max(metadataRange.startDate.getTime(), range.startDate.getTime()));
+      const clippedEnd = new Date(Math.min(metadataRange.endDate.getTime(), range.endDate.getTime()));
+      if (clippedStart > clippedEnd) return;
+      const clippedRange = { startDate: clippedStart, endDate: clippedEnd };
+      perCalendarMetadata[entityId] = {
+        ...metadata,
+        range: clippedRange,
+        lastSuccessfulRefresh: metadata.lastSuccessfulRefresh,
+        refreshFailed: false,
+        firstFailureAt: null
+      };
+      hasRetainedCalendar = true;
+    });
+    if (!hasRetainedCalendar) return { perCalendarMetadata, coveredRange: null };
+    return {
+      perCalendarMetadata,
+      coveredRange: range
+    };
+  }
+
   async persistEventCacheSnapshot({ generation = this._eventWriteGeneration } = {}) {
     if (generation !== this._eventWriteGeneration) return false;
-    if (!this._loadedEventRange || !Number.isFinite(this._lastSuccessfulEventRefresh)) return false;
     const configSignature = this.getEventCacheConfigSignature();
     if (!configSignature) return false;
     const cacheEpoch = getEventCacheMutationEpoch();
+    const retainedRange = this.getEventCacheRetainedRange();
+    const { perCalendarMetadata, coveredRange } = this.getPrunedEventMetadataForCache(retainedRange);
+    if (!coveredRange || !Number.isFinite(this._lastSuccessfulEventRefresh)) return false;
     const snapshot = createEventCacheSnapshot({
       configSignature,
-      startDate: this._loadedEventRange.startDate,
-      endDate: this._loadedEventRange.endDate,
-      eventsByCalendar: this.getPrunedEventsByCalendarForCache(this._eventsByCalendar, this._loadedEventRange),
+      startDate: coveredRange.startDate,
+      endDate: coveredRange.endDate,
+      eventsByCalendar: this.getPrunedEventsByCalendarForCache(this._eventsByCalendar, retainedRange),
       lastSuccessfulRefresh: this._lastSuccessfulEventRefresh,
-      perCalendarMetadata: this._calendarEventMetadata
+      perCalendarMetadata
     });
     if (!snapshot || generation !== this._eventWriteGeneration) return false;
     return writeEventCacheSnapshot(snapshot, { epoch: cacheEpoch });
@@ -2195,7 +2254,7 @@ class SkylightCalendarCard extends HTMLElement {
         requestId: generation
       });
       const warningVisibilityChanged = wasWarningVisible !== this.shouldShowEventRefreshWarning(now);
-      if (failedEntityIds.length === 0) this.persistEventCacheSnapshot({ generation: this._eventWriteGeneration });
+      this.persistEventCacheSnapshot({ generation: this._eventWriteGeneration });
       if (anyChanged || shouldRenderForUnchangedData || failedEntityIds.length > 0 || warningVisibilityChanged) {
         this._lastUnchangedDataRender = now;
         if (preserveScroll) {
@@ -2271,7 +2330,7 @@ class SkylightCalendarCard extends HTMLElement {
         requestId: generation,
         coverageMode: 'union'
       });
-      if (failedEntityIds.length === 0) this.persistEventCacheSnapshot({ generation: this._eventWriteGeneration });
+      this.persistEventCacheSnapshot({ generation: this._eventWriteGeneration });
       if ((render || failedEntityIds.length > 0) && (anyChanged || failedEntityIds.length > 0)) this.render();
       return failedEntityIds.length === 0;
     } finally {
@@ -2296,6 +2355,8 @@ class SkylightCalendarCard extends HTMLElement {
     if (this.isEventManagementDialogOpen() && (force || shouldRefreshForAge)) {
       return;
     }
+
+    if (this._fetching && !force) return;
 
     if (force || shouldRefreshForAge || !this._loadedEventRange) {
       const shouldPreserveScrollDuringRefresh = this._viewMode === 'agenda' && !force && !renderIfCovered;

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -374,9 +374,14 @@ class SkylightCalendarCard extends HTMLElement {
     this._events = [];
     this._eventsByCalendar = {};
     this._eventCacheGeneration = 0;
+    this._eventFetchGeneration = 0;
+    this._eventWriteGeneration = 0;
+    this._pendingEventRefreshAfterCurrentFetch = false;
+    this._eventRefreshWarningTimer = null;
     this._eventCacheHydrated = false;
     this._lastSuccessfulEventRefresh = null;
     this._lastEventRefreshFailed = false;
+    this._calendarEventMetadata = {};
     this._currentDate = new Date();
     this._viewMode = DEFAULT_VIEW; // 'month', 'week-compact', 'week-standard', or 'agenda'
     this._weekStart = new Date();
@@ -986,9 +991,14 @@ class SkylightCalendarCard extends HTMLElement {
     this._loadedEventRange = null;
     this._eventsByCalendar = {};
     this._eventCacheGeneration += 1;
+    this._eventFetchGeneration += 1;
+    this._eventWriteGeneration += 1;
+    this._pendingEventRefreshAfterCurrentFetch = false;
     this._eventCacheHydrated = false;
     this._lastSuccessfulEventRefresh = null;
     this._lastEventRefreshFailed = false;
+    this._calendarEventMetadata = {};
+    this.clearEventRefreshWarningTimer();
     this._calendarDataSignatures = {};
     this._lastUnchangedDataRender = null;
     this._weatherForecastController.handleConfigChanged(previousHeaderWeatherSensor, this._config.header_weather_sensor);
@@ -1064,6 +1074,7 @@ class SkylightCalendarCard extends HTMLElement {
 
     // Refresh only when stale or when current view needs dates outside loaded range.
     if (!oldHass) {
+      this.loadEventCacheForCurrentConfig();
       this.ensureEventsForCurrentRange({ force: true });
     } else {
       this.ensureEventsForCurrentRange();
@@ -1881,55 +1892,142 @@ class SkylightCalendarCard extends HTMLElement {
     return getCalendarDataSignatureHelper(events);
   }
 
+  getEventCacheUserScope() {
+    return this._hass?.user?.id || this._hass?.user?.name || this._hass?.auth?.data?.user?.id || null;
+  }
+
   getEventCacheConfigSignature() {
+    const userScope = this.getEventCacheUserScope();
+    if (!userScope) return null;
     return buildEventCacheConfigSignature({
       entities: this._config?.entities || [],
       timeZone: this.getConfiguredTimeZone(),
-      colors: this._config?.colors || {}
+      colors: this._config?.colors || {},
+      userScope
     });
   }
 
-  applyEventsByCalendar(eventsByCalendar = {}, { startDate, endDate, lastSuccessfulRefresh = null } = {}) {
-    const normalizedByCalendar = {};
-    (this._config.entities || []).forEach((entityId) => {
-      normalizedByCalendar[entityId] = Array.isArray(eventsByCalendar[entityId]) ? eventsByCalendar[entityId] : [];
-      this._calendarDataSignatures[entityId] = this.getCalendarDataSignature(normalizedByCalendar[entityId]);
+  getValidRange(startDate, endDate) {
+    const start = startDate instanceof Date ? startDate : new Date(startDate);
+    const end = endDate instanceof Date ? endDate : new Date(endDate);
+    if (!Number.isFinite(start.getTime()) || !Number.isFinite(end.getTime()) || start > end) return null;
+    return { startDate: start, endDate: end };
+  }
+
+  recomputeLoadedEventRange() {
+    const ranges = (this._config.entities || []).map((entityId) => {
+      const range = this._calendarEventMetadata[entityId]?.range;
+      return this.getValidRange(range?.startDate, range?.endDate);
     });
-    this._eventsByCalendar = normalizedByCalendar;
-    this._events = sortEventsByStartDateHelper(Object.values(normalizedByCalendar).flat(), {
+    if (ranges.length === 0 || ranges.some(range => !range)) {
+      this._loadedEventRange = null;
+      return;
+    }
+    const startDate = new Date(Math.max(...ranges.map(range => range.startDate.getTime())));
+    const endDate = new Date(Math.min(...ranges.map(range => range.endDate.getTime())));
+    this._loadedEventRange = startDate <= endDate ? { startDate, endDate } : null;
+  }
+
+  recomputeLastSuccessfulEventRefresh() {
+    const refreshTimes = (this._config.entities || [])
+      .map(entityId => this._calendarEventMetadata[entityId]?.lastSuccessfulRefresh)
+      .filter(Number.isFinite);
+    this._lastSuccessfulEventRefresh = refreshTimes.length ? Math.min(...refreshTimes) : null;
+  }
+
+  recomputeEventRefreshFailure() {
+    this._lastEventRefreshFailed = (this._config.entities || [])
+      .some(entityId => this._calendarEventMetadata[entityId]?.refreshFailed);
+  }
+
+  recomputeEventState() {
+    this._events = sortEventsByStartDateHelper(Object.values(this._eventsByCalendar).flat(), {
       getEventStartDate: this.getEventStartDate.bind(this)
     });
-    if (startDate && endDate) this._loadedEventRange = { startDate, endDate };
-    if (Number.isFinite(lastSuccessfulRefresh)) this._lastSuccessfulEventRefresh = lastSuccessfulRefresh;
+    this.recomputeLoadedEventRange();
+    this.recomputeLastSuccessfulEventRefresh();
+    this.recomputeEventRefreshFailure();
+    this.scheduleEventRefreshWarningTimer();
+  }
+
+  applyEventsByCalendar(eventsByCalendar = {}, { startDate, endDate, lastSuccessfulRefresh = null, successfulEntityIds = null, failedEntityIds = [], source = 'network', requestId = null } = {}) {
+    const range = this.getValidRange(startDate, endDate);
+    const successfulSet = successfulEntityIds ? new Set(successfulEntityIds) : new Set(this._config.entities || []);
+    const failedSet = new Set(failedEntityIds || []);
+    (this._config.entities || []).forEach((entityId) => {
+      const existingMetadata = this._calendarEventMetadata[entityId] || {};
+      if (!successfulSet.has(entityId)) {
+        this._calendarEventMetadata[entityId] = {
+          ...existingMetadata,
+          lastSuccessfulRefresh: existingMetadata.lastSuccessfulRefresh ?? this._lastSuccessfulEventRefresh,
+          refreshFailed: failedSet.has(entityId) || existingMetadata.refreshFailed
+        };
+        return;
+      }
+      if (source === 'cache' && existingMetadata.lastNetworkSuccessRequest && existingMetadata.lastNetworkSuccessRequest > requestId) return;
+      const events = Array.isArray(eventsByCalendar[entityId]) ? eventsByCalendar[entityId] : [];
+      this._eventsByCalendar[entityId] = events;
+      this._calendarDataSignatures[entityId] = this.getCalendarDataSignature(events);
+      this._calendarEventMetadata[entityId] = {
+        ...existingMetadata,
+        range: range || existingMetadata.range || null,
+        lastSuccessfulRefresh: Number.isFinite(lastSuccessfulRefresh) ? lastSuccessfulRefresh : existingMetadata.lastSuccessfulRefresh,
+        refreshFailed: false,
+        lastNetworkSuccessRequest: source === 'network' ? requestId : existingMetadata.lastNetworkSuccessRequest
+      };
+    });
+    this.recomputeEventState();
   }
 
   async loadEventCacheForCurrentConfig() {
     const generation = ++this._eventCacheGeneration;
+    const requestId = this._eventFetchGeneration;
     const configSignature = this.getEventCacheConfigSignature();
-    const snapshot = await readEventCacheSnapshot(configSignature);
-    if (generation !== this._eventCacheGeneration || !snapshot || this._lastSuccessfulEventRefresh) return;
+    if (!configSignature) return;
+    const { available, snapshot } = await readEventCacheSnapshot(configSignature);
+    if (generation !== this._eventCacheGeneration || !available || !snapshot) return;
+    const cacheEventsByCalendar = {};
+    const successfulEntityIds = [];
+    (this._config.entities || []).forEach((entityId) => {
+      const metadata = this._calendarEventMetadata[entityId] || {};
+      if (metadata.lastNetworkSuccessRequest && metadata.lastNetworkSuccessRequest > requestId) return;
+      cacheEventsByCalendar[entityId] = snapshot.eventsByCalendar[entityId] || [];
+      successfulEntityIds.push(entityId);
+    });
+    if (successfulEntityIds.length === 0) return;
     this._eventCacheHydrated = true;
-    this.applyEventsByCalendar(snapshot.eventsByCalendar, {
+    this.applyEventsByCalendar(cacheEventsByCalendar, {
       startDate: new Date(snapshot.coveredRange.start),
       endDate: new Date(snapshot.coveredRange.end),
-      lastSuccessfulRefresh: snapshot.lastSuccessfulRefresh
+      lastSuccessfulRefresh: snapshot.lastSuccessfulRefresh,
+      successfulEntityIds,
+      source: 'cache',
+      requestId
     });
     this.render();
   }
 
-  persistEventCacheSnapshot() {
-    if (!this._loadedEventRange) return;
+  async persistEventCacheSnapshot({ generation = this._eventWriteGeneration } = {}) {
+    if (!this._loadedEventRange || !Number.isFinite(this._lastSuccessfulEventRefresh)) return false;
+    const configSignature = this.getEventCacheConfigSignature();
+    if (!configSignature) return false;
     const snapshot = createEventCacheSnapshot({
-      configSignature: this.getEventCacheConfigSignature(),
+      configSignature,
       startDate: this._loadedEventRange.startDate,
       endDate: this._loadedEventRange.endDate,
       eventsByCalendar: this._eventsByCalendar,
-      lastSuccessfulRefresh: this._lastSuccessfulEventRefresh || Date.now()
+      lastSuccessfulRefresh: this._lastSuccessfulEventRefresh,
+      perCalendarMetadata: this._calendarEventMetadata
     });
-    writeEventCacheSnapshot(snapshot);
+    if (!snapshot) return false;
+    const persisted = await writeEventCacheSnapshot(snapshot);
+    return generation === this._eventWriteGeneration && persisted;
   }
 
   async flushEventCache({ refresh = true } = {}) {
+    this._eventCacheGeneration += 1;
+    this._eventFetchGeneration += 1;
+    this._eventWriteGeneration += 1;
     const cleared = await clearAllEventCacheSnapshots();
     this._eventCacheGeneration += 1;
     this._eventCacheHydrated = false;
@@ -1937,54 +2035,100 @@ class SkylightCalendarCard extends HTMLElement {
     this._events = [];
     this._loadedEventRange = null;
     this._calendarDataSignatures = {};
+    this._calendarEventMetadata = {};
     this._lastSuccessfulEventRefresh = null;
     this._lastEventRefreshFailed = false;
+    this.clearEventRefreshWarningTimer();
     this.render();
-    if (refresh && this._hass) this.ensureEventsForCurrentRange({ force: true });
+    if (refresh && this._hass) {
+      if (this._fetching) {
+        this._pendingEventRefreshAfterCurrentFetch = true;
+      } else {
+        await this.ensureEventsForCurrentRange({ force: true });
+      }
+    }
     return cleared;
   }
 
+  getOldestFailedEventRefreshTime() {
+    const failedTimes = (this._config.entities || [])
+      .map(entityId => this._calendarEventMetadata[entityId])
+      .filter(metadata => metadata?.refreshFailed && Number.isFinite(metadata.lastSuccessfulRefresh))
+      .map(metadata => metadata.lastSuccessfulRefresh);
+    return failedTimes.length ? Math.min(...failedTimes) : null;
+  }
+
+  clearEventRefreshWarningTimer() {
+    if (this._eventRefreshWarningTimer) clearTimeout(this._eventRefreshWarningTimer);
+    this._eventRefreshWarningTimer = null;
+  }
+
+  scheduleEventRefreshWarningTimer() {
+    this.clearEventRefreshWarningTimer();
+    const oldestFailedRefresh = this.getOldestFailedEventRefreshTime();
+    if (!Number.isFinite(oldestFailedRefresh)) return;
+    const delay = Math.max(0, oldestFailedRefresh + 30 * 60 * 1000 - Date.now());
+    this._eventRefreshWarningTimer = setTimeout(() => {
+      this._eventRefreshWarningTimer = null;
+      this.render();
+    }, delay);
+  }
+
   shouldShowEventRefreshWarning(now = Date.now()) {
-    return !!this._lastEventRefreshFailed && Number.isFinite(this._lastSuccessfulEventRefresh) &&
-      (now - this._lastSuccessfulEventRefresh) > 30 * 60 * 1000;
+    const oldestFailedRefresh = this.getOldestFailedEventRefreshTime();
+    return Number.isFinite(oldestFailedRefresh) && (now - oldestFailedRefresh) > 30 * 60 * 1000;
   }
 
   renderEventRefreshWarning() {
     if (!this.shouldShowEventRefreshWarning()) return '';
-    return `<div class="event-refresh-warning" role="status">${this.t('eventRefreshStaleWarning', { time: this.formatTime(new Date(this._lastSuccessfulEventRefresh)) })}</div>`;
+    const oldestFailedRefresh = this.getOldestFailedEventRefreshTime();
+    return `<div class="event-refresh-warning" role="status">${this.t('eventRefreshStaleWarning', { time: this.formatTime(new Date(oldestFailedRefresh)) })}</div>`;
   }
 
   async updateEvents({ preserveScroll = false } = {}) {
-    if (!this._hass || this._fetching) return;
+    if (!this._hass) return;
+    if (this._fetching) {
+      this._pendingEventRefreshAfterCurrentFetch = true;
+      return;
+    }
 
     const { startDate, endDate } = this.getEventFetchRange();
+    const generation = ++this._eventFetchGeneration;
     this._fetching = true;
     this._lastFetch = Date.now();
 
     try {
       const fetchResultsByCalendar = await this.fetchEventsByCalendarInRange(startDate, endDate);
+      if (generation !== this._eventFetchGeneration) return;
       const nextEventsByCalendar = { ...this._eventsByCalendar };
-      let anySuccess = false;
-      let anyFailure = false;
+      const successfulEntityIds = [];
+      const failedEntityIds = [];
       let anyChanged = false;
 
       this._config.entities.forEach(entityId => {
         const result = fetchResultsByCalendar[entityId];
         if (!result?.success) {
-          anyFailure = true;
+          failedEntityIds.push(entityId);
           return;
         }
-        anySuccess = true;
+        successfulEntityIds.push(entityId);
         const events = Array.isArray(result.events) ? result.events : [];
         const oldSignature = this._calendarDataSignatures[entityId];
         const newSignature = this.getCalendarDataSignature(events);
         if (oldSignature !== newSignature) anyChanged = true;
         nextEventsByCalendar[entityId] = events;
-        this._calendarDataSignatures[entityId] = newSignature;
       });
 
-      if (!anySuccess) {
-        this._lastEventRefreshFailed = true;
+      if (successfulEntityIds.length === 0) {
+        failedEntityIds.forEach((entityId) => {
+          const existingMetadata = this._calendarEventMetadata[entityId] || {};
+          this._calendarEventMetadata[entityId] = {
+            ...existingMetadata,
+            lastSuccessfulRefresh: existingMetadata.lastSuccessfulRefresh ?? this._lastSuccessfulEventRefresh,
+            refreshFailed: true
+          };
+        });
+        this.recomputeEventState();
         this.render();
         return;
       }
@@ -1992,12 +2136,17 @@ class SkylightCalendarCard extends HTMLElement {
       const now = Date.now();
       const shouldRenderForUnchangedData = !this._lastUnchangedDataRender ||
         (now - this._lastUnchangedDataRender >= 15 * 60 * 1000);
-      const refreshMetadata = { startDate, endDate };
-      if (!anyFailure) refreshMetadata.lastSuccessfulRefresh = now;
-      this.applyEventsByCalendar(nextEventsByCalendar, refreshMetadata);
-      this._lastEventRefreshFailed = anyFailure;
-      if (!anyFailure) this.persistEventCacheSnapshot();
-      if (anyChanged || shouldRenderForUnchangedData) {
+      this.applyEventsByCalendar(nextEventsByCalendar, {
+        startDate,
+        endDate,
+        lastSuccessfulRefresh: now,
+        successfulEntityIds,
+        failedEntityIds,
+        source: 'network',
+        requestId: generation
+      });
+      if (failedEntityIds.length === 0) this.persistEventCacheSnapshot({ generation: this._eventWriteGeneration });
+      if (anyChanged || shouldRenderForUnchangedData || failedEntityIds.length > 0) {
         this._lastUnchangedDataRender = now;
         if (preserveScroll) {
           this.renderPreservingAgendaScroll();
@@ -2007,28 +2156,77 @@ class SkylightCalendarCard extends HTMLElement {
       }
     } finally {
       this._fetching = false;
+      if (this._pendingEventRefreshAfterCurrentFetch) {
+        this._pendingEventRefreshAfterCurrentFetch = false;
+        this.ensureEventsForCurrentRange({ force: true });
+      }
     }
   }
 
   async extendEventsForRange(startDate, endDate, { render = true } = {}) {
-    if (!this._hass || this._fetching) return;
+    if (!this._hass) return;
+    if (this._fetching) {
+      this._pendingEventRefreshAfterCurrentFetch = true;
+      return false;
+    }
 
+    const generation = ++this._eventFetchGeneration;
     this._fetching = true;
     this._lastFetch = Date.now();
 
     try {
-      const additionalEvents = await this.fetchEventsInRange(startDate, endDate);
-      if (!additionalEvents) {
-        this._lastEventRefreshFailed = true;
+      const fetchResultsByCalendar = await this.fetchEventsByCalendarInRange(startDate, endDate);
+      if (generation !== this._eventFetchGeneration) return false;
+      const nextEventsByCalendar = { ...this._eventsByCalendar };
+      const successfulEntityIds = [];
+      const failedEntityIds = [];
+      let anyChanged = false;
+
+      this._config.entities.forEach(entityId => {
+        const result = fetchResultsByCalendar[entityId];
+        if (!result?.success) {
+          failedEntityIds.push(entityId);
+          return;
+        }
+        successfulEntityIds.push(entityId);
+        const mergedEvents = this.mergeEvents(this._eventsByCalendar[entityId] || [], result.events || []);
+        const oldSignature = this._calendarDataSignatures[entityId];
+        const newSignature = this.getCalendarDataSignature(mergedEvents);
+        if (oldSignature !== newSignature) anyChanged = true;
+        nextEventsByCalendar[entityId] = mergedEvents;
+      });
+
+      if (successfulEntityIds.length === 0) {
+        failedEntityIds.forEach((entityId) => {
+          const existingMetadata = this._calendarEventMetadata[entityId] || {};
+          this._calendarEventMetadata[entityId] = {
+            ...existingMetadata,
+            lastSuccessfulRefresh: existingMetadata.lastSuccessfulRefresh ?? this._lastSuccessfulEventRefresh,
+            refreshFailed: true
+          };
+        });
+        this.recomputeEventState();
         return false;
       }
-      this._lastEventRefreshFailed = false;
-      this._events = this.mergeEvents(this._events, additionalEvents);
-      if (render) {
-        this.render();
-      }
+
+      this.applyEventsByCalendar(nextEventsByCalendar, {
+        startDate,
+        endDate,
+        lastSuccessfulRefresh: Date.now(),
+        successfulEntityIds,
+        failedEntityIds,
+        source: 'network',
+        requestId: generation
+      });
+      if (failedEntityIds.length === 0) this.persistEventCacheSnapshot({ generation: this._eventWriteGeneration });
+      if (render && (anyChanged || failedEntityIds.length > 0)) this.render();
+      return failedEntityIds.length === 0;
     } finally {
       this._fetching = false;
+      if (this._pendingEventRefreshAfterCurrentFetch) {
+        this._pendingEventRefreshAfterCurrentFetch = false;
+        this.ensureEventsForCurrentRange({ force: true });
+      }
     }
   }
 
@@ -2080,17 +2278,13 @@ class SkylightCalendarCard extends HTMLElement {
       missingRanges.push({ startDate: missingEndStart, endDate });
     }
 
+    let allExtended = true;
     for (const range of missingRanges) {
       const extended = await this.extendEventsForRange(range.startDate, range.endDate, { render: false });
-      if (extended === false) return;
+      if (extended === false) allExtended = false;
     }
 
-    this._loadedEventRange = {
-      startDate: new Date(Math.min(this._loadedEventRange.startDate.getTime(), startDate.getTime())),
-      endDate: new Date(Math.max(this._loadedEventRange.endDate.getTime(), endDate.getTime()))
-    };
-
-    this.render();
+    if (allExtended) this.render();
   }
 
   getEventFetchRange() {
@@ -2250,6 +2444,9 @@ class SkylightCalendarCard extends HTMLElement {
     window.removeEventListener('resize', this._handleViewportResize);
     window.removeEventListener('daylight-calendar-card-flush-event-cache', this._handleEventCacheFlush);
     window.visualViewport?.removeEventListener('resize', this._handleViewportResize);
+    this._eventCacheGeneration += 1;
+    this._eventFetchGeneration += 1;
+    this.clearEventRefreshWarningTimer();
     this.cancelMonthCompactMeasurement();
     if (this._monthGridResizeObserver) {
       this._monthGridResizeObserver.disconnect();

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -151,6 +151,13 @@ import {
   toStableString as toStableStringHelper
 } from './events/event-fetcher.js';
 import { buildContinuousDaySpanLayout } from './events/continuous-day-span-layout.js';
+import {
+  buildEventCacheConfigSignature,
+  clearAllEventCacheSnapshots,
+  createEventCacheSnapshot,
+  readEventCacheSnapshot,
+  writeEventCacheSnapshot
+} from './events/event-cache.js';
 import { getMonthVisibleDateRange } from './views/month-view-model.js';
 import {
   getRollingDaysForView as getRollingDaysForViewModel,
@@ -365,6 +372,11 @@ class SkylightCalendarCard extends HTMLElement {
     this._root = this;
     this._config = {};
     this._events = [];
+    this._eventsByCalendar = {};
+    this._eventCacheGeneration = 0;
+    this._eventCacheHydrated = false;
+    this._lastSuccessfulEventRefresh = null;
+    this._lastEventRefreshFailed = false;
     this._currentDate = new Date();
     this._viewMode = DEFAULT_VIEW; // 'month', 'week-compact', 'week-standard', or 'agenda'
     this._weekStart = new Date();
@@ -442,6 +454,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._lastObservedHostSize = null;
     this._monthCompactMeasurementDirty = true;
     this._lastCompactMonthViewportHeight = null;
+    this._handleEventCacheFlush = () => this.flushEventCache({ refresh: true });
     this._handleViewportResize = () => {
       if (this.isEventManagementDialogOpen()) {
         return;
@@ -971,6 +984,11 @@ class SkylightCalendarCard extends HTMLElement {
     this._customEventColors = createEmptyCustomEventColors();
     this.loadPersistedPreferences();
     this._loadedEventRange = null;
+    this._eventsByCalendar = {};
+    this._eventCacheGeneration += 1;
+    this._eventCacheHydrated = false;
+    this._lastSuccessfulEventRefresh = null;
+    this._lastEventRefreshFailed = false;
     this._calendarDataSignatures = {};
     this._lastUnchangedDataRender = null;
     this._weatherForecastController.handleConfigChanged(previousHeaderWeatherSensor, this._config.header_weather_sensor);
@@ -979,6 +997,7 @@ class SkylightCalendarCard extends HTMLElement {
     this.resetAgendaWindowToToday();
     this.render();
     this._activeLanguage = language;
+    this.loadEventCacheForCurrentConfig();
   }
 
   set hass(hass) {
@@ -1789,8 +1808,9 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   async fetchEventsInRange(startDate, endDate) {
-    const eventsByCalendar = await this.fetchEventsByCalendarInRange(startDate, endDate);
-    return Object.values(eventsByCalendar).flat();
+    const resultsByCalendar = await this.fetchEventsByCalendarInRange(startDate, endDate);
+    if (Object.values(resultsByCalendar).some(result => !result?.success)) return null;
+    return Object.values(resultsByCalendar).flatMap(result => result.events || []);
   }
 
   async fetchEventsByCalendarInRange(startDate, endDate) {
@@ -1861,6 +1881,79 @@ class SkylightCalendarCard extends HTMLElement {
     return getCalendarDataSignatureHelper(events);
   }
 
+  getEventCacheConfigSignature() {
+    return buildEventCacheConfigSignature({
+      entities: this._config?.entities || [],
+      timeZone: this.getConfiguredTimeZone(),
+      colors: this._config?.colors || {}
+    });
+  }
+
+  applyEventsByCalendar(eventsByCalendar = {}, { startDate, endDate, lastSuccessfulRefresh = null } = {}) {
+    const normalizedByCalendar = {};
+    (this._config.entities || []).forEach((entityId) => {
+      normalizedByCalendar[entityId] = Array.isArray(eventsByCalendar[entityId]) ? eventsByCalendar[entityId] : [];
+      this._calendarDataSignatures[entityId] = this.getCalendarDataSignature(normalizedByCalendar[entityId]);
+    });
+    this._eventsByCalendar = normalizedByCalendar;
+    this._events = sortEventsByStartDateHelper(Object.values(normalizedByCalendar).flat(), {
+      getEventStartDate: this.getEventStartDate.bind(this)
+    });
+    if (startDate && endDate) this._loadedEventRange = { startDate, endDate };
+    if (Number.isFinite(lastSuccessfulRefresh)) this._lastSuccessfulEventRefresh = lastSuccessfulRefresh;
+  }
+
+  async loadEventCacheForCurrentConfig() {
+    const generation = ++this._eventCacheGeneration;
+    const configSignature = this.getEventCacheConfigSignature();
+    const snapshot = await readEventCacheSnapshot(configSignature);
+    if (generation !== this._eventCacheGeneration || !snapshot || this._lastSuccessfulEventRefresh) return;
+    this._eventCacheHydrated = true;
+    this.applyEventsByCalendar(snapshot.eventsByCalendar, {
+      startDate: new Date(snapshot.coveredRange.start),
+      endDate: new Date(snapshot.coveredRange.end),
+      lastSuccessfulRefresh: snapshot.lastSuccessfulRefresh
+    });
+    this.render();
+  }
+
+  persistEventCacheSnapshot() {
+    if (!this._loadedEventRange) return;
+    const snapshot = createEventCacheSnapshot({
+      configSignature: this.getEventCacheConfigSignature(),
+      startDate: this._loadedEventRange.startDate,
+      endDate: this._loadedEventRange.endDate,
+      eventsByCalendar: this._eventsByCalendar,
+      lastSuccessfulRefresh: this._lastSuccessfulEventRefresh || Date.now()
+    });
+    writeEventCacheSnapshot(snapshot);
+  }
+
+  async flushEventCache({ refresh = true } = {}) {
+    const cleared = await clearAllEventCacheSnapshots();
+    this._eventCacheGeneration += 1;
+    this._eventCacheHydrated = false;
+    this._eventsByCalendar = {};
+    this._events = [];
+    this._loadedEventRange = null;
+    this._calendarDataSignatures = {};
+    this._lastSuccessfulEventRefresh = null;
+    this._lastEventRefreshFailed = false;
+    this.render();
+    if (refresh && this._hass) this.ensureEventsForCurrentRange({ force: true });
+    return cleared;
+  }
+
+  shouldShowEventRefreshWarning(now = Date.now()) {
+    return !!this._lastEventRefreshFailed && Number.isFinite(this._lastSuccessfulEventRefresh) &&
+      (now - this._lastSuccessfulEventRefresh) > 30 * 60 * 1000;
+  }
+
+  renderEventRefreshWarning() {
+    if (!this.shouldShowEventRefreshWarning()) return '';
+    return `<div class="event-refresh-warning" role="status">${this.t('eventRefreshStaleWarning', { time: this.formatTime(new Date(this._lastSuccessfulEventRefresh)) })}</div>`;
+  }
+
   async updateEvents({ preserveScroll = false } = {}) {
     if (!this._hass || this._fetching) return;
 
@@ -1869,52 +1962,42 @@ class SkylightCalendarCard extends HTMLElement {
     this._lastFetch = Date.now();
 
     try {
-      const newEventsByCalendar = await this.fetchEventsByCalendarInRange(startDate, endDate);
-      const changedCalendars = this._config.entities.filter(entityId => {
-        const hasOldSignature = Object.prototype.hasOwnProperty.call(this._calendarDataSignatures, entityId);
-        if (!hasOldSignature) {
-          return true;
-        }
+      const fetchResultsByCalendar = await this.fetchEventsByCalendarInRange(startDate, endDate);
+      const nextEventsByCalendar = { ...this._eventsByCalendar };
+      let anySuccess = false;
+      let anyChanged = false;
 
+      this._config.entities.forEach(entityId => {
+        const result = fetchResultsByCalendar[entityId];
+        if (!result?.success) return;
+        anySuccess = true;
+        const events = Array.isArray(result.events) ? result.events : [];
         const oldSignature = this._calendarDataSignatures[entityId];
-        const newSignature = this.getCalendarDataSignature(newEventsByCalendar[entityId]);
-        return oldSignature !== newSignature;
+        const newSignature = this.getCalendarDataSignature(events);
+        if (oldSignature !== newSignature) anyChanged = true;
+        nextEventsByCalendar[entityId] = events;
+        this._calendarDataSignatures[entityId] = newSignature;
       });
 
-      if (changedCalendars.length === 0) {
-        this._loadedEventRange = { startDate, endDate };
-
-        const now = Date.now();
-        const shouldRenderForUnchangedData = !this._lastUnchangedDataRender ||
-          (now - this._lastUnchangedDataRender >= 15 * 60 * 1000);
-
-        if (shouldRenderForUnchangedData) {
-          this._lastUnchangedDataRender = now;
-          if (preserveScroll) {
-            this.renderPreservingAgendaScroll();
-          } else {
-            this.render();
-          }
-        }
-
+      if (!anySuccess) {
+        this._lastEventRefreshFailed = true;
+        this.render();
         return;
       }
 
-      this._config.entities.forEach(entityId => {
-        this._calendarDataSignatures[entityId] = this.getCalendarDataSignature(newEventsByCalendar[entityId]);
-      });
-
-      const mergedEvents = sortEventsByStartDateHelper(Object.values(newEventsByCalendar).flat(), {
-        getEventStartDate: this.getEventStartDate.bind(this)
-      });
-
-      this._events = mergedEvents;
-      this._loadedEventRange = { startDate, endDate };
-      this._lastUnchangedDataRender = Date.now();
-      if (preserveScroll) {
-        this.renderPreservingAgendaScroll();
-      } else {
-        this.render();
+      const now = Date.now();
+      const shouldRenderForUnchangedData = !this._lastUnchangedDataRender ||
+        (now - this._lastUnchangedDataRender >= 15 * 60 * 1000);
+      this.applyEventsByCalendar(nextEventsByCalendar, { startDate, endDate, lastSuccessfulRefresh: now });
+      this._lastEventRefreshFailed = false;
+      this.persistEventCacheSnapshot();
+      if (anyChanged || shouldRenderForUnchangedData) {
+        this._lastUnchangedDataRender = now;
+        if (preserveScroll) {
+          this.renderPreservingAgendaScroll();
+        } else {
+          this.render();
+        }
       }
     } finally {
       this._fetching = false;
@@ -1929,6 +2012,11 @@ class SkylightCalendarCard extends HTMLElement {
 
     try {
       const additionalEvents = await this.fetchEventsInRange(startDate, endDate);
+      if (!additionalEvents) {
+        this._lastEventRefreshFailed = true;
+        return false;
+      }
+      this._lastEventRefreshFailed = false;
       this._events = this.mergeEvents(this._events, additionalEvents);
       if (render) {
         this.render();
@@ -1987,7 +2075,8 @@ class SkylightCalendarCard extends HTMLElement {
     }
 
     for (const range of missingRanges) {
-      await this.extendEventsForRange(range.startDate, range.endDate, { render: false });
+      const extended = await this.extendEventsForRange(range.startDate, range.endDate, { render: false });
+      if (extended === false) return;
     }
 
     this._loadedEventRange = {
@@ -2144,6 +2233,7 @@ class SkylightCalendarCard extends HTMLElement {
   connectedCallback() {
     checkAndShowStaleResourceWarning();
     window.addEventListener('resize', this._handleViewportResize);
+    window.addEventListener('daylight-calendar-card-flush-event-cache', this._handleEventCacheFlush);
     window.visualViewport?.addEventListener('resize', this._handleViewportResize);
     this.attachSystemThemeListener();
     this.observeHostAndParentResize();
@@ -2152,6 +2242,7 @@ class SkylightCalendarCard extends HTMLElement {
 
   disconnectedCallback() {
     window.removeEventListener('resize', this._handleViewportResize);
+    window.removeEventListener('daylight-calendar-card-flush-event-cache', this._handleEventCacheFlush);
     window.visualViewport?.removeEventListener('resize', this._handleViewportResize);
     this.cancelMonthCompactMeasurement();
     if (this._monthGridResizeObserver) {
@@ -2918,6 +3009,7 @@ class SkylightCalendarCard extends HTMLElement {
 
       <div class="calendar-container ${this._isDarkMode ? 'dark-mode' : ''} ${hasCustomBackground ? 'custom-background' : ''} ${this._config.hide_year ? 'hide-year' : ''} ${this._config.agenda_compact_events ? 'agenda-compact-events' : ''}" style="${containerStyle}">
         ${this._config.hide_header ? '' : (this._config.compact_header ? this.renderCompactHeader() : this.renderStandardHeader())}
+        ${this.renderEventRefreshWarning()}
         <div class="calendar-body">
           ${this.renderCalendarView()}
         </div>

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -1968,8 +1968,7 @@ class SkylightCalendarCard extends HTMLElement {
     if (!event?.uid) return null;
     const recurrenceId = event.recurrence_id || event.recurring_event_id;
     if (recurrenceId) return `${entityId}|${event.uid}|${recurrenceId}`;
-    if (event.rrule) return null;
-    return `${entityId}|${event.uid}`;
+    return null;
   }
 
   reconcileEventsForFetchedRange(existingEvents = [], incomingEvents = [], fetchedRange = null) {

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -1926,12 +1926,58 @@ class SkylightCalendarCard extends HTMLElement {
     const incoming = this.getValidRange(incomingRange?.startDate, incomingRange?.endDate);
     if (!existing) return incoming;
     if (!incoming) return existing;
-    if (incoming.endDate < existing.startDate) return incoming;
-    if (incoming.startDate > existing.endDate) return incoming;
+    if (incoming.endDate < existing.startDate || incoming.startDate > existing.endDate) {
+      const disjointRanges = [
+        ...(Array.isArray(existingRange?.disjointRanges) ? existingRange.disjointRanges : [existing]),
+        incoming
+      ].map(range => ({
+        startDate: new Date(range.startDate),
+        endDate: new Date(range.endDate)
+      }));
+      return { ...existing, disjointRanges };
+    }
     return {
       startDate: new Date(Math.min(existing.startDate.getTime(), incoming.startDate.getTime())),
       endDate: new Date(Math.max(existing.endDate.getTime(), incoming.endDate.getTime()))
     };
+  }
+
+  doEventRangesOverlap(event, range) {
+    const validRange = this.getValidRange(range?.startDate, range?.endDate);
+    if (!validRange) return false;
+    const eventStart = this.getEventStartDate(event);
+    const eventEnd = this.getEventEndDate(event);
+    if (!Number.isFinite(eventStart.getTime()) || !Number.isFinite(eventEnd.getTime())) return false;
+    return eventStart <= validRange.endDate && eventEnd >= validRange.startDate;
+  }
+
+  isEventContainedInRange(event, range) {
+    const validRange = this.getValidRange(range?.startDate, range?.endDate);
+    if (!validRange) return false;
+    const eventStart = this.getEventStartDate(event);
+    const eventEnd = this.getEventEndDate(event);
+    if (!Number.isFinite(eventStart.getTime()) || !Number.isFinite(eventEnd.getTime())) return false;
+    return eventStart >= validRange.startDate && eventEnd <= validRange.endDate;
+  }
+
+  getEventLogicalIdentityKey(entityId, event) {
+    const stableId = event?.uid || event?.recurring_event_id;
+    return stableId ? `${entityId}|${stableId}` : this.getEventIdentityKey(entityId, event);
+  }
+
+  reconcileEventsForFetchedRange(existingEvents = [], incomingEvents = [], fetchedRange = null) {
+    const range = this.getValidRange(fetchedRange?.startDate, fetchedRange?.endDate);
+    if (!range) return this.mergeEvents(existingEvents, incomingEvents);
+    const incomingLogicalKeys = new Set(
+      (incomingEvents || []).map(event => this.getEventLogicalIdentityKey(event.entityId, event))
+    );
+    const retainedExisting = (existingEvents || []).filter((event) => {
+      const containedInAuthoritativeRange = this.isEventContainedInRange(event, range);
+      if (containedInAuthoritativeRange) return false;
+      const logicalKey = this.getEventLogicalIdentityKey(event.entityId, event);
+      return !(incomingLogicalKeys.has(logicalKey) && this.doEventRangesOverlap(event, range));
+    });
+    return this.mergeEvents(retainedExisting, incomingEvents);
   }
 
   recomputeLoadedEventRange() {
@@ -2067,7 +2113,9 @@ class SkylightCalendarCard extends HTMLElement {
   getEventCacheRetentionAnchorRange() {
     if (this._viewMode === 'agenda') {
       const agendaVisibleRange = this.getValidRange(this._agendaVisibleStartDate, this._agendaVisibleEndDate);
-      if (agendaVisibleRange) return agendaVisibleRange;
+      if (agendaVisibleRange && this.isAgendaRangeWithinCurrentWindow(agendaVisibleRange)) return agendaVisibleRange;
+      const agendaWindowRange = this.getValidRange(this._agendaStartDate, this._agendaEndDate);
+      if (agendaWindowRange) return agendaWindowRange;
       const fallbackStart = new Date(this._currentDate || Date.now());
       fallbackStart.setHours(0, 0, 0, 0);
       const fallbackEnd = new Date(fallbackStart);
@@ -2348,7 +2396,8 @@ class SkylightCalendarCard extends HTMLElement {
           return;
         }
         successfulEntityIds.push(entityId);
-        const mergedEvents = this.mergeEvents(this._eventsByCalendar[entityId] || [], result.events || []);
+        const fetchedRange = this.getValidRange(result.fetchedRange?.startDate, result.fetchedRange?.endDate) || { startDate, endDate };
+        const mergedEvents = this.reconcileEventsForFetchedRange(this._eventsByCalendar[entityId] || [], result.events || [], fetchedRange);
         const oldSignature = this._calendarDataSignatures[entityId];
         const newSignature = this.getCalendarDataSignature(mergedEvents);
         if (oldSignature !== newSignature) anyChanged = true;
@@ -2377,9 +2426,13 @@ class SkylightCalendarCard extends HTMLElement {
         return toResult(false, false, stateChanged);
       }
 
+      const successfulFetchedRange = successfulEntityIds
+        .map(entityId => fetchResultsByCalendar[entityId]?.fetchedRange)
+        .map(range => this.getValidRange(range?.startDate, range?.endDate))
+        .find(Boolean) || { startDate, endDate };
       this.applyEventsByCalendar(nextEventsByCalendar, {
-        startDate,
-        endDate,
+        startDate: successfulFetchedRange.startDate,
+        endDate: successfulFetchedRange.endDate,
         lastSuccessfulRefresh: Date.now(),
         successfulEntityIds,
         failedEntityIds,
@@ -5591,6 +5644,9 @@ class SkylightCalendarCard extends HTMLElement {
       this._agendaStartDate.setHours(0, 0, 0, 0);
       this._agendaEndDate.setDate(this._agendaEndDate.getDate() - backwardDays);
       this._agendaEndDate.setHours(23, 59, 59, 999);
+      this._currentDate = new Date(this._agendaStartDate);
+      this._agendaVisibleStartDate = new Date(this._agendaStartDate);
+      this._agendaVisibleEndDate = new Date(this._agendaEndDate);
     } else if (this._viewMode === 'month') {
       if (this._config.rolling_weeks !== null) {
         // In rolling weeks mode, go back by the number of weeks shown
@@ -5656,6 +5712,9 @@ class SkylightCalendarCard extends HTMLElement {
 
       this._agendaStartDate = targetStart;
       this._agendaEndDate = targetEnd;
+      this._currentDate = new Date(this._agendaStartDate);
+      this._agendaVisibleStartDate = new Date(this._agendaStartDate);
+      this._agendaVisibleEndDate = new Date(this._agendaEndDate);
     } else if (this._viewMode === 'month') {
       if (this._config.rolling_weeks !== null) {
         // In rolling weeks mode, go forward by the number of weeks shown

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -388,6 +388,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._viewMode = DEFAULT_VIEW; // 'month', 'week-compact', 'week-standard', or 'agenda'
     this._weekStart = new Date();
     this._fetching = false;
+    this._activeEventFetchRange = null;
     this._lastFetch = null;
     this._loadedEventRange = null;
     this._calendarDataSignatures = {}; // Track per-calendar data for change detection
@@ -2015,40 +2016,47 @@ class SkylightCalendarCard extends HTMLElement {
     if (!configSignature) return;
     const { available, snapshot } = await readEventCacheSnapshot(configSignature);
     if (generation !== this._eventCacheGeneration || !available || !snapshot) return;
+    const hydratable = this.getHydratableEventCacheSnapshotData(snapshot, requestId);
+    if (hydratable.successfulEntityIds.length === 0) return;
+    this._eventCacheHydrated = true;
+    this.applyEventsByCalendar(hydratable.eventsByCalendar, {
+      startDate: new Date(snapshot.coveredRange.start),
+      endDate: new Date(snapshot.coveredRange.end),
+      lastSuccessfulRefresh: snapshot.lastSuccessfulRefresh,
+      successfulEntityIds: hydratable.successfulEntityIds,
+      source: 'cache',
+      requestId,
+      perCalendarMetadata: hydratable.perCalendarMetadata
+    });
+    this.render();
+  }
+
+  getHydratableEventCacheSnapshotData(snapshot, requestId = this._eventFetchGeneration) {
     const cacheEventsByCalendar = {};
     const cacheMetadataByCalendar = {};
     const successfulEntityIds = [];
     (this._config.entities || []).forEach((entityId) => {
       const metadata = this._calendarEventMetadata[entityId] || {};
       if (metadata.lastNetworkSuccessRequest && metadata.lastNetworkSuccessRequest > requestId) return;
-      const cachedMetadata = snapshot.perCalendarMetadata?.[entityId] || {};
-      const cachedRange = this.getValidRange(
-        cachedMetadata.range?.startDate || snapshot.coveredRange.start,
-        cachedMetadata.range?.endDate || snapshot.coveredRange.end
-      );
-      const cachedLastSuccessfulRefresh = Number.isFinite(cachedMetadata.lastSuccessfulRefresh)
-        ? cachedMetadata.lastSuccessfulRefresh
-        : snapshot.lastSuccessfulRefresh;
+      if (!Object.prototype.hasOwnProperty.call(snapshot.perCalendarMetadata || {}, entityId)) return;
+      if (!Object.prototype.hasOwnProperty.call(snapshot.eventsByCalendar || {}, entityId)) return;
+      if (!Array.isArray(snapshot.eventsByCalendar[entityId])) return;
+      const cachedMetadata = snapshot.perCalendarMetadata[entityId] || {};
+      const cachedRange = this.getValidRange(cachedMetadata.range?.startDate, cachedMetadata.range?.endDate);
+      const cachedLastSuccessfulRefresh = cachedMetadata.lastSuccessfulRefresh;
       if (!cachedRange || !Number.isFinite(cachedLastSuccessfulRefresh)) return;
-      cacheEventsByCalendar[entityId] = snapshot.eventsByCalendar[entityId] || [];
+      cacheEventsByCalendar[entityId] = snapshot.eventsByCalendar[entityId];
       cacheMetadataByCalendar[entityId] = {
         range: cachedRange,
         lastSuccessfulRefresh: cachedLastSuccessfulRefresh
       };
       successfulEntityIds.push(entityId);
     });
-    if (successfulEntityIds.length === 0) return;
-    this._eventCacheHydrated = true;
-    this.applyEventsByCalendar(cacheEventsByCalendar, {
-      startDate: new Date(snapshot.coveredRange.start),
-      endDate: new Date(snapshot.coveredRange.end),
-      lastSuccessfulRefresh: snapshot.lastSuccessfulRefresh,
-      successfulEntityIds,
-      source: 'cache',
-      requestId,
-      perCalendarMetadata: cacheMetadataByCalendar
-    });
-    this.render();
+    return {
+      eventsByCalendar: cacheEventsByCalendar,
+      perCalendarMetadata: cacheMetadataByCalendar,
+      successfulEntityIds
+    };
   }
 
   getEventCacheRetainedRange() {
@@ -2115,11 +2123,17 @@ class SkylightCalendarCard extends HTMLElement {
     const retainedRange = this.getEventCacheRetainedRange();
     const { perCalendarMetadata, coveredRange } = this.getPrunedEventMetadataForCache(retainedRange);
     if (!coveredRange || !Number.isFinite(this._lastSuccessfulEventRefresh)) return false;
+    const persistedEventsByCalendar = {};
+    Object.keys(perCalendarMetadata).forEach((entityId) => {
+      if (Object.prototype.hasOwnProperty.call(this._eventsByCalendar, entityId)) {
+        persistedEventsByCalendar[entityId] = this.getPrunedEventsByCalendarForCache({ [entityId]: this._eventsByCalendar[entityId] }, retainedRange)[entityId] || [];
+      }
+    });
     const snapshot = createEventCacheSnapshot({
       configSignature,
       startDate: coveredRange.startDate,
       endDate: coveredRange.endDate,
-      eventsByCalendar: this.getPrunedEventsByCalendarForCache(this._eventsByCalendar, retainedRange),
+      eventsByCalendar: persistedEventsByCalendar,
       lastSuccessfulRefresh: this._lastSuccessfulEventRefresh,
       perCalendarMetadata
     });
@@ -2200,6 +2214,7 @@ class SkylightCalendarCard extends HTMLElement {
     const { startDate, endDate } = this.getEventFetchRange();
     const generation = ++this._eventFetchGeneration;
     this._fetching = true;
+    this._activeEventFetchRange = { startDate, endDate };
     this._lastFetch = Date.now();
 
     try {
@@ -2265,6 +2280,7 @@ class SkylightCalendarCard extends HTMLElement {
       }
     } finally {
       this._fetching = false;
+      this._activeEventFetchRange = null;
       if (this._pendingEventRefreshAfterCurrentFetch) {
         this._pendingEventRefreshAfterCurrentFetch = false;
         this.ensureEventsForCurrentRange({ force: true });
@@ -2281,6 +2297,7 @@ class SkylightCalendarCard extends HTMLElement {
 
     const generation = ++this._eventFetchGeneration;
     this._fetching = true;
+    this._activeEventFetchRange = { startDate, endDate };
     this._lastFetch = Date.now();
 
     try {
@@ -2335,6 +2352,7 @@ class SkylightCalendarCard extends HTMLElement {
       return failedEntityIds.length === 0;
     } finally {
       this._fetching = false;
+      this._activeEventFetchRange = null;
       if (this._pendingEventRefreshAfterCurrentFetch) {
         this._pendingEventRefreshAfterCurrentFetch = false;
         this.ensureEventsForCurrentRange({ force: true });
@@ -2356,7 +2374,19 @@ class SkylightCalendarCard extends HTMLElement {
       return;
     }
 
-    if (this._fetching && !force) return;
+    const { startDate, endDate } = this.getEventFetchRange();
+
+    if (this._fetching) {
+      if (this.isDateRangeCoveredByLoadedEvents(visibleStartDate, visibleEndDate)) {
+        if (renderIfCovered) this.render();
+        return;
+      }
+      const activeRange = this.getValidRange(this._activeEventFetchRange?.startDate, this._activeEventFetchRange?.endDate);
+      if (force || !activeRange || !isDateRangeCoveredByLoadedEventsHelper(activeRange, startDate, endDate)) {
+        this._pendingEventRefreshAfterCurrentFetch = true;
+      }
+      return;
+    }
 
     if (force || shouldRefreshForAge || !this._loadedEventRange) {
       const shouldPreserveScrollDuringRefresh = this._viewMode === 'agenda' && !force && !renderIfCovered;
@@ -2375,7 +2405,6 @@ class SkylightCalendarCard extends HTMLElement {
 
     // Once visible range falls outside loaded coverage, fetch around current view
     // (with buffer) and only request missing leading/trailing segments.
-    const { startDate, endDate } = this.getEventFetchRange();
     const missingRanges = [];
 
     if (startDate < this._loadedEventRange.startDate) {

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -152,9 +152,11 @@ import {
 } from './events/event-fetcher.js';
 import { buildContinuousDaySpanLayout } from './events/continuous-day-span-layout.js';
 import {
+  beginEventCacheFlush,
   buildEventCacheConfigSignature,
   clearAllEventCacheSnapshots,
   createEventCacheSnapshot,
+  getEventCacheMutationEpoch,
   readEventCacheSnapshot,
   writeEventCacheSnapshot
 } from './events/event-cache.js';
@@ -377,7 +379,6 @@ class SkylightCalendarCard extends HTMLElement {
     this._eventFetchGeneration = 0;
     this._eventWriteGeneration = 0;
     this._pendingEventRefreshAfterCurrentFetch = false;
-    this._eventCacheMutationQueue = Promise.resolve();
     this._eventRefreshWarningTimer = null;
     this._eventCacheHydrated = false;
     this._lastSuccessfulEventRefresh = null;
@@ -1002,6 +1003,7 @@ class SkylightCalendarCard extends HTMLElement {
     this.clearEventRefreshWarningTimer();
     this._calendarDataSignatures = {};
     this._lastUnchangedDataRender = null;
+    this._lastFetch = null;
     this._weatherForecastController.handleConfigChanged(previousHeaderWeatherSensor, this._config.header_weather_sensor);
     this.ensureWeatherForecastSubscription();
     this.setWeekStart();
@@ -1009,6 +1011,7 @@ class SkylightCalendarCard extends HTMLElement {
     this.render();
     this._activeLanguage = language;
     this.loadEventCacheForCurrentConfig();
+    if (this._hass) this.ensureEventsForCurrentRange({ force: true });
   }
 
   set hass(hass) {
@@ -1925,12 +1928,6 @@ class SkylightCalendarCard extends HTMLElement {
     };
   }
 
-  queueEventCacheMutation(callback) {
-    const run = this._eventCacheMutationQueue.then(callback, callback);
-    this._eventCacheMutationQueue = run.catch(() => {});
-    return run;
-  }
-
   recomputeLoadedEventRange() {
     const ranges = (this._config.entities || []).map((entityId) => {
       const range = this._calendarEventMetadata[entityId]?.range;
@@ -1977,7 +1974,7 @@ class SkylightCalendarCard extends HTMLElement {
         const isFailure = failedSet.has(entityId);
         this._calendarEventMetadata[entityId] = {
           ...existingMetadata,
-          lastSuccessfulRefresh: existingMetadata.lastSuccessfulRefresh ?? this._lastSuccessfulEventRefresh,
+          lastSuccessfulRefresh: existingMetadata.lastSuccessfulRefresh,
           refreshFailed: isFailure || existingMetadata.refreshFailed,
           firstFailureAt: isFailure ? (existingMetadata.firstFailureAt ?? Date.now()) : existingMetadata.firstFailureAt,
           lastNetworkFailureRequest: isFailure && source === 'network' ? requestId : existingMetadata.lastNetworkFailureRequest
@@ -2033,34 +2030,50 @@ class SkylightCalendarCard extends HTMLElement {
     this.render();
   }
 
-  async persistEventCacheSnapshot({ generation = this._eventWriteGeneration } = {}) {
-    return this.queueEventCacheMutation(async () => {
-      if (generation !== this._eventWriteGeneration) return false;
-      if (!this._loadedEventRange || !Number.isFinite(this._lastSuccessfulEventRefresh)) return false;
-      const configSignature = this.getEventCacheConfigSignature();
-      if (!configSignature) return false;
-      const snapshot = createEventCacheSnapshot({
-        configSignature,
-        startDate: this._loadedEventRange.startDate,
-        endDate: this._loadedEventRange.endDate,
-        eventsByCalendar: this._eventsByCalendar,
-        lastSuccessfulRefresh: this._lastSuccessfulEventRefresh,
-        perCalendarMetadata: this._calendarEventMetadata
+  getPrunedEventsByCalendarForCache(eventsByCalendar = {}, range = this._loadedEventRange) {
+    const validRange = this.getValidRange(range?.startDate, range?.endDate);
+    if (!validRange) return eventsByCalendar;
+    const retainedStart = new Date(validRange.startDate);
+    retainedStart.setDate(retainedStart.getDate() - 90);
+    const retainedEnd = new Date(validRange.endDate);
+    retainedEnd.setDate(retainedEnd.getDate() + 90);
+    const pruned = {};
+    Object.entries(eventsByCalendar || {}).forEach(([entityId, events]) => {
+      pruned[entityId] = (Array.isArray(events) ? events : []).filter((event) => {
+        const eventStart = this.getEventStartDate(event);
+        const rawEnd = event?.end?.dateTime || event?.end?.date || event?.end;
+        const eventEnd = rawEnd ? new Date(rawEnd) : eventStart;
+        const safeEnd = Number.isFinite(eventEnd.getTime()) ? eventEnd : eventStart;
+        return eventStart <= retainedEnd && safeEnd >= retainedStart;
       });
-      if (!snapshot || generation !== this._eventWriteGeneration) return false;
-      return writeEventCacheSnapshot(snapshot);
     });
+    return pruned;
+  }
+
+  async persistEventCacheSnapshot({ generation = this._eventWriteGeneration } = {}) {
+    if (generation !== this._eventWriteGeneration) return false;
+    if (!this._loadedEventRange || !Number.isFinite(this._lastSuccessfulEventRefresh)) return false;
+    const configSignature = this.getEventCacheConfigSignature();
+    if (!configSignature) return false;
+    const cacheEpoch = getEventCacheMutationEpoch();
+    const snapshot = createEventCacheSnapshot({
+      configSignature,
+      startDate: this._loadedEventRange.startDate,
+      endDate: this._loadedEventRange.endDate,
+      eventsByCalendar: this.getPrunedEventsByCalendarForCache(this._eventsByCalendar, this._loadedEventRange),
+      lastSuccessfulRefresh: this._lastSuccessfulEventRefresh,
+      perCalendarMetadata: this._calendarEventMetadata
+    });
+    if (!snapshot || generation !== this._eventWriteGeneration) return false;
+    return writeEventCacheSnapshot(snapshot, { epoch: cacheEpoch });
   }
 
   async flushEventCache({ refresh = true } = {}) {
     this._eventCacheGeneration += 1;
     this._eventFetchGeneration += 1;
     this._eventWriteGeneration += 1;
-    const clearGeneration = this._eventWriteGeneration;
-    const cleared = await this.queueEventCacheMutation(async () => {
-      if (clearGeneration !== this._eventWriteGeneration) return false;
-      return clearAllEventCacheSnapshots();
-    });
+    const clearEpoch = beginEventCacheFlush();
+    const cleared = await clearAllEventCacheSnapshots({ epoch: clearEpoch });
     this._eventCacheGeneration += 1;
     this._eventCacheHydrated = false;
     this._eventsByCalendar = {};
@@ -2109,7 +2122,7 @@ class SkylightCalendarCard extends HTMLElement {
 
   shouldShowEventRefreshWarning(now = Date.now()) {
     const oldestFailedRefresh = this.getOldestFailedEventRefreshTime();
-    return Number.isFinite(oldestFailedRefresh) && (now - oldestFailedRefresh) > 30 * 60 * 1000;
+    return Number.isFinite(oldestFailedRefresh) && (now - oldestFailedRefresh) >= 30 * 60 * 1000;
   }
 
   renderEventRefreshWarning() {
@@ -2157,7 +2170,7 @@ class SkylightCalendarCard extends HTMLElement {
           const existingMetadata = this._calendarEventMetadata[entityId] || {};
           this._calendarEventMetadata[entityId] = {
             ...existingMetadata,
-            lastSuccessfulRefresh: existingMetadata.lastSuccessfulRefresh ?? this._lastSuccessfulEventRefresh,
+            lastSuccessfulRefresh: existingMetadata.lastSuccessfulRefresh,
             refreshFailed: true,
             firstFailureAt: existingMetadata.firstFailureAt ?? Date.now(),
             lastNetworkFailureRequest: generation
@@ -2238,7 +2251,7 @@ class SkylightCalendarCard extends HTMLElement {
           const existingMetadata = this._calendarEventMetadata[entityId] || {};
           this._calendarEventMetadata[entityId] = {
             ...existingMetadata,
-            lastSuccessfulRefresh: existingMetadata.lastSuccessfulRefresh ?? this._lastSuccessfulEventRefresh,
+            lastSuccessfulRefresh: existingMetadata.lastSuccessfulRefresh,
             refreshFailed: true,
             firstFailureAt: existingMetadata.firstFailureAt ?? Date.now(),
             lastNetworkFailureRequest: generation

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -1965,11 +1965,15 @@ class SkylightCalendarCard extends HTMLElement {
       const fetchResultsByCalendar = await this.fetchEventsByCalendarInRange(startDate, endDate);
       const nextEventsByCalendar = { ...this._eventsByCalendar };
       let anySuccess = false;
+      let anyFailure = false;
       let anyChanged = false;
 
       this._config.entities.forEach(entityId => {
         const result = fetchResultsByCalendar[entityId];
-        if (!result?.success) return;
+        if (!result?.success) {
+          anyFailure = true;
+          return;
+        }
         anySuccess = true;
         const events = Array.isArray(result.events) ? result.events : [];
         const oldSignature = this._calendarDataSignatures[entityId];
@@ -1988,9 +1992,11 @@ class SkylightCalendarCard extends HTMLElement {
       const now = Date.now();
       const shouldRenderForUnchangedData = !this._lastUnchangedDataRender ||
         (now - this._lastUnchangedDataRender >= 15 * 60 * 1000);
-      this.applyEventsByCalendar(nextEventsByCalendar, { startDate, endDate, lastSuccessfulRefresh: now });
-      this._lastEventRefreshFailed = false;
-      this.persistEventCacheSnapshot();
+      const refreshMetadata = { startDate, endDate };
+      if (!anyFailure) refreshMetadata.lastSuccessfulRefresh = now;
+      this.applyEventsByCalendar(nextEventsByCalendar, refreshMetadata);
+      this._lastEventRefreshFailed = anyFailure;
+      if (!anyFailure) this.persistEventCacheSnapshot();
       if (anyChanged || shouldRenderForUnchangedData) {
         this._lastUnchangedDataRender = now;
         if (preserveScroll) {

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -1961,12 +1961,11 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   getEventLogicalIdentityKey(entityId, event) {
-    const uid = event?.uid;
-    const recurrenceId = event?.recurrence_id || event?.recurring_event_id;
-    if (uid && recurrenceId) return `${entityId}|${uid}|${recurrenceId}`;
-    if (uid) return `${entityId}|${uid}`;
-    if (recurrenceId) return `${entityId}|recurrence|${recurrenceId}`;
     return this.getEventIdentityKey(entityId, event);
+  }
+
+  getStableEventIdentityKey(entityId, event) {
+    return event?.uid ? this.getEventIdentityKey(entityId, event) : null;
   }
 
   reconcileEventsForFetchedRange(existingEvents = [], incomingEvents = [], fetchedRange = null) {
@@ -1975,7 +1974,14 @@ class SkylightCalendarCard extends HTMLElement {
     const incomingLogicalKeys = new Set(
       (incomingEvents || []).map(event => this.getEventLogicalIdentityKey(event.entityId, event))
     );
+    const incomingStableKeys = new Set(
+      (incomingEvents || [])
+        .map(event => this.getStableEventIdentityKey(event.entityId, event))
+        .filter(Boolean)
+    );
     const retainedExisting = (existingEvents || []).filter((event) => {
+      const stableKey = this.getStableEventIdentityKey(event.entityId, event);
+      if (stableKey && incomingStableKeys.has(stableKey)) return false;
       const containedInAuthoritativeRange = this.isEventContainedInRange(event, range);
       if (containedInAuthoritativeRange) return false;
       const logicalKey = this.getEventLogicalIdentityKey(event.entityId, event);

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -2061,12 +2061,24 @@ class SkylightCalendarCard extends HTMLElement {
     };
   }
 
-  getEventCacheRetainedRange() {
-    const fetchRange = this.getEventFetchRange?.();
+  getEventCacheRetentionAnchorRange() {
+    if (this._viewMode === 'agenda') {
+      const agendaVisibleRange = this.getValidRange(this._agendaVisibleStartDate, this._agendaVisibleEndDate);
+      if (agendaVisibleRange) return agendaVisibleRange;
+      const fallbackStart = new Date(this._currentDate || Date.now());
+      fallbackStart.setHours(0, 0, 0, 0);
+      const fallbackEnd = new Date(fallbackStart);
+      fallbackEnd.setDate(fallbackEnd.getDate() + 14);
+      fallbackEnd.setHours(23, 59, 59, 999);
+      return this.getValidRange(fallbackStart, fallbackEnd);
+    }
     const visibleRange = this.getVisibleDateRange?.();
-    const validRange = this.getValidRange(fetchRange?.startDate, fetchRange?.endDate) ||
-      this.getValidRange(visibleRange?.startDate, visibleRange?.endDate) ||
+    return this.getValidRange(visibleRange?.startDate, visibleRange?.endDate) ||
       this.getValidRange(this._loadedEventRange?.startDate, this._loadedEventRange?.endDate);
+  }
+
+  getEventCacheRetainedRange() {
+    const validRange = this.getEventCacheRetentionAnchorRange();
     if (!validRange) return null;
     const maxSpanMs = MAX_PERSISTED_EVENT_CACHE_SPAN_DAYS * 24 * 60 * 60 * 1000;
     const rangeSpanMs = validRange.endDate.getTime() - validRange.startDate.getTime();
@@ -2392,12 +2404,17 @@ class SkylightCalendarCard extends HTMLElement {
     const { startDate, endDate } = this.getEventFetchRange();
 
     if (this._fetching) {
+      if (force) {
+        this._pendingEventRefreshAfterCurrentFetch = true;
+        if (renderIfCovered) this._pendingEventRenderAfterCurrentFetch = true;
+        return;
+      }
       if (this.isDateRangeCoveredByLoadedEvents(visibleStartDate, visibleEndDate)) {
         if (renderIfCovered) this.render();
         return;
       }
       const activeRange = this.getValidRange(this._activeEventFetchRange?.startDate, this._activeEventFetchRange?.endDate);
-      if (force || !activeRange || !isDateRangeCoveredByLoadedEventsHelper(activeRange, startDate, endDate)) {
+      if (!activeRange || !isDateRangeCoveredByLoadedEventsHelper(activeRange, startDate, endDate)) {
         this._pendingEventRefreshAfterCurrentFetch = true;
         if (renderIfCovered) this._pendingEventRenderAfterCurrentFetch = true;
       } else if (renderIfCovered) {

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -377,6 +377,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._eventFetchGeneration = 0;
     this._eventWriteGeneration = 0;
     this._pendingEventRefreshAfterCurrentFetch = false;
+    this._eventCacheMutationQueue = Promise.resolve();
     this._eventRefreshWarningTimer = null;
     this._eventCacheHydrated = false;
     this._lastSuccessfulEventRefresh = null;
@@ -1914,6 +1915,22 @@ class SkylightCalendarCard extends HTMLElement {
     return { startDate: start, endDate: end };
   }
 
+  unionEventRanges(existingRange, incomingRange) {
+    const existing = this.getValidRange(existingRange?.startDate, existingRange?.endDate);
+    if (!existing) return incomingRange;
+    if (!incomingRange) return existing;
+    return {
+      startDate: new Date(Math.min(existing.startDate.getTime(), incomingRange.startDate.getTime())),
+      endDate: new Date(Math.max(existing.endDate.getTime(), incomingRange.endDate.getTime()))
+    };
+  }
+
+  queueEventCacheMutation(callback) {
+    const run = this._eventCacheMutationQueue.then(callback, callback);
+    this._eventCacheMutationQueue = run.catch(() => {});
+    return run;
+  }
+
   recomputeLoadedEventRange() {
     const ranges = (this._config.entities || []).map((entityId) => {
       const range = this._calendarEventMetadata[entityId]?.range;
@@ -1950,29 +1967,38 @@ class SkylightCalendarCard extends HTMLElement {
     this.scheduleEventRefreshWarningTimer();
   }
 
-  applyEventsByCalendar(eventsByCalendar = {}, { startDate, endDate, lastSuccessfulRefresh = null, successfulEntityIds = null, failedEntityIds = [], source = 'network', requestId = null } = {}) {
+  applyEventsByCalendar(eventsByCalendar = {}, { startDate, endDate, lastSuccessfulRefresh = null, successfulEntityIds = null, failedEntityIds = [], source = 'network', requestId = null, coverageMode = 'replace' } = {}) {
     const range = this.getValidRange(startDate, endDate);
     const successfulSet = successfulEntityIds ? new Set(successfulEntityIds) : new Set(this._config.entities || []);
     const failedSet = new Set(failedEntityIds || []);
     (this._config.entities || []).forEach((entityId) => {
       const existingMetadata = this._calendarEventMetadata[entityId] || {};
       if (!successfulSet.has(entityId)) {
+        const isFailure = failedSet.has(entityId);
         this._calendarEventMetadata[entityId] = {
           ...existingMetadata,
           lastSuccessfulRefresh: existingMetadata.lastSuccessfulRefresh ?? this._lastSuccessfulEventRefresh,
-          refreshFailed: failedSet.has(entityId) || existingMetadata.refreshFailed
+          refreshFailed: isFailure || existingMetadata.refreshFailed,
+          firstFailureAt: isFailure ? (existingMetadata.firstFailureAt ?? Date.now()) : existingMetadata.firstFailureAt,
+          lastNetworkFailureRequest: isFailure && source === 'network' ? requestId : existingMetadata.lastNetworkFailureRequest
         };
         return;
       }
-      if (source === 'cache' && existingMetadata.lastNetworkSuccessRequest && existingMetadata.lastNetworkSuccessRequest > requestId) return;
+      const hasNewerNetworkSuccess = existingMetadata.lastNetworkSuccessRequest && existingMetadata.lastNetworkSuccessRequest > requestId;
+      if (source === 'cache' && hasNewerNetworkSuccess) return;
+      const hasNewerNetworkFailure = source === 'cache' && existingMetadata.lastNetworkFailureRequest && existingMetadata.lastNetworkFailureRequest > requestId;
       const events = Array.isArray(eventsByCalendar[entityId]) ? eventsByCalendar[entityId] : [];
       this._eventsByCalendar[entityId] = events;
       this._calendarDataSignatures[entityId] = this.getCalendarDataSignature(events);
+      const nextRange = coverageMode === 'union'
+        ? this.unionEventRanges(existingMetadata.range, range)
+        : (range || existingMetadata.range || null);
       this._calendarEventMetadata[entityId] = {
         ...existingMetadata,
-        range: range || existingMetadata.range || null,
+        range: nextRange,
         lastSuccessfulRefresh: Number.isFinite(lastSuccessfulRefresh) ? lastSuccessfulRefresh : existingMetadata.lastSuccessfulRefresh,
-        refreshFailed: false,
+        refreshFailed: hasNewerNetworkFailure ? existingMetadata.refreshFailed : false,
+        firstFailureAt: hasNewerNetworkFailure ? existingMetadata.firstFailureAt : null,
         lastNetworkSuccessRequest: source === 'network' ? requestId : existingMetadata.lastNetworkSuccessRequest
       };
     });
@@ -2008,27 +2034,33 @@ class SkylightCalendarCard extends HTMLElement {
   }
 
   async persistEventCacheSnapshot({ generation = this._eventWriteGeneration } = {}) {
-    if (!this._loadedEventRange || !Number.isFinite(this._lastSuccessfulEventRefresh)) return false;
-    const configSignature = this.getEventCacheConfigSignature();
-    if (!configSignature) return false;
-    const snapshot = createEventCacheSnapshot({
-      configSignature,
-      startDate: this._loadedEventRange.startDate,
-      endDate: this._loadedEventRange.endDate,
-      eventsByCalendar: this._eventsByCalendar,
-      lastSuccessfulRefresh: this._lastSuccessfulEventRefresh,
-      perCalendarMetadata: this._calendarEventMetadata
+    return this.queueEventCacheMutation(async () => {
+      if (generation !== this._eventWriteGeneration) return false;
+      if (!this._loadedEventRange || !Number.isFinite(this._lastSuccessfulEventRefresh)) return false;
+      const configSignature = this.getEventCacheConfigSignature();
+      if (!configSignature) return false;
+      const snapshot = createEventCacheSnapshot({
+        configSignature,
+        startDate: this._loadedEventRange.startDate,
+        endDate: this._loadedEventRange.endDate,
+        eventsByCalendar: this._eventsByCalendar,
+        lastSuccessfulRefresh: this._lastSuccessfulEventRefresh,
+        perCalendarMetadata: this._calendarEventMetadata
+      });
+      if (!snapshot || generation !== this._eventWriteGeneration) return false;
+      return writeEventCacheSnapshot(snapshot);
     });
-    if (!snapshot) return false;
-    const persisted = await writeEventCacheSnapshot(snapshot);
-    return generation === this._eventWriteGeneration && persisted;
   }
 
   async flushEventCache({ refresh = true } = {}) {
     this._eventCacheGeneration += 1;
     this._eventFetchGeneration += 1;
     this._eventWriteGeneration += 1;
-    const cleared = await clearAllEventCacheSnapshots();
+    const clearGeneration = this._eventWriteGeneration;
+    const cleared = await this.queueEventCacheMutation(async () => {
+      if (clearGeneration !== this._eventWriteGeneration) return false;
+      return clearAllEventCacheSnapshots();
+    });
     this._eventCacheGeneration += 1;
     this._eventCacheHydrated = false;
     this._eventsByCalendar = {};
@@ -2053,8 +2085,8 @@ class SkylightCalendarCard extends HTMLElement {
   getOldestFailedEventRefreshTime() {
     const failedTimes = (this._config.entities || [])
       .map(entityId => this._calendarEventMetadata[entityId])
-      .filter(metadata => metadata?.refreshFailed && Number.isFinite(metadata.lastSuccessfulRefresh))
-      .map(metadata => metadata.lastSuccessfulRefresh);
+      .filter(metadata => metadata?.refreshFailed && (Number.isFinite(metadata.lastSuccessfulRefresh) || Number.isFinite(metadata.firstFailureAt)))
+      .map(metadata => Number.isFinite(metadata.lastSuccessfulRefresh) ? metadata.lastSuccessfulRefresh : metadata.firstFailureAt);
     return failedTimes.length ? Math.min(...failedTimes) : null;
   }
 
@@ -2072,6 +2104,7 @@ class SkylightCalendarCard extends HTMLElement {
       this._eventRefreshWarningTimer = null;
       this.render();
     }, delay);
+    this._eventRefreshWarningTimer?.unref?.();
   }
 
   shouldShowEventRefreshWarning(now = Date.now()) {
@@ -2125,7 +2158,9 @@ class SkylightCalendarCard extends HTMLElement {
           this._calendarEventMetadata[entityId] = {
             ...existingMetadata,
             lastSuccessfulRefresh: existingMetadata.lastSuccessfulRefresh ?? this._lastSuccessfulEventRefresh,
-            refreshFailed: true
+            refreshFailed: true,
+            firstFailureAt: existingMetadata.firstFailureAt ?? Date.now(),
+            lastNetworkFailureRequest: generation
           };
         });
         this.recomputeEventState();
@@ -2134,6 +2169,7 @@ class SkylightCalendarCard extends HTMLElement {
       }
 
       const now = Date.now();
+      const wasWarningVisible = this.shouldShowEventRefreshWarning(now);
       const shouldRenderForUnchangedData = !this._lastUnchangedDataRender ||
         (now - this._lastUnchangedDataRender >= 15 * 60 * 1000);
       this.applyEventsByCalendar(nextEventsByCalendar, {
@@ -2145,8 +2181,9 @@ class SkylightCalendarCard extends HTMLElement {
         source: 'network',
         requestId: generation
       });
+      const warningVisibilityChanged = wasWarningVisible !== this.shouldShowEventRefreshWarning(now);
       if (failedEntityIds.length === 0) this.persistEventCacheSnapshot({ generation: this._eventWriteGeneration });
-      if (anyChanged || shouldRenderForUnchangedData || failedEntityIds.length > 0) {
+      if (anyChanged || shouldRenderForUnchangedData || failedEntityIds.length > 0 || warningVisibilityChanged) {
         this._lastUnchangedDataRender = now;
         if (preserveScroll) {
           this.renderPreservingAgendaScroll();
@@ -2202,7 +2239,9 @@ class SkylightCalendarCard extends HTMLElement {
           this._calendarEventMetadata[entityId] = {
             ...existingMetadata,
             lastSuccessfulRefresh: existingMetadata.lastSuccessfulRefresh ?? this._lastSuccessfulEventRefresh,
-            refreshFailed: true
+            refreshFailed: true,
+            firstFailureAt: existingMetadata.firstFailureAt ?? Date.now(),
+            lastNetworkFailureRequest: generation
           };
         });
         this.recomputeEventState();
@@ -2216,10 +2255,11 @@ class SkylightCalendarCard extends HTMLElement {
         successfulEntityIds,
         failedEntityIds,
         source: 'network',
-        requestId: generation
+        requestId: generation,
+        coverageMode: 'union'
       });
       if (failedEntityIds.length === 0) this.persistEventCacheSnapshot({ generation: this._eventWriteGeneration });
-      if (render && (anyChanged || failedEntityIds.length > 0)) this.render();
+      if ((render || failedEntityIds.length > 0) && (anyChanged || failedEntityIds.length > 0)) this.render();
       return failedEntityIds.length === 0;
     } finally {
       this._fetching = false;

--- a/src/styles/card-styles.js
+++ b/src/styles/card-styles.js
@@ -102,6 +102,17 @@ export function getCardStyles() {
         padding: 16px 24px;
       }
 
+      .event-refresh-warning {
+        margin: 8px 12px 0;
+        padding: 8px 10px;
+        border-radius: 8px;
+        background: rgba(251, 191, 36, 0.18);
+        border: 1px solid rgba(245, 158, 11, 0.55);
+        color: var(--warning-color, #92400e);
+        font-size: 13px;
+        line-height: 1.35;
+      }
+
       .calendar-body {
         position: relative;
         z-index: 1;

--- a/src/translations.js
+++ b/src/translations.js
@@ -123,7 +123,8 @@ export const TRANSLATIONS = {
       durationMinutes: '{count} minutes',
       moreEvents: '+{count} more',
       eventTitleWithStartTime: '{title}, {time}',
-      monthWeekPrefix: 'CW'
+      monthWeekPrefix: 'CW',
+      eventRefreshStaleWarning: 'Unable to refresh calendar data since {time}'
     }
   },
 

--- a/src/translations.js
+++ b/src/translations.js
@@ -238,7 +238,8 @@ export const TRANSLATIONS = {
       durationMinutes: '{count} minutes',
       moreEvents: '+{count} de plus',
       eventTitleWithStartTime: '{title}, {time}',
-      monthWeekPrefix: 'Sem'
+      monthWeekPrefix: 'Sem',
+      eventRefreshStaleWarning: 'Impossible d’actualiser les données du calendrier depuis {time}'
     }
   },
 
@@ -352,7 +353,8 @@ export const TRANSLATIONS = {
       durationMinutes: '{count} Minuten',
       moreEvents: '+{count} mehr',
       eventTitleWithStartTime: '{title}, {time}',
-      monthWeekPrefix: 'KW'
+      monthWeekPrefix: 'KW',
+      eventRefreshStaleWarning: 'Kalenderdaten konnten seit {time} nicht aktualisiert werden'
     }
   },
 
@@ -466,7 +468,8 @@ export const TRANSLATIONS = {
       durationMinutes: '{count} minuten',
       moreEvents: '+{count} meer',
       eventTitleWithStartTime: '{title}, {time}',
-      monthWeekPrefix: 'KW'
+      monthWeekPrefix: 'KW',
+      eventRefreshStaleWarning: 'Kan agendagegevens niet vernieuwen sinds {time}'
     }
   },
   es: {
@@ -579,7 +582,8 @@ export const TRANSLATIONS = {
       durationMinutes: '{count} minutos',
       moreEvents: '+{count} más',
       eventTitleWithStartTime: '{title}, {time}',
-      monthWeekPrefix: 'Sem.'
+      monthWeekPrefix: 'Sem.',
+      eventRefreshStaleWarning: 'No se pueden actualizar los datos del calendario desde {time}'
     }
   },
   
@@ -698,7 +702,8 @@ export const TRANSLATIONS = {
       durationMinutes: '{count} minutit',
       moreEvents: '+{count} veel',
       eventTitleWithStartTime: '{title}, {time}',
-      monthWeekPrefix: 'Nädal'
+      monthWeekPrefix: 'Nädal',
+      eventRefreshStaleWarning: 'Kalendriandmeid ei saanud värskendada alates {time}'
     }
   },
 
@@ -812,7 +817,8 @@ export const TRANSLATIONS = {
       durationMinutes: '{count} minuts',
       moreEvents: '+{count} més',
       eventTitleWithStartTime: '{title}, {time}',
-      monthWeekPrefix: 'Set.'
+      monthWeekPrefix: 'Set.',
+      eventRefreshStaleWarning: 'No es poden actualitzar les dades del calendari des de {time}'
     }
   },
 
@@ -926,7 +932,8 @@ export const TRANSLATIONS = {
       durationMinutes: '{count} minutter',
       moreEvents: '+{count} flere',
       eventTitleWithStartTime: '{title}, {time}',
-      monthWeekPrefix: 'Uge'
+      monthWeekPrefix: 'Uge',
+      eventRefreshStaleWarning: 'Kan ikke opdatere kalenderdata siden {time}'
     }
   },
 
@@ -1034,7 +1041,8 @@ export const TRANSLATIONS = {
       durationMinutes: '{count} minuter',
       moreEvents: '+{count} fler',
       eventTitleWithStartTime: '{title}, {time}',
-      monthWeekPrefix: 'v.'
+      monthWeekPrefix: 'v.',
+      eventRefreshStaleWarning: 'Det går inte att uppdatera kalenderdata sedan {time}'
     }
   }
 };


### PR DESCRIPTION
### Motivation
- Allow the card to render a last-known-good set of calendar events immediately on startup while still performing a fresh Home Assistant refresh in the background. 
- Ensure failures do not erase good data, allow successful empty responses to clear old events, and surface a non-intrusive stale-refresh warning after 30 minutes without success. 

### Description
- Add an IndexedDB-backed event cache helper (`src/events/event-cache.js`) that stores versioned snapshots containing schema version, covered start/end range, `lastSuccessfulRefresh`, a deterministic config signature, and per-calendar normalized events with bounded cleanup and safe corruption handling. 
- Refactor fetching (`src/events/event-fetcher.js`) to return explicit per-chunk and per-calendar `{ success, events }` results so failed WS/REST fetches are distinguishable from successful empty results. 
- Integrate cache hydration, generation-based race protection, stale-while-revalidate loading, and persistence into the main card (`src/skylight-calendar-card.js`) with new in-memory `_eventsByCalendar`, `loadEventCacheForCurrentConfig`, `persistEventCacheSnapshot`, `flushEventCache`, and logic to preserve last-known-good events on partial or total refresh failures. 
- Add a non-intrusive 30-minute stale-refresh warning (translation key + styling) and a safe "Flush event cache" action in the editor diagnostics that clears only persistent Daylight event snapshots and triggers a fresh load. 

### Testing
- Built and static-checked the code (`npm run build`, `node --check` on changed files) with no syntax errors. 
- Ran unit tests (`npm test`) which passed and include new/updated cases for cache signature behavior, corrupt snapshot handling, cache hydration before network refresh, successful refresh persisting cache, failed refresh preserving last-known-good, partial-calendar failures, empty successful responses clearing old data, cache flush behavior, stale-warning timing, and race-protection. 
- Ran visual tests (`npm run test:visual`) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ed0492838833192282453248add41)