### PR TITLE
Add structured custom header items

### DIFF
--- a/docs/configuration/weather.mdx
+++ b/docs/configuration/weather.mdx
@@ -82,6 +82,40 @@ header_time_sensor: sensor.time
 header_weather_sensor: weather.home
 ```
 
+## Custom header items
+
+Use `header_items` to add short, structured icon/value pairs after the title, live time, and weather summary. Header items are intended for glanceable values. For the best responsive layout, use 1–4 short items.
+
+<ParamField path="header_items" type="array">
+  Optional list of custom header items. Each item supports:
+
+  - `icon`: optional static MDI icon, such as `mdi:weather-sunset-up`.
+  - `entity`: optional Home Assistant entity ID.
+  - `attribute`: optional attribute name. When set, the card displays that attribute instead of the entity state.
+  - `text`: optional static text or fallback text.
+  - `format`: optional display format. Defaults to `auto`. Supported values are `auto`, `raw`, `time`, `date`, and `datetime`.
+
+  `auto` uses compact formatting: timestamp entities show a local time, date entities show a localized date, entities with units keep their unit, and other values display as raw state text.
+</ParamField>
+
+```yaml
+type: custom:daylight-calendar-card
+title: Family Calendar
+entities:
+  - calendar.family
+header_weather_sensor: weather.home
+header_time_sensor: sensor.time
+header_items:
+  - icon: mdi:weather-sunset-up
+    entity: sensor.sun_next_rising
+  - icon: mdi:weather-sunset-down
+    entity: sensor.sun_next_setting
+  - icon: mdi:home
+    text: Family
+```
+
+Header items hide automatically when their resolved value is empty, `unknown`, or `unavailable`. If an entity is missing and `text` is provided, the card displays the text fallback. Values and icon names are escaped before rendering. Arbitrary HTML and Jinja/template subscriptions are intentionally not supported in this initial feature.
+
 ## Combined Example
 
 The configuration below shows a card that displays both a live clock and a daily weather forecast in the header:

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -302,13 +302,17 @@ function stringifyRawValue(value) {
 
 function parseDateValue(value, parseTimeValue) {
   if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+  const raw = String(value ?? '').trim();
+  if (!raw) return null;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+    const parsedLocalDate = parseLocalDate(raw);
+    return parsedLocalDate instanceof Date && !Number.isNaN(parsedLocalDate.getTime()) ? parsedLocalDate : null;
+  }
   if (typeof parseTimeValue === 'function') {
     const parsedTime = parseTimeValue(value);
     if (parsedTime) return parsedTime;
   }
-  const raw = String(value ?? '').trim();
-  if (!raw) return null;
-  const parsed = /^\d{4}-\d{2}-\d{2}$/.test(raw) ? parseLocalDate(raw) : parsePossiblyLocalDateTime(raw);
+  const parsed = parsePossiblyLocalDateTime(raw);
   return parsed instanceof Date && !Number.isNaN(parsed.getTime()) ? parsed : null;
 }
 
@@ -10159,7 +10163,7 @@ function renderHeaderTitle({
         <h2 class="header-title">${helpers.escapeHtml(title || '')}</h2>
         ${headerTime ? `<span class="header-time">${helpers.escapeHtml(headerTime)}</span>` : ''}
         ${headerWeather ? `<span class="header-weather"><ha-icon icon="${helpers.escapeHtml(headerWeather.conditionIcon)}"></ha-icon>${helpers.escapeHtml(headerWeather.temperature)}</span>` : ''}
-        ${headerItems.map((item) => `<span class="header-item">${item.icon ? `<ha-icon icon="${helpers.escapeHtml(item.icon)}"></ha-icon>` : ''}<span class="header-item-value">${helpers.escapeHtml(item.value)}</span></span>`).join('')}
+        ${headerItems.map((item) => `<span class="header-item">${item.icon ? `<ha-icon icon="${helpers.escapeHtmlAttribute(item.icon)}"></ha-icon>` : ''}<span class="header-item-value">${helpers.escapeHtml(item.value)}</span></span>`).join('')}
       </div>
     `;
 }
@@ -14008,6 +14012,7 @@ class SkylightCalendarCard extends HTMLElement {
   getHeaderRenderHelpers() {
     return {
       escapeHtml: (value) => this.escapeHtml(value),
+      escapeHtmlAttribute: (value) => this.escapeHtmlAttribute(value),
       getPeriodLabel: () => this.getPeriodLabel(),
       renderCalendarBadgesInline: () => this.renderCalendarBadgesInline(),
       renderDashboardNavButton: () => this.renderDashboardNavButton(),

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -179,6 +179,7 @@ const DEFAULT_STUB_CONFIG = {
   show_dashboard_nav_button: false,
   header_dashboard_path: null,
   header_weather_sensor: '',
+  header_items: [],
   calendar_person_entities: {},
   default_hidden_calendars: [],
   color_scheme: 'auto',
@@ -192,8 +193,180 @@ const createDefaultStubConfig = () => ({
   week_days: [...DEFAULT_STUB_CONFIG.week_days],
   day_badges: [...DEFAULT_STUB_CONFIG.day_badges],
   calendar_person_entities: { ...DEFAULT_STUB_CONFIG.calendar_person_entities },
-  default_hidden_calendars: [...DEFAULT_STUB_CONFIG.default_hidden_calendars]
+  default_hidden_calendars: [...DEFAULT_STUB_CONFIG.default_hidden_calendars],
+  header_items: [...DEFAULT_STUB_CONFIG.header_items]
 });
+
+function getDateRangeChunks(startDate, endDate, chunkDays = 30) {
+  const chunks = [];
+  let cursor = new Date(startDate);
+  cursor.setHours(0, 0, 0, 0);
+
+  while (cursor <= endDate) {
+    const chunkStart = new Date(cursor);
+    const chunkEnd = new Date(cursor);
+    chunkEnd.setDate(chunkEnd.getDate() + chunkDays - 1);
+    if (chunkEnd > endDate) {
+      chunkEnd.setTime(endDate.getTime());
+    }
+    chunkEnd.setHours(23, 59, 59, 999);
+
+    chunks.push({ startDate: chunkStart, endDate: chunkEnd });
+
+    cursor = new Date(chunkEnd);
+    cursor.setDate(cursor.getDate() + 1);
+    cursor.setHours(0, 0, 0, 0);
+  }
+
+  return chunks;
+}
+
+function parseLocalDate(dateStr) {
+  if (!dateStr || typeof dateStr !== 'string') return new Date(dateStr);
+  const [year, month, day] = dateStr.split('-').map(Number);
+  if (![year, month, day].every(Number.isFinite)) return new Date(dateStr);
+  return new Date(year, month - 1, day);
+}
+
+function parsePossiblyLocalDateTime(value) {
+  if (!value || typeof value !== 'string') return new Date(value);
+
+  const hasTimezone = /(?:[zZ]|[+-]\d{2}:?\d{2})$/.test(value);
+  if (hasTimezone) return new Date(value);
+
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?$/);
+  if (!match) return new Date(value);
+
+  const [, year, month, day, hour, minute, second = '0'] = match;
+  return new Date(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute),
+    Number(second)
+  );
+}
+
+function formatLocalDate(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '';
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function getIsoWeekNumber(date) {
+  const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const dayNumber = utcDate.getUTCDay() || 7;
+  utcDate.setUTCDate(utcDate.getUTCDate() + 4 - dayNumber);
+  const yearStart = new Date(Date.UTC(utcDate.getUTCFullYear(), 0, 1));
+  return Math.ceil((((utcDate - yearStart) / 86400000) + 1) / 7);
+}
+
+const HEADER_ITEM_FORMATS = new Set(['auto', 'raw', 'time', 'date', 'datetime']);
+const EMPTY_STATES = new Set(['', 'unknown', 'unavailable']);
+
+function normalizeOptionalString(value) {
+  if (value === undefined || value === null) return null;
+  const normalized = String(value).trim();
+  return normalized || null;
+}
+
+function normalizeHeaderItems(items) {
+  if (!Array.isArray(items)) return [];
+  return items
+    .filter((item) => item && typeof item === 'object' && !Array.isArray(item))
+    .map((item) => ({
+      icon: normalizeOptionalString(item.icon),
+      entity: normalizeOptionalString(item.entity),
+      attribute: normalizeOptionalString(item.attribute),
+      text: normalizeOptionalString(item.text),
+      format: HEADER_ITEM_FORMATS.has(normalizeOptionalString(item.format)) ? normalizeOptionalString(item.format) : 'auto'
+    }))
+    .filter((item) => item.icon || item.entity || item.text);
+}
+
+function isEmptyResolvedValue(value) {
+  if (value === undefined || value === null) return true;
+  if (typeof value === 'string') return EMPTY_STATES.has(value.trim().toLowerCase());
+  return false;
+}
+
+function stringifyRawValue(value) {
+  if (value instanceof Date) return value.toISOString();
+  if (Array.isArray(value)) return value.join(', ');
+  if (typeof value === 'object' && value !== null) return JSON.stringify(value);
+  return String(value);
+}
+
+function parseDateValue(value, parseTimeValue) {
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+  if (typeof parseTimeValue === 'function') {
+    const parsedTime = parseTimeValue(value);
+    if (parsedTime) return parsedTime;
+  }
+  const raw = String(value ?? '').trim();
+  if (!raw) return null;
+  const parsed = /^\d{4}-\d{2}-\d{2}$/.test(raw) ? parseLocalDate(raw) : parsePossiblyLocalDateTime(raw);
+  return parsed instanceof Date && !Number.isNaN(parsed.getTime()) ? parsed : null;
+}
+
+function formatDateValue(value, format, formatters = {}) {
+  const parsed = parseDateValue(value, formatters.parseTimeValue);
+  if (!parsed) return '';
+  if (format === 'time') return formatters.formatTime?.(parsed) || '';
+  if (format === 'date') return formatters.formatDate?.(parsed) || '';
+  return formatters.formatDateTime?.(parsed) || '';
+}
+
+function resolveHeaderItemValue(item, hass, formatters = {}) {
+  const entityState = item.entity ? hass?.states?.[item.entity] : null;
+  const hasEntityValue = !!entityState;
+  const rawEntityValue = hasEntityValue
+    ? (item.attribute ? entityState.attributes?.[item.attribute] : entityState.state)
+    : undefined;
+  const rawValue = !isEmptyResolvedValue(rawEntityValue) ? rawEntityValue : item.text;
+  if (isEmptyResolvedValue(rawValue)) return '';
+
+  const format = item.format || 'auto';
+  if (format === 'time' || format === 'date' || format === 'datetime') {
+    return formatDateValue(rawValue, format, formatters);
+  }
+
+  if (format === 'raw') return stringifyRawValue(rawValue);
+
+  const deviceClass = normalizeOptionalString(entityState?.attributes?.device_class);
+  if (deviceClass === 'timestamp') return formatDateValue(rawValue, 'time', formatters);
+  if (deviceClass === 'date') return formatDateValue(rawValue, 'date', formatters);
+
+  const rawText = stringifyRawValue(rawValue);
+  const unit = normalizeOptionalString(entityState?.attributes?.unit_of_measurement);
+  if (unit && hasEntityValue && !item.attribute) return `${rawText} ${unit}`;
+  return rawText;
+}
+
+function resolveHeaderItems(items, hass, formatters = {}) {
+  return normalizeHeaderItems(items).map((item) => ({
+    icon: item.icon,
+    value: resolveHeaderItemValue(item, hass, formatters)
+  })).filter((item) => !isEmptyResolvedValue(item.value));
+}
+
+function getHeaderItemsRenderSignature(items, hass) {
+  return JSON.stringify(normalizeHeaderItems(items).filter((item) => item.entity).map((item) => {
+    const state = hass?.states?.[item.entity];
+    return {
+      entity: item.entity,
+      attribute: item.attribute,
+      state: state?.state ?? null,
+      attributeValue: item.attribute ? state?.attributes?.[item.attribute] ?? null : null,
+      deviceClass: state?.attributes?.device_class ?? null,
+      unitOfMeasurement: state?.attributes?.unit_of_measurement ?? null,
+      icon: state?.attributes?.icon ?? null
+    };
+  }));
+}
 
 function createConfigNormalizationSchema({
   hasCustomTitle,
@@ -255,6 +428,7 @@ function createConfigNormalizationSchema({
       { key: 'header_dashboard_path', defaultValue: ({ rawConfig }) => normalizeDashboardPath(rawConfig.header_dashboard_path), normalize: ({ rawConfig }) => normalizeDashboardPath(rawConfig.header_dashboard_path) },
       { key: 'header_time_sensor', defaultValue: ({ derived }) => derived.normalizedHeaderTimeSensor, normalize: ({ derived }) => derived.normalizedHeaderTimeSensor },
       { key: 'header_weather_sensor', defaultValue: ({ derived }) => derived.normalizedHeaderWeatherSensor, normalize: ({ derived }) => derived.normalizedHeaderWeatherSensor },
+      { key: 'header_items', defaultValue: ({ derived }) => derived.normalizedHeaderItems, normalize: ({ derived }) => derived.normalizedHeaderItems },
       { key: 'hide_event_calendar_bubble', defaultValue: ({ rawConfig }) => rawConfig.hide_event_calendar_bubble || DEFAULT_CONFIG_VALUES.hide_event_calendar_bubble },
       { key: 'show_event_location', defaultValue: ({ rawConfig }) => rawConfig.show_event_location || DEFAULT_CONFIG_VALUES.show_event_location },
       { key: 'use_short_location', defaultValue: ({ rawConfig }) => rawConfig.use_short_location || DEFAULT_CONFIG_VALUES.use_short_location },
@@ -3306,7 +3480,8 @@ function getCardStyles() {
         white-space: nowrap;
       }
 
-      .header-weather {
+      .header-weather,
+      .header-item {
         display: inline-flex;
         align-items: center;
         gap: 4px;
@@ -3317,8 +3492,13 @@ function getCardStyles() {
         white-space: nowrap;
       }
 
-      .header-weather ha-icon {
+      .header-weather ha-icon,
+      .header-item ha-icon {
         --mdc-icon-size: 28px;
+      }
+
+      .header-item-value {
+        display: inline-block;
       }
 
       .add-event-button {
@@ -7275,73 +7455,6 @@ function normalizeDayBadges(rawRules, {
     .filter(Boolean);
 }
 
-function getDateRangeChunks(startDate, endDate, chunkDays = 30) {
-  const chunks = [];
-  let cursor = new Date(startDate);
-  cursor.setHours(0, 0, 0, 0);
-
-  while (cursor <= endDate) {
-    const chunkStart = new Date(cursor);
-    const chunkEnd = new Date(cursor);
-    chunkEnd.setDate(chunkEnd.getDate() + chunkDays - 1);
-    if (chunkEnd > endDate) {
-      chunkEnd.setTime(endDate.getTime());
-    }
-    chunkEnd.setHours(23, 59, 59, 999);
-
-    chunks.push({ startDate: chunkStart, endDate: chunkEnd });
-
-    cursor = new Date(chunkEnd);
-    cursor.setDate(cursor.getDate() + 1);
-    cursor.setHours(0, 0, 0, 0);
-  }
-
-  return chunks;
-}
-
-function parseLocalDate(dateStr) {
-  if (!dateStr || typeof dateStr !== 'string') return new Date(dateStr);
-  const [year, month, day] = dateStr.split('-').map(Number);
-  if (![year, month, day].every(Number.isFinite)) return new Date(dateStr);
-  return new Date(year, month - 1, day);
-}
-
-function parsePossiblyLocalDateTime(value) {
-  if (!value || typeof value !== 'string') return new Date(value);
-
-  const hasTimezone = /(?:[zZ]|[+-]\d{2}:?\d{2})$/.test(value);
-  if (hasTimezone) return new Date(value);
-
-  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?$/);
-  if (!match) return new Date(value);
-
-  const [, year, month, day, hour, minute, second = '0'] = match;
-  return new Date(
-    Number(year),
-    Number(month) - 1,
-    Number(day),
-    Number(hour),
-    Number(minute),
-    Number(second)
-  );
-}
-
-function formatLocalDate(date) {
-  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '';
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-}
-
-function getIsoWeekNumber(date) {
-  const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
-  const dayNumber = utcDate.getUTCDay() || 7;
-  utcDate.setUTCDate(utcDate.getUTCDate() + 4 - dayNumber);
-  const yearStart = new Date(Date.UTC(utcDate.getUTCFullYear(), 0, 1));
-  return Math.ceil((((utcDate - yearStart) / 86400000) + 1) / 7);
-}
-
 function normalizeSingleColor(colorValue) {
   if (colorValue === undefined || colorValue === null) {
     return colorValue;
@@ -10038,6 +10151,7 @@ function renderHeaderTitle({
   title,
   headerTime,
   headerWeather,
+  headerItems = [],
   helpers
 }) {
   return `
@@ -10045,6 +10159,7 @@ function renderHeaderTitle({
         <h2 class="header-title">${helpers.escapeHtml(title || '')}</h2>
         ${headerTime ? `<span class="header-time">${helpers.escapeHtml(headerTime)}</span>` : ''}
         ${headerWeather ? `<span class="header-weather"><ha-icon icon="${helpers.escapeHtml(headerWeather.conditionIcon)}"></ha-icon>${helpers.escapeHtml(headerWeather.temperature)}</span>` : ''}
+        ${headerItems.map((item) => `<span class="header-item">${item.icon ? `<ha-icon icon="${helpers.escapeHtml(item.icon)}"></ha-icon>` : ''}<span class="header-item-value">${helpers.escapeHtml(item.value)}</span></span>`).join('')}
       </div>
     `;
 }
@@ -11296,6 +11411,7 @@ class SkylightCalendarCard extends HTMLElement {
       normalizedHeaderWeatherSensor: typeof rawConfig.header_weather_sensor === 'string' && rawConfig.header_weather_sensor.trim()
         ? rawConfig.header_weather_sensor.trim()
         : null,
+      normalizedHeaderItems: normalizeHeaderItems(rawConfig.header_items),
       language
     };
   }
@@ -11405,8 +11521,11 @@ class SkylightCalendarCard extends HTMLElement {
     const nextHeaderWeatherSensorState = configuredHeaderWeatherSensor
       ? this.getHeaderEntityRenderSignature(hass?.states?.[configuredHeaderWeatherSensor])
       : null;
+    const previousHeaderItemsState = getHeaderItemsRenderSignature(this._config?.header_items, oldHass);
+    const nextHeaderItemsState = getHeaderItemsRenderSignature(this._config?.header_items, hass);
     const headerSensorChanged = previousHeaderTimeSensorState !== nextHeaderTimeSensorState ||
-      previousHeaderWeatherSensorState !== nextHeaderWeatherSensorState;
+      previousHeaderWeatherSensorState !== nextHeaderWeatherSensorState ||
+      previousHeaderItemsState !== nextHeaderItemsState;
     const badgePersonStateChanged = this.getCalendarBadgePersonRenderSignature(oldHass) !==
       this.getCalendarBadgePersonRenderSignature(hass);
 
@@ -13952,10 +14071,12 @@ class SkylightCalendarCard extends HTMLElement {
   renderHeaderTitle() {
     const headerTime = this.getFormattedHeaderSensorTime();
     const headerWeather = this.getHeaderWeatherData();
+    const headerItems = this.resolveHeaderItems();
     return renderHeaderTitle({
       title: this._config.title,
       headerTime,
       headerWeather,
+      headerItems,
       helpers: this.getHeaderRenderHelpers()
     });
   }
@@ -17854,6 +17975,15 @@ class SkylightCalendarCard extends HTMLElement {
     const sensorEntityId = this._config?.header_weather_sensor;
     if (!sensorEntityId) return null;
     return getHeaderWeatherDisplayData(this._hass, sensorEntityId);
+  }
+
+  resolveHeaderItems() {
+    return resolveHeaderItems(this._config?.header_items, this._hass, {
+      parseTimeValue: (value) => this.parseTimeValue(value),
+      formatTime: (date) => this.formatTime(date),
+      formatDate: (date) => new Intl.DateTimeFormat(this.getLocale(), this.withTimeZone({ month: 'short', day: 'numeric' })).format(date),
+      formatDateTime: (date) => new Intl.DateTimeFormat(this.getLocale(), this.withTimeZone({ month: 'short', day: 'numeric', ...this.getTimeFormatOptions() })).format(date)
+    });
   }
 
   getFormattedHeaderWeather() {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -118,6 +118,7 @@ const CONFIG_COVERAGE_INVENTORY = {
   header_dashboard_path: 'setConfig schema keeps normalized fields from being overwritten by raw config',
   header_time_sensor: 'setConfig schema keeps normalized fields from being overwritten by raw config',
   header_weather_sensor: 'weather renders Home Assistant mdi icons instead of emoji glyphs',
+  header_items: 'header_items normalize supported item shapes and formats',
   hide_event_calendar_bubble: 'setConfig applies visual layout and styling options',
   show_event_location: 'setConfig applies visual layout and styling options',
   location_links: 'event location links are opt-in for the details modal',
@@ -809,7 +810,7 @@ test('getStubConfig and normalized defaults include key configuration defaults',
     'combine_background', 'hide_calendars', 'hide_header', 'hide_year', 'hide_controls',
     'hide_navigation_buttons', 'hide_add_event_button', 'hide_view_selector',
     'hide_dark_mode_toggle', 'show_dashboard_nav_button', 'header_dashboard_path',
-    'header_weather_sensor', 'calendar_person_entities', 'default_hidden_calendars', 'color_scheme', 'enable_event_management', 'event_modal_size'
+    'header_weather_sensor', 'header_items', 'calendar_person_entities', 'default_hidden_calendars', 'color_scheme', 'enable_event_management', 'event_modal_size'
   ];
   for (const key of requiredStubKeys) assert.ok(key in stub, `${key} should exist in getStubConfig()`);
   assert.deepEqual(stub, {
@@ -861,6 +862,7 @@ test('getStubConfig and normalized defaults include key configuration defaults',
     show_dashboard_nav_button: false,
     header_dashboard_path: null,
     header_weather_sensor: '',
+    header_items: [],
     calendar_person_entities: {},
     default_hidden_calendars: [],
     color_scheme: 'auto',
@@ -2697,6 +2699,97 @@ test('weather renders Home Assistant mdi icons instead of emoji glyphs', () => {
   const forecastHtml = card.renderDayForecast(new Date('2026-05-14T00:00:00Z'));
   assert.match(forecastHtml, /<ha-icon icon="mdi:weather-partly-cloudy"><\/ha-icon>/);
   assert.doesNotMatch(forecastHtml, /☀️|⛅/);
+});
+
+
+
+test('header_items normalize supported item shapes and formats', async () => {
+  const { normalizeHeaderItems } = await import('./src/header/header-items.js');
+
+  assert.deepEqual(normalizeHeaderItems(null), []);
+  assert.deepEqual(normalizeHeaderItems('bad'), []);
+  assert.deepEqual(normalizeHeaderItems([
+    { icon: ' mdi:home ', text: ' Family ' },
+    { entity: ' sensor.temp ', format: 'raw' },
+    { entity: 'sensor.sun', attribute: 'next_rising', format: 'nonsense' },
+    { text: 'Hidden format', format: 'date' },
+    null,
+    {}
+  ]), [
+    { icon: 'mdi:home', entity: null, attribute: null, text: 'Family', format: 'auto' },
+    { icon: null, entity: 'sensor.temp', attribute: null, text: null, format: 'raw' },
+    { icon: null, entity: 'sensor.sun', attribute: 'next_rising', text: null, format: 'auto' },
+    { icon: null, entity: null, attribute: null, text: 'Hidden format', format: 'date' }
+  ]);
+});
+
+test('header_items render icons entity values fallbacks and escaped text', () => {
+  const card = makeCard({
+    entities: ['calendar.family'],
+    header_items: [
+      { icon: 'mdi:test"bad', entity: 'sensor.temp' },
+      { icon: 'mdi:bad', entity: 'sensor.missing', text: '<Family>' },
+      { icon: 'mdi:hidden', entity: 'sensor.hidden' }
+    ]
+  });
+  card._hass = { states: {
+    'sensor.temp': { state: '72', attributes: { unit_of_measurement: '°F' } },
+    'sensor.hidden': { state: 'unavailable', attributes: {} }
+  } };
+
+  const html = card.renderHeaderTitle();
+  assert.match(html, /<span class="header-item"><ha-icon icon="mdi:test&quot;bad"><\/ha-icon><span class="header-item-value">72 °F<\/span><\/span>/);
+  assert.match(html, /<span class="header-item"><ha-icon icon="mdi:bad"><\/ha-icon><span class="header-item-value">&lt;Family&gt;<\/span><\/span>/);
+  assert.doesNotMatch(html, /mdi:hidden/);
+  assert.doesNotMatch(html, /<Family>/);
+});
+
+test('header_items resolves attribute and auto date timestamp unit and raw values', async () => {
+  const { resolveHeaderItems } = await import('./src/header/header-items.js');
+  const hass = { states: {
+    'sensor.sunrise': { state: '2026-07-10T11:12:00Z', attributes: { device_class: 'timestamp' } },
+    'sensor.day': { state: '2026-07-10', attributes: { device_class: 'date' } },
+    'sensor.temp': { state: '22', attributes: { unit_of_measurement: '°C' } },
+    'sensor.attr': { state: 'ok', attributes: { label: 'Attribute <value>' } },
+    'sensor.raw': { state: 'plain', attributes: {} }
+  } };
+  const formatters = {
+    parseTimeValue: (value) => new Date(value),
+    formatTime: () => '11:12 AM',
+    formatDate: () => 'Jul 10',
+    formatDateTime: () => 'Jul 10, 11:12 AM'
+  };
+
+  assert.deepEqual(resolveHeaderItems([
+    { entity: 'sensor.sunrise' },
+    { entity: 'sensor.day' },
+    { entity: 'sensor.temp' },
+    { entity: 'sensor.attr', attribute: 'label' },
+    { entity: 'sensor.raw' }
+  ], hass, formatters).map((item) => item.value), [
+    '11:12 AM',
+    'Jul 10',
+    '22 °C',
+    'Attribute <value>',
+    'plain'
+  ]);
+});
+
+test('header_items explicit time date and datetime formats use supplied formatters', async () => {
+  const { resolveHeaderItems } = await import('./src/header/header-items.js');
+  const hass = { states: { 'sensor.value': { state: '2026-07-10T11:12:00Z', attributes: {} } } };
+  const formatters = {
+    parseTimeValue: (value) => new Date(value),
+    formatTime: () => 'time value',
+    formatDate: () => 'date value',
+    formatDateTime: () => 'datetime value'
+  };
+
+  assert.deepEqual(resolveHeaderItems([
+    { entity: 'sensor.value', format: 'time' },
+    { entity: 'sensor.value', format: 'date' },
+    { entity: 'sensor.value', format: 'datetime' }
+  ], hass, formatters).map((item) => item.value), ['time value', 'date value', 'datetime value']);
 });
 
 

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -2727,7 +2727,7 @@ test('header_items render icons entity values fallbacks and escaped text', () =>
   const card = makeCard({
     entities: ['calendar.family'],
     header_items: [
-      { icon: 'mdi:test"bad', entity: 'sensor.temp' },
+      { icon: "mdi:test\"bad'attr", entity: 'sensor.temp' },
       { icon: 'mdi:bad', entity: 'sensor.missing', text: '<Family>' },
       { icon: 'mdi:hidden', entity: 'sensor.hidden' }
     ]
@@ -2738,7 +2738,7 @@ test('header_items render icons entity values fallbacks and escaped text', () =>
   } };
 
   const html = card.renderHeaderTitle();
-  assert.match(html, /<span class="header-item"><ha-icon icon="mdi:test&quot;bad"><\/ha-icon><span class="header-item-value">72 °F<\/span><\/span>/);
+  assert.match(html, /<span class="header-item"><ha-icon icon="mdi:test&quot;bad&#39;attr"><\/ha-icon><span class="header-item-value">72 °F<\/span><\/span>/);
   assert.match(html, /<span class="header-item"><ha-icon icon="mdi:bad"><\/ha-icon><span class="header-item-value">&lt;Family&gt;<\/span><\/span>/);
   assert.doesNotMatch(html, /mdi:hidden/);
   assert.doesNotMatch(html, /<Family>/);
@@ -2773,6 +2773,25 @@ test('header_items resolves attribute and auto date timestamp unit and raw value
     'Attribute <value>',
     'plain'
   ]);
+});
+
+
+test('header_items date-only device_class values parse as local dates before generic time parsing', async () => {
+  const { resolveHeaderItems } = await import('./src/header/header-items.js');
+  const hass = { states: { 'sensor.day': { state: '2026-07-10', attributes: { device_class: 'date' } } } };
+  let parseTimeCalls = 0;
+  const formatters = {
+    parseTimeValue: (value) => {
+      parseTimeCalls += 1;
+      return new Date(value);
+    },
+    formatDate: (date) => `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`
+  };
+
+  assert.deepEqual(resolveHeaderItems([
+    { entity: 'sensor.day' }
+  ], hass, formatters).map((item) => item.value), ['2026-7-10']);
+  assert.equal(parseTimeCalls, 0);
 });
 
 test('header_items explicit time date and datetime formats use supplied formatters', async () => {

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -146,6 +146,7 @@ export const DEFAULT_STUB_CONFIG = {
   show_dashboard_nav_button: false,
   header_dashboard_path: null,
   header_weather_sensor: '',
+  header_items: [],
   calendar_person_entities: {},
   default_hidden_calendars: [],
   color_scheme: 'auto',
@@ -159,5 +160,6 @@ export const createDefaultStubConfig = () => ({
   week_days: [...DEFAULT_STUB_CONFIG.week_days],
   day_badges: [...DEFAULT_STUB_CONFIG.day_badges],
   calendar_person_entities: { ...DEFAULT_STUB_CONFIG.calendar_person_entities },
-  default_hidden_calendars: [...DEFAULT_STUB_CONFIG.default_hidden_calendars]
+  default_hidden_calendars: [...DEFAULT_STUB_CONFIG.default_hidden_calendars],
+  header_items: [...DEFAULT_STUB_CONFIG.header_items]
 });

--- a/src/editor/editor-schema.js
+++ b/src/editor/editor-schema.js
@@ -1,3 +1,4 @@
+import { normalizeHeaderItems } from '../header/header-items.js';
 import {
   DEFAULT_BACKGROUND_IMAGE_POSITION,
   DEFAULT_BACKGROUND_IMAGE_REPEAT,
@@ -72,6 +73,7 @@ export function createConfigNormalizationSchema({
       { key: 'header_dashboard_path', defaultValue: ({ rawConfig }) => normalizeDashboardPath(rawConfig.header_dashboard_path), normalize: ({ rawConfig }) => normalizeDashboardPath(rawConfig.header_dashboard_path) },
       { key: 'header_time_sensor', defaultValue: ({ derived }) => derived.normalizedHeaderTimeSensor, normalize: ({ derived }) => derived.normalizedHeaderTimeSensor },
       { key: 'header_weather_sensor', defaultValue: ({ derived }) => derived.normalizedHeaderWeatherSensor, normalize: ({ derived }) => derived.normalizedHeaderWeatherSensor },
+      { key: 'header_items', defaultValue: ({ derived }) => derived.normalizedHeaderItems, normalize: ({ derived }) => derived.normalizedHeaderItems },
       { key: 'hide_event_calendar_bubble', defaultValue: ({ rawConfig }) => rawConfig.hide_event_calendar_bubble || DEFAULT_CONFIG_VALUES.hide_event_calendar_bubble },
       { key: 'show_event_location', defaultValue: ({ rawConfig }) => rawConfig.show_event_location || DEFAULT_CONFIG_VALUES.show_event_location },
       { key: 'use_short_location', defaultValue: ({ rawConfig }) => rawConfig.use_short_location || DEFAULT_CONFIG_VALUES.use_short_location },

--- a/src/header/header-items.js
+++ b/src/header/header-items.js
@@ -38,13 +38,17 @@ function stringifyRawValue(value) {
 
 function parseDateValue(value, parseTimeValue) {
   if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+  const raw = String(value ?? '').trim();
+  if (!raw) return null;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+    const parsedLocalDate = parseLocalDate(raw);
+    return parsedLocalDate instanceof Date && !Number.isNaN(parsedLocalDate.getTime()) ? parsedLocalDate : null;
+  }
   if (typeof parseTimeValue === 'function') {
     const parsedTime = parseTimeValue(value);
     if (parsedTime) return parsedTime;
   }
-  const raw = String(value ?? '').trim();
-  if (!raw) return null;
-  const parsed = /^\d{4}-\d{2}-\d{2}$/.test(raw) ? parseLocalDate(raw) : parsePossiblyLocalDateTime(raw);
+  const parsed = parsePossiblyLocalDateTime(raw);
   return parsed instanceof Date && !Number.isNaN(parsed.getTime()) ? parsed : null;
 }
 

--- a/src/header/header-items.js
+++ b/src/header/header-items.js
@@ -1,0 +1,105 @@
+import { parseLocalDate, parsePossiblyLocalDateTime } from '../utils/date-utils.js';
+
+const HEADER_ITEM_FORMATS = new Set(['auto', 'raw', 'time', 'date', 'datetime']);
+const EMPTY_STATES = new Set(['', 'unknown', 'unavailable']);
+
+function normalizeOptionalString(value) {
+  if (value === undefined || value === null) return null;
+  const normalized = String(value).trim();
+  return normalized || null;
+}
+
+export function normalizeHeaderItems(items) {
+  if (!Array.isArray(items)) return [];
+  return items
+    .filter((item) => item && typeof item === 'object' && !Array.isArray(item))
+    .map((item) => ({
+      icon: normalizeOptionalString(item.icon),
+      entity: normalizeOptionalString(item.entity),
+      attribute: normalizeOptionalString(item.attribute),
+      text: normalizeOptionalString(item.text),
+      format: HEADER_ITEM_FORMATS.has(normalizeOptionalString(item.format)) ? normalizeOptionalString(item.format) : 'auto'
+    }))
+    .filter((item) => item.icon || item.entity || item.text);
+}
+
+function isEmptyResolvedValue(value) {
+  if (value === undefined || value === null) return true;
+  if (typeof value === 'string') return EMPTY_STATES.has(value.trim().toLowerCase());
+  return false;
+}
+
+function stringifyRawValue(value) {
+  if (value instanceof Date) return value.toISOString();
+  if (Array.isArray(value)) return value.join(', ');
+  if (typeof value === 'object' && value !== null) return JSON.stringify(value);
+  return String(value);
+}
+
+function parseDateValue(value, parseTimeValue) {
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+  if (typeof parseTimeValue === 'function') {
+    const parsedTime = parseTimeValue(value);
+    if (parsedTime) return parsedTime;
+  }
+  const raw = String(value ?? '').trim();
+  if (!raw) return null;
+  const parsed = /^\d{4}-\d{2}-\d{2}$/.test(raw) ? parseLocalDate(raw) : parsePossiblyLocalDateTime(raw);
+  return parsed instanceof Date && !Number.isNaN(parsed.getTime()) ? parsed : null;
+}
+
+function formatDateValue(value, format, formatters = {}) {
+  const parsed = parseDateValue(value, formatters.parseTimeValue);
+  if (!parsed) return '';
+  if (format === 'time') return formatters.formatTime?.(parsed) || '';
+  if (format === 'date') return formatters.formatDate?.(parsed) || '';
+  return formatters.formatDateTime?.(parsed) || '';
+}
+
+export function resolveHeaderItemValue(item, hass, formatters = {}) {
+  const entityState = item.entity ? hass?.states?.[item.entity] : null;
+  const hasEntityValue = !!entityState;
+  const rawEntityValue = hasEntityValue
+    ? (item.attribute ? entityState.attributes?.[item.attribute] : entityState.state)
+    : undefined;
+  const rawValue = !isEmptyResolvedValue(rawEntityValue) ? rawEntityValue : item.text;
+  if (isEmptyResolvedValue(rawValue)) return '';
+
+  const format = item.format || 'auto';
+  if (format === 'time' || format === 'date' || format === 'datetime') {
+    return formatDateValue(rawValue, format, formatters);
+  }
+
+  if (format === 'raw') return stringifyRawValue(rawValue);
+
+  const deviceClass = normalizeOptionalString(entityState?.attributes?.device_class);
+  if (deviceClass === 'timestamp') return formatDateValue(rawValue, 'time', formatters);
+  if (deviceClass === 'date') return formatDateValue(rawValue, 'date', formatters);
+
+  const rawText = stringifyRawValue(rawValue);
+  const unit = normalizeOptionalString(entityState?.attributes?.unit_of_measurement);
+  if (unit && hasEntityValue && !item.attribute) return `${rawText} ${unit}`;
+  return rawText;
+}
+
+export function resolveHeaderItems(items, hass, formatters = {}) {
+  return normalizeHeaderItems(items).map((item) => ({
+    icon: item.icon,
+    value: resolveHeaderItemValue(item, hass, formatters)
+  })).filter((item) => !isEmptyResolvedValue(item.value));
+}
+
+export function getHeaderItemsRenderSignature(items, hass) {
+  return JSON.stringify(normalizeHeaderItems(items).filter((item) => item.entity).map((item) => {
+    const state = hass?.states?.[item.entity];
+    return {
+      entity: item.entity,
+      attribute: item.attribute,
+      state: state?.state ?? null,
+      attributeValue: item.attribute ? state?.attributes?.[item.attribute] ?? null : null,
+      deviceClass: state?.attributes?.device_class ?? null,
+      unitOfMeasurement: state?.attributes?.unit_of_measurement ?? null,
+      icon: state?.attributes?.icon ?? null
+    };
+  }));
+}

--- a/src/renderers/header-renderer.js
+++ b/src/renderers/header-renderer.js
@@ -60,6 +60,7 @@ export function renderHeaderTitle({
   title,
   headerTime,
   headerWeather,
+  headerItems = [],
   helpers
 }) {
   return `
@@ -67,6 +68,7 @@ export function renderHeaderTitle({
         <h2 class="header-title">${helpers.escapeHtml(title || '')}</h2>
         ${headerTime ? `<span class="header-time">${helpers.escapeHtml(headerTime)}</span>` : ''}
         ${headerWeather ? `<span class="header-weather"><ha-icon icon="${helpers.escapeHtml(headerWeather.conditionIcon)}"></ha-icon>${helpers.escapeHtml(headerWeather.temperature)}</span>` : ''}
+        ${headerItems.map((item) => `<span class="header-item">${item.icon ? `<ha-icon icon="${helpers.escapeHtml(item.icon)}"></ha-icon>` : ''}<span class="header-item-value">${helpers.escapeHtml(item.value)}</span></span>`).join('')}
       </div>
     `;
 }

--- a/src/renderers/header-renderer.js
+++ b/src/renderers/header-renderer.js
@@ -68,7 +68,7 @@ export function renderHeaderTitle({
         <h2 class="header-title">${helpers.escapeHtml(title || '')}</h2>
         ${headerTime ? `<span class="header-time">${helpers.escapeHtml(headerTime)}</span>` : ''}
         ${headerWeather ? `<span class="header-weather"><ha-icon icon="${helpers.escapeHtml(headerWeather.conditionIcon)}"></ha-icon>${helpers.escapeHtml(headerWeather.temperature)}</span>` : ''}
-        ${headerItems.map((item) => `<span class="header-item">${item.icon ? `<ha-icon icon="${helpers.escapeHtml(item.icon)}"></ha-icon>` : ''}<span class="header-item-value">${helpers.escapeHtml(item.value)}</span></span>`).join('')}
+        ${headerItems.map((item) => `<span class="header-item">${item.icon ? `<ha-icon icon="${helpers.escapeHtmlAttribute(item.icon)}"></ha-icon>` : ''}<span class="header-item-value">${helpers.escapeHtml(item.value)}</span></span>`).join('')}
       </div>
     `;
 }

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -69,6 +69,11 @@ import {
 } from './config/config-normalizers.js';
 import { escapeHtmlAttribute, normalizeEventTextValue } from './utils/string-utils.js';
 import {
+  getHeaderItemsRenderSignature,
+  normalizeHeaderItems as normalizeHeaderItemsHelper,
+  resolveHeaderItems as resolveHeaderItemsHelper
+} from './header/header-items.js';
+import {
   detectStaleSkylightResource,
   STALE_RESOURCE_TROUBLESHOOTING_URL,
   STALE_RESOURCE_WARNING_STORAGE_KEY
@@ -949,6 +954,7 @@ class SkylightCalendarCard extends HTMLElement {
       normalizedHeaderWeatherSensor: typeof rawConfig.header_weather_sensor === 'string' && rawConfig.header_weather_sensor.trim()
         ? rawConfig.header_weather_sensor.trim()
         : null,
+      normalizedHeaderItems: normalizeHeaderItemsHelper(rawConfig.header_items),
       language
     };
   }
@@ -1058,8 +1064,11 @@ class SkylightCalendarCard extends HTMLElement {
     const nextHeaderWeatherSensorState = configuredHeaderWeatherSensor
       ? this.getHeaderEntityRenderSignature(hass?.states?.[configuredHeaderWeatherSensor])
       : null;
+    const previousHeaderItemsState = getHeaderItemsRenderSignature(this._config?.header_items, oldHass);
+    const nextHeaderItemsState = getHeaderItemsRenderSignature(this._config?.header_items, hass);
     const headerSensorChanged = previousHeaderTimeSensorState !== nextHeaderTimeSensorState ||
-      previousHeaderWeatherSensorState !== nextHeaderWeatherSensorState;
+      previousHeaderWeatherSensorState !== nextHeaderWeatherSensorState ||
+      previousHeaderItemsState !== nextHeaderItemsState;
     const badgePersonStateChanged = this.getCalendarBadgePersonRenderSignature(oldHass) !==
       this.getCalendarBadgePersonRenderSignature(hass);
 
@@ -3605,10 +3614,12 @@ class SkylightCalendarCard extends HTMLElement {
   renderHeaderTitle() {
     const headerTime = this.getFormattedHeaderSensorTime();
     const headerWeather = this.getHeaderWeatherData();
+    const headerItems = this.resolveHeaderItems();
     return renderHeaderTitleMarkup({
       title: this._config.title,
       headerTime,
       headerWeather,
+      headerItems,
       helpers: this.getHeaderRenderHelpers()
     });
   }
@@ -7507,6 +7518,15 @@ class SkylightCalendarCard extends HTMLElement {
     const sensorEntityId = this._config?.header_weather_sensor;
     if (!sensorEntityId) return null;
     return getHeaderWeatherDisplayData(this._hass, sensorEntityId);
+  }
+
+  resolveHeaderItems() {
+    return resolveHeaderItemsHelper(this._config?.header_items, this._hass, {
+      parseTimeValue: (value) => this.parseTimeValue(value),
+      formatTime: (date) => this.formatTime(date),
+      formatDate: (date) => new Intl.DateTimeFormat(this.getLocale(), this.withTimeZone({ month: 'short', day: 'numeric' })).format(date),
+      formatDateTime: (date) => new Intl.DateTimeFormat(this.getLocale(), this.withTimeZone({ month: 'short', day: 'numeric', ...this.getTimeFormatOptions() })).format(date)
+    });
   }
 
   getFormattedHeaderWeather() {

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -3551,6 +3551,7 @@ class SkylightCalendarCard extends HTMLElement {
   getHeaderRenderHelpers() {
     return {
       escapeHtml: (value) => this.escapeHtml(value),
+      escapeHtmlAttribute: (value) => this.escapeHtmlAttribute(value),
       getPeriodLabel: () => this.getPeriodLabel(),
       renderCalendarBadgesInline: () => this.renderCalendarBadgesInline(),
       renderDashboardNavButton: () => this.renderDashboardNavButton(),

--- a/src/styles/card-styles.js
+++ b/src/styles/card-styles.js
@@ -292,7 +292,8 @@ export function getCardStyles() {
         white-space: nowrap;
       }
 
-      .header-weather {
+      .header-weather,
+      .header-item {
         display: inline-flex;
         align-items: center;
         gap: 4px;
@@ -303,8 +304,13 @@ export function getCardStyles() {
         white-space: nowrap;
       }
 
-      .header-weather ha-icon {
+      .header-weather ha-icon,
+      .header-item ha-icon {
         --mdc-icon-size: 28px;
+      }
+
+      .header-item-value {
+        display: inline-block;
       }
 
       .add-event-button {


### PR DESCRIPTION
### Motivation
- Implement issue #484 to let users add short, safe icon/value pairs to the card header without arbitrary HTML or Jinja templates. 
- Header items are intended as compact glanceable values (recommend 1–4) and must update only when their configured entity/attribute values change.

### Description
- Add a focused helper module `src/header/header-items.js` providing `normalizeHeaderItems`, `resolveHeaderItems`, `resolveHeaderItemValue`, and `getHeaderItemsRenderSignature` for safe normalization, resolution, compact formatting (auto/raw/time/date/datetime), and render-signature generation.
- Wire `header_items` into config normalization and the editor schema with safe defaults and normalization so invalid/missing values normalize to an empty array.
- Render resolved `headerItems` after existing title/time/weather in `renderHeaderTitle` using escaped values and escaped icon names with markup `<span class="header-item">` / `<ha-icon>` / `<span class="header-item-value">` and matching header styles in `src/styles/card-styles.js` to keep each pair together (`white-space: nowrap`).
- Update the `hass` setter to include header-items render signatures so the card rerenders only when a configured header item’s referenced entity/attribute/metadata changes.
- Add unit tests covering normalization, resolution, escaping, fallbacks, hiding unavailable values, `auto` heuristics, and explicit `time`/`date`/`datetime` formats, plus a small visual/doc update with a sunrise/sunset example.
- Regenerate the shipped artifact so the built `skylight-calendar-card.js` matches the new source.

### Testing
- Ran `node --check` on the new helper and affected source files and they passed (`src/header/header-items.js`, `src/skylight-calendar-card.js`, `src/renderers/header-renderer.js`, `src/editor/editor-schema.js`).
- Ran `npm run build` and verified the generated shipped artifact is up-to-date after the change.
- Ran `npm test` (unit tests) and all tests passed (399 tests total).
- Ran `npm run test:visual` (Playwright visual tests) and the visual suite passed (46 tests).
- Performed a small Playwright screenshot smoke check to verify header rendering with sample `header_items` (screenshot saved during the rollout).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a515dacfd908331ac3f067893d05242)