### PR TITLE
Throttle retries after total calendar fetch failure

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -13002,6 +13002,9 @@ class SkylightCalendarCard extends HTMLElement {
     }
 
     if (!this._loadedEventRange) {
+      if (renderIfCovered) {
+        this.render();
+      }
       return;
     }
 

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -12995,9 +12995,13 @@ class SkylightCalendarCard extends HTMLElement {
       return;
     }
 
-    if (force || shouldRefreshForAge || !this._loadedEventRange) {
+    if (force || shouldRefreshForAge) {
       const shouldPreserveScrollDuringRefresh = this._viewMode === 'agenda' && !force && !renderIfCovered;
       await this.updateEvents({ preserveScroll: shouldPreserveScrollDuringRefresh, renderAfterFetch: renderIfCovered });
+      return;
+    }
+
+    if (!this._loadedEventRange) {
       return;
     }
 

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -13002,6 +13002,14 @@ class SkylightCalendarCard extends HTMLElement {
     }
 
     if (!this._loadedEventRange) {
+      const hasLoadedCalendarRange = (this._config.entities || []).some((entityId) => {
+        const range = this._calendarEventMetadata[entityId]?.range;
+        return !!this.getValidRange(range?.startDate, range?.endDate);
+      });
+      if (renderIfCovered && hasLoadedCalendarRange) {
+        await this.updateEvents({ renderAfterFetch: true });
+        return;
+      }
       if (renderIfCovered) {
         this.render();
       }

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -8554,6 +8554,42 @@ test('view change requiring refresh renders even when fetched events are identic
   assert.equal(rendered, 1);
 });
 
+test('partial calendar fetch failure allows navigation refresh during retry throttle', async () => {
+  const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
+  card._hass = { user: { id: 'user-1' }, states: {} };
+  card._loadedEventRange = null;
+  let fetchCount = 0;
+  let renderCount = 0;
+  card.getVisibleDateRange = () => ({ startDate: new Date('2026-03-10T00:00:00Z'), endDate: new Date('2026-03-17T00:00:00Z') });
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-03-01T00:00:00Z'), endDate: new Date('2026-04-01T00:00:00Z') });
+  card.fetchEventsByCalendarInRange = async () => {
+    fetchCount += 1;
+    return {
+      'calendar.a': { success: true, events: [{ entityId: 'calendar.a', summary: 'a', start: { date: '2026-03-10' }, end: { date: '2026-03-11' } }] },
+      'calendar.b': { success: false, events: [] }
+    };
+  };
+  card.render = () => { renderCount += 1; };
+  card.persistEventCacheSnapshot = () => {};
+  card.ensureEventsForCurrentRange = originalEnsureEventsForCurrentRange.bind(card);
+
+  const originalDateNow = Date.now;
+  Date.now = () => Date.parse('2026-03-01T12:00:00Z');
+  try {
+    await card.ensureEventsForCurrentRange();
+    assert.equal(fetchCount, 1);
+    assert.equal(card._loadedEventRange, null);
+    assert.ok(card._calendarEventMetadata['calendar.a'].range);
+    renderCount = 0;
+
+    await card.ensureEventsForCurrentRange({ renderIfCovered: true });
+    assert.equal(fetchCount, 2);
+    assert.equal(renderCount, 1);
+  } finally {
+    Date.now = originalDateNow;
+  }
+});
+
 test('total calendar fetch failure keeps unloaded range retries throttled', async () => {
   const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
   card._hass = { user: { id: 'user-1' }, states: {} };

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -8561,6 +8561,7 @@ test('total calendar fetch failure keeps unloaded range retries throttled', asyn
   card.getVisibleDateRange = () => ({ startDate: new Date('2026-03-10T00:00:00Z'), endDate: new Date('2026-03-17T00:00:00Z') });
   card.getEventFetchRange = () => ({ startDate: new Date('2026-03-01T00:00:00Z'), endDate: new Date('2026-04-01T00:00:00Z') });
   let fetchCount = 0;
+  let renderCount = 0;
   card.fetchEventsByCalendarInRange = async () => {
     fetchCount += 1;
     return {
@@ -8568,7 +8569,7 @@ test('total calendar fetch failure keeps unloaded range retries throttled', asyn
       'calendar.b': { success: false, events: [] }
     };
   };
-  card.render = () => {};
+  card.render = () => { renderCount += 1; };
   card.ensureEventsForCurrentRange = originalEnsureEventsForCurrentRange.bind(card);
 
   const originalDateNow = Date.now;
@@ -8579,9 +8580,16 @@ test('total calendar fetch failure keeps unloaded range retries throttled', asyn
     assert.equal(fetchCount, 1);
     assert.equal(card._loadedEventRange, null);
     assert.equal(card.isDateRangeCoveredByLoadedEvents(new Date('2026-03-10T00:00:00Z'), new Date('2026-03-17T00:00:00Z')), false);
+    renderCount = 0;
 
     await card.ensureEventsForCurrentRange();
     assert.equal(fetchCount, 1);
+    assert.equal(renderCount, 0);
+    assert.equal(card._loadedEventRange, null);
+
+    await card.ensureEventsForCurrentRange({ renderIfCovered: true });
+    assert.equal(fetchCount, 1);
+    assert.equal(renderCount, 1);
     assert.equal(card._loadedEventRange, null);
 
     now += 60000;

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -8554,6 +8554,51 @@ test('view change requiring refresh renders even when fetched events are identic
   assert.equal(rendered, 1);
 });
 
+test('total calendar fetch failure keeps unloaded range retries throttled', async () => {
+  const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
+  card._hass = { user: { id: 'user-1' }, states: {} };
+  card._loadedEventRange = null;
+  card.getVisibleDateRange = () => ({ startDate: new Date('2026-03-10T00:00:00Z'), endDate: new Date('2026-03-17T00:00:00Z') });
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-03-01T00:00:00Z'), endDate: new Date('2026-04-01T00:00:00Z') });
+  let fetchCount = 0;
+  card.fetchEventsByCalendarInRange = async () => {
+    fetchCount += 1;
+    return {
+      'calendar.a': { success: false, events: [] },
+      'calendar.b': { success: false, events: [] }
+    };
+  };
+  card.render = () => {};
+  card.ensureEventsForCurrentRange = originalEnsureEventsForCurrentRange.bind(card);
+
+  const originalDateNow = Date.now;
+  let now = Date.parse('2026-03-01T12:00:00Z');
+  Date.now = () => now;
+  try {
+    await card.ensureEventsForCurrentRange();
+    assert.equal(fetchCount, 1);
+    assert.equal(card._loadedEventRange, null);
+    assert.equal(card.isDateRangeCoveredByLoadedEvents(new Date('2026-03-10T00:00:00Z'), new Date('2026-03-17T00:00:00Z')), false);
+
+    await card.ensureEventsForCurrentRange();
+    assert.equal(fetchCount, 1);
+    assert.equal(card._loadedEventRange, null);
+
+    now += 60000;
+    await card.ensureEventsForCurrentRange();
+    assert.equal(fetchCount, 1);
+    assert.equal(card._loadedEventRange, null);
+
+    now += 1;
+    await card.ensureEventsForCurrentRange();
+    assert.equal(fetchCount, 2);
+    assert.equal(card._loadedEventRange, null);
+    assert.equal(card.isDateRangeCoveredByLoadedEvents(new Date('2026-03-10T00:00:00Z'), new Date('2026-03-17T00:00:00Z')), false);
+  } finally {
+    Date.now = originalDateNow;
+  }
+});
+
 test('today navigation requiring refresh renders even when fetched events are identical', async () => {
   const card = makeCard({ entities: ['calendar.a'] });
   card._hass = { user: { id: 'user-1' }, states: {} };

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -2534,9 +2534,13 @@ class SkylightCalendarCard extends HTMLElement {
       return;
     }
 
-    if (force || shouldRefreshForAge || !this._loadedEventRange) {
+    if (force || shouldRefreshForAge) {
       const shouldPreserveScrollDuringRefresh = this._viewMode === 'agenda' && !force && !renderIfCovered;
       await this.updateEvents({ preserveScroll: shouldPreserveScrollDuringRefresh, renderAfterFetch: renderIfCovered });
+      return;
+    }
+
+    if (!this._loadedEventRange) {
       return;
     }
 

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -2541,6 +2541,9 @@ class SkylightCalendarCard extends HTMLElement {
     }
 
     if (!this._loadedEventRange) {
+      if (renderIfCovered) {
+        this.render();
+      }
       return;
     }
 

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -2541,6 +2541,14 @@ class SkylightCalendarCard extends HTMLElement {
     }
 
     if (!this._loadedEventRange) {
+      const hasLoadedCalendarRange = (this._config.entities || []).some((entityId) => {
+        const range = this._calendarEventMetadata[entityId]?.range;
+        return !!this.getValidRange(range?.startDate, range?.endDate);
+      });
+      if (renderIfCovered && hasLoadedCalendarRange) {
+        await this.updateEvents({ renderAfterFetch: true });
+        return;
+      }
       if (renderIfCovered) {
         this.render();
       }


### PR DESCRIPTION
### Motivation
- Prevent repeated immediate refetches on every Home Assistant state tick when every calendar fetch fails and `_loadedEventRange` remains `null`.
- Reuse the existing `_lastFetch` / `shouldRefreshEvents()` throttle to control retry timing instead of unconditionally triggering a network fetch whenever `_loadedEventRange` is falsy.

### Description
- Adjusted `ensureEventsForCurrentRange()` to stop treating `!this._loadedEventRange` as an unconditional fetch signal and to rely on `shouldRefreshEvents()` / `_lastFetch` for initial/retry throttling by removing the `|| !this._loadedEventRange` path and returning early when `_loadedEventRange` is still null and a throttle prevents a fetch (`src/skylight-calendar-card.js`).
- Added a regression test `total calendar fetch failure keeps unloaded range retries throttled` that verifies: immediate subsequent calls do not refetch, calls before the 60s threshold do not refetch, a call after the threshold retries once, and failed ranges remain uncovered (`skylight-calendar-card.test.js`).
- Rebuilt the generated/shipped bundle `skylight-calendar-card.js` to match the source change.

### Testing
- Ran `npm test` and the full test suite passed, including the new regression test which validates the 0s/60s/60s+ retry behavior.
- Ran `npm run check:build` which rebuilt `skylight-calendar-card.js` and confirmed the committed bundle is up-to-date.
- Ran `node --check` on `src/skylight-calendar-card.js`, `skylight-calendar-card.js`, and the test file and no syntax errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56d43ab964833185d6b5746b54e1e7)