### PR TITLE
Resume event loading after card reconnect

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -10848,6 +10848,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._pendingEventRenderAfterCurrentFetch = false;
     this._eventRefreshWarningTimer = null;
     this._eventCacheHydrated = false;
+    this._eventLoadingInvalidatedWhileDisconnected = false;
     this._lastSuccessfulEventRefresh = null;
     this._lastEventRefreshFailed = false;
     this._calendarEventMetadata = {};
@@ -13006,8 +13007,20 @@ class SkylightCalendarCard extends HTMLElement {
         const range = this._calendarEventMetadata[entityId]?.range;
         return !!this.getValidRange(range?.startDate, range?.endDate);
       });
+      const hasCalendarMetadata = (this._config.entities || []).some((entityId) => {
+        const metadata = this._calendarEventMetadata[entityId];
+        return !!metadata && Object.keys(metadata).length > 0;
+      });
       if (renderIfCovered && hasLoadedCalendarRange) {
         await this.updateEvents({ renderAfterFetch: true });
+        return;
+      }
+      // A lifecycle invalidation can leave _lastFetch looking recent even though
+      // neither the cache nor the request was allowed to populate usable data.
+      // Retry that unloaded state immediately, while retaining the normal retry
+      // throttle for calendars with recorded failure metadata.
+      if (!hasLoadedCalendarRange && !hasCalendarMetadata) {
+        await this.updateEvents({ renderAfterFetch: renderIfCovered });
         return;
       }
       if (renderIfCovered) {
@@ -13207,6 +13220,11 @@ class SkylightCalendarCard extends HTMLElement {
     this.attachSystemThemeListener();
     this.observeHostAndParentResize();
     this.render();
+    if (this._eventLoadingInvalidatedWhileDisconnected) {
+      this._eventLoadingInvalidatedWhileDisconnected = false;
+      this.loadEventCacheForCurrentConfig();
+      if (this._hass) this.ensureEventsForCurrentRange({ force: true });
+    }
   }
 
   disconnectedCallback() {
@@ -13215,6 +13233,7 @@ class SkylightCalendarCard extends HTMLElement {
     window.visualViewport?.removeEventListener('resize', this._handleViewportResize);
     this._eventCacheGeneration += 1;
     this._eventFetchGeneration += 1;
+    this._eventLoadingInvalidatedWhileDisconnected = true;
     this.clearEventRefreshWarningTimer();
     this.cancelMonthCompactMeasurement();
     if (this._monthGridResizeObserver) {

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -10848,7 +10848,9 @@ class SkylightCalendarCard extends HTMLElement {
     this._pendingEventRenderAfterCurrentFetch = false;
     this._eventRefreshWarningTimer = null;
     this._eventCacheHydrated = false;
+    this._eventCacheLoadInFlight = false;
     this._eventLoadingInvalidatedWhileDisconnected = false;
+    this._eventCacheLoadingInvalidatedWhileDisconnected = false;
     this._lastSuccessfulEventRefresh = null;
     this._lastEventRefreshFailed = false;
     this._calendarEventMetadata = {};
@@ -12543,7 +12545,10 @@ class SkylightCalendarCard extends HTMLElement {
     const requestId = this._eventFetchGeneration;
     const configSignature = this.getEventCacheConfigSignature();
     if (!configSignature) return;
-    const { available, snapshot } = await readEventCacheSnapshot(configSignature);
+    this._eventCacheLoadInFlight = true;
+    const { available, snapshot } = await readEventCacheSnapshot(configSignature).finally(() => {
+      if (generation === this._eventCacheGeneration) this._eventCacheLoadInFlight = false;
+    });
     if (generation !== this._eventCacheGeneration || !available || !snapshot) return;
     const hydratable = this.getHydratableEventCacheSnapshotData(snapshot, requestId);
     if (hydratable.successfulEntityIds.length === 0) return;
@@ -13222,7 +13227,10 @@ class SkylightCalendarCard extends HTMLElement {
     this.render();
     if (this._eventLoadingInvalidatedWhileDisconnected) {
       this._eventLoadingInvalidatedWhileDisconnected = false;
-      this.loadEventCacheForCurrentConfig();
+      if (this._eventCacheLoadingInvalidatedWhileDisconnected) {
+        this._eventCacheLoadingInvalidatedWhileDisconnected = false;
+        this.loadEventCacheForCurrentConfig();
+      }
       if (this._hass) this.ensureEventsForCurrentRange({ force: true });
     }
   }
@@ -13231,7 +13239,11 @@ class SkylightCalendarCard extends HTMLElement {
     window.removeEventListener('resize', this._handleViewportResize);
     window.removeEventListener('daylight-calendar-card-flush-event-cache', this._handleEventCacheFlush);
     window.visualViewport?.removeEventListener('resize', this._handleViewportResize);
+    this._eventCacheLoadingInvalidatedWhileDisconnected = this._eventCacheLoadingInvalidatedWhileDisconnected
+      || this._eventCacheLoadInFlight
+      || !this._loadedEventRange;
     this._eventCacheGeneration += 1;
+    this._eventCacheLoadInFlight = false;
     this._eventFetchGeneration += 1;
     this._eventLoadingInvalidatedWhileDisconnected = true;
     this.clearEventRefreshWarningTimer();

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -4733,6 +4733,30 @@ test('repeated reconnects coalesce replacement event fetches and first connectio
   }
 });
 
+test('reconnect preserves usable in-memory events instead of reloading an older cache snapshot', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const restore = stubLifecycleEnvironment(card);
+  card._hass = { user: { id: 'user-1' }, states: {} };
+  card._events = [{ entityId: 'calendar.a', summary: 'fresh network event' }];
+  card._loadedEventRange = {
+    startDate: new Date('2026-07-01T00:00:00Z'),
+    endDate: new Date('2026-08-01T00:00:00Z')
+  };
+  let cacheLoads = 0;
+  card.loadEventCacheForCurrentConfig = () => { cacheLoads += 1; };
+  card.ensureEventsForCurrentRange = () => {};
+
+  try {
+    card.disconnectedCallback();
+    card.connectedCallback();
+
+    assert.equal(cacheLoads, 0);
+    assert.equal(card._events[0].summary, 'fresh network event');
+  } finally {
+    restore();
+  }
+});
+
 test('day_badge CSS variables do not leak into non-badge selectors', () => {
   const card = makeCard({ entities: ['calendar.a'] });
   const styles = card.getStyles();

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -4607,6 +4607,132 @@ test('disconnectedCallback disconnects host ResizeObserver', () => {
   }
 });
 
+function stubLifecycleEnvironment(card) {
+  const originals = {
+    addEventListener: window.addEventListener,
+    removeEventListener: window.removeEventListener,
+    cancelAnimationFrame: window.cancelAnimationFrame
+  };
+  window.addEventListener = () => {};
+  window.removeEventListener = () => {};
+  window.cancelAnimationFrame = () => {};
+  card.attachSystemThemeListener = () => {};
+  card.detachSystemThemeListener = () => {};
+  card.observeHostAndParentResize = () => {};
+  card.teardownWeatherForecastSubscription = () => {};
+  card.updateEventModalOpenState = () => {};
+  card.cancelMonthCompactMeasurement = () => {};
+  card.render = () => {};
+  return () => Object.assign(window, originals);
+}
+
+test('reconnect invalidates a delayed request and promptly replaces it without waiting for staleness', async () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const restore = stubLifecycleEnvironment(card);
+  card._hass = { user: { id: 'user-1' }, states: {} };
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-07-01T00:00:00Z'), endDate: new Date('2026-08-01T00:00:00Z') });
+  const pending = [];
+  let fetchCount = 0;
+  card.fetchEventsByCalendarInRange = () => {
+    fetchCount += 1;
+    return new Promise(resolve => pending.push(resolve));
+  };
+  card.persistEventCacheSnapshot = () => {};
+  card.loadEventCacheForCurrentConfig = () => {};
+  card.ensureEventsForCurrentRange = originalEnsureEventsForCurrentRange.bind(card);
+
+  try {
+    const oldRequest = card.updateEvents();
+    assert.equal(fetchCount, 1);
+    card.disconnectedCallback();
+    card.connectedCallback();
+    assert.equal(card._pendingEventRefreshAfterCurrentFetch, true);
+
+    pending[0]({
+      'calendar.a': { success: true, events: [{ entityId: 'calendar.a', summary: 'obsolete', start: { date: '2026-07-10' }, end: { date: '2026-07-11' } }] }
+    });
+    await oldRequest;
+    assert.equal(fetchCount, 2);
+    assert.deepEqual(card._events, []);
+
+    pending[1]({
+      'calendar.a': { success: true, events: [{ entityId: 'calendar.a', summary: 'reconnected', start: { date: '2026-07-12' }, end: { date: '2026-07-13' } }] }
+    });
+    while (card._fetching) await new Promise(resolve => setTimeout(resolve, 0));
+    assert.equal(card._events[0].summary, 'reconnected');
+    assert.equal(fetchCount, 2);
+  } finally {
+    restore();
+  }
+});
+
+test('reconnect restarts invalidated delayed cache hydration and ignores its obsolete result', async () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const restore = stubLifecycleEnvironment(card);
+  card._hass = null;
+  const pending = [];
+  card.loadEventCacheForCurrentConfig = function() {
+    const generation = ++this._eventCacheGeneration;
+    return new Promise(resolve => pending.push(() => {
+      if (generation === this._eventCacheGeneration) this._events = [{ summary: `cache-${generation}` }];
+      resolve();
+    }));
+  };
+
+  try {
+    const oldCacheRead = card.loadEventCacheForCurrentConfig();
+    card.disconnectedCallback();
+    card.connectedCallback();
+    assert.equal(pending.length, 2);
+    pending[0]();
+    await oldCacheRead;
+    assert.deepEqual(card._events, []);
+    pending[1]();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    assert.equal(card._events[0].summary, `cache-${card._eventCacheGeneration}`);
+  } finally {
+    restore();
+  }
+});
+
+test('repeated reconnects coalesce replacement event fetches and first connection stays unchanged', async () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const restore = stubLifecycleEnvironment(card);
+  card._hass = { user: { id: 'user-1' }, states: {} };
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-07-01T00:00:00Z'), endDate: new Date('2026-08-01T00:00:00Z') });
+  const pending = [];
+  let fetchCount = 0;
+  let cacheLoads = 0;
+  card.fetchEventsByCalendarInRange = () => {
+    fetchCount += 1;
+    return new Promise(resolve => pending.push(resolve));
+  };
+  card.loadEventCacheForCurrentConfig = () => { cacheLoads += 1; };
+  card.persistEventCacheSnapshot = () => {};
+  card.ensureEventsForCurrentRange = originalEnsureEventsForCurrentRange.bind(card);
+
+  try {
+    card.connectedCallback();
+    assert.equal(fetchCount, 0);
+    assert.equal(cacheLoads, 0);
+    const oldRequest = card.updateEvents();
+    for (let index = 0; index < 3; index += 1) {
+      card.disconnectedCallback();
+      card.connectedCallback();
+    }
+    assert.equal(fetchCount, 1);
+    assert.equal(cacheLoads, 3);
+    pending[0]({ 'calendar.a': { success: true, events: [] } });
+    await oldRequest;
+    assert.equal(fetchCount, 2);
+    pending[1]({ 'calendar.a': { success: true, events: [] } });
+    while (card._fetching) await new Promise(resolve => setTimeout(resolve, 0));
+    assert.equal(fetchCount, 2);
+  } finally {
+    restore();
+  }
+});
+
 test('day_badge CSS variables do not leak into non-badge selectors', () => {
   const card = makeCard({ entities: ['calendar.a'] });
   const styles = card.getStyles();
@@ -8479,6 +8605,30 @@ test('normal hass update does not queue redundant refresh while forced setConfig
   card._pendingEventRefreshAfterCurrentFetch = false;
   await card.ensureEventsForCurrentRange();
   assert.equal(card._pendingEventRefreshAfterCurrentFetch, false);
+});
+
+test('recent invalidated fetch timestamp does not delay an entirely unloaded card', async () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  card._hass = { user: { id: 'user-1' }, states: {} };
+  card._lastFetch = Date.now();
+  card._loadedEventRange = null;
+  card._calendarEventMetadata = {};
+  card.getVisibleDateRange = () => ({ startDate: new Date('2026-07-10T00:00:00Z'), endDate: new Date('2026-07-17T00:00:00Z') });
+  card.getEventFetchRange = () => ({ startDate: new Date('2026-07-01T00:00:00Z'), endDate: new Date('2026-08-01T00:00:00Z') });
+  let fetchCount = 0;
+  card.fetchEventsByCalendarInRange = async () => {
+    fetchCount += 1;
+    return {
+      'calendar.a': { success: true, events: [{ entityId: 'calendar.a', summary: 'prompt', start: { date: '2026-07-12' }, end: { date: '2026-07-13' } }] }
+    };
+  };
+  card.persistEventCacheSnapshot = () => {};
+  card.ensureEventsForCurrentRange = originalEnsureEventsForCurrentRange.bind(card);
+
+  await card.ensureEventsForCurrentRange();
+
+  assert.equal(fetchCount, 1);
+  assert.equal(card._events[0].summary, 'prompt');
 });
 
 test('active fetch queues follow-up when switched view needs uncovered range', async () => {

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -387,6 +387,7 @@ class SkylightCalendarCard extends HTMLElement {
     this._pendingEventRenderAfterCurrentFetch = false;
     this._eventRefreshWarningTimer = null;
     this._eventCacheHydrated = false;
+    this._eventLoadingInvalidatedWhileDisconnected = false;
     this._lastSuccessfulEventRefresh = null;
     this._lastEventRefreshFailed = false;
     this._calendarEventMetadata = {};
@@ -2545,8 +2546,20 @@ class SkylightCalendarCard extends HTMLElement {
         const range = this._calendarEventMetadata[entityId]?.range;
         return !!this.getValidRange(range?.startDate, range?.endDate);
       });
+      const hasCalendarMetadata = (this._config.entities || []).some((entityId) => {
+        const metadata = this._calendarEventMetadata[entityId];
+        return !!metadata && Object.keys(metadata).length > 0;
+      });
       if (renderIfCovered && hasLoadedCalendarRange) {
         await this.updateEvents({ renderAfterFetch: true });
+        return;
+      }
+      // A lifecycle invalidation can leave _lastFetch looking recent even though
+      // neither the cache nor the request was allowed to populate usable data.
+      // Retry that unloaded state immediately, while retaining the normal retry
+      // throttle for calendars with recorded failure metadata.
+      if (!hasLoadedCalendarRange && !hasCalendarMetadata) {
+        await this.updateEvents({ renderAfterFetch: renderIfCovered });
         return;
       }
       if (renderIfCovered) {
@@ -2746,6 +2759,11 @@ class SkylightCalendarCard extends HTMLElement {
     this.attachSystemThemeListener();
     this.observeHostAndParentResize();
     this.render();
+    if (this._eventLoadingInvalidatedWhileDisconnected) {
+      this._eventLoadingInvalidatedWhileDisconnected = false;
+      this.loadEventCacheForCurrentConfig();
+      if (this._hass) this.ensureEventsForCurrentRange({ force: true });
+    }
   }
 
   disconnectedCallback() {
@@ -2754,6 +2772,7 @@ class SkylightCalendarCard extends HTMLElement {
     window.visualViewport?.removeEventListener('resize', this._handleViewportResize);
     this._eventCacheGeneration += 1;
     this._eventFetchGeneration += 1;
+    this._eventLoadingInvalidatedWhileDisconnected = true;
     this.clearEventRefreshWarningTimer();
     this.cancelMonthCompactMeasurement();
     if (this._monthGridResizeObserver) {

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -387,7 +387,9 @@ class SkylightCalendarCard extends HTMLElement {
     this._pendingEventRenderAfterCurrentFetch = false;
     this._eventRefreshWarningTimer = null;
     this._eventCacheHydrated = false;
+    this._eventCacheLoadInFlight = false;
     this._eventLoadingInvalidatedWhileDisconnected = false;
+    this._eventCacheLoadingInvalidatedWhileDisconnected = false;
     this._lastSuccessfulEventRefresh = null;
     this._lastEventRefreshFailed = false;
     this._calendarEventMetadata = {};
@@ -2082,7 +2084,10 @@ class SkylightCalendarCard extends HTMLElement {
     const requestId = this._eventFetchGeneration;
     const configSignature = this.getEventCacheConfigSignature();
     if (!configSignature) return;
-    const { available, snapshot } = await readEventCacheSnapshot(configSignature);
+    this._eventCacheLoadInFlight = true;
+    const { available, snapshot } = await readEventCacheSnapshot(configSignature).finally(() => {
+      if (generation === this._eventCacheGeneration) this._eventCacheLoadInFlight = false;
+    });
     if (generation !== this._eventCacheGeneration || !available || !snapshot) return;
     const hydratable = this.getHydratableEventCacheSnapshotData(snapshot, requestId);
     if (hydratable.successfulEntityIds.length === 0) return;
@@ -2761,7 +2766,10 @@ class SkylightCalendarCard extends HTMLElement {
     this.render();
     if (this._eventLoadingInvalidatedWhileDisconnected) {
       this._eventLoadingInvalidatedWhileDisconnected = false;
-      this.loadEventCacheForCurrentConfig();
+      if (this._eventCacheLoadingInvalidatedWhileDisconnected) {
+        this._eventCacheLoadingInvalidatedWhileDisconnected = false;
+        this.loadEventCacheForCurrentConfig();
+      }
       if (this._hass) this.ensureEventsForCurrentRange({ force: true });
     }
   }
@@ -2770,7 +2778,11 @@ class SkylightCalendarCard extends HTMLElement {
     window.removeEventListener('resize', this._handleViewportResize);
     window.removeEventListener('daylight-calendar-card-flush-event-cache', this._handleEventCacheFlush);
     window.visualViewport?.removeEventListener('resize', this._handleViewportResize);
+    this._eventCacheLoadingInvalidatedWhileDisconnected = this._eventCacheLoadingInvalidatedWhileDisconnected
+      || this._eventCacheLoadInFlight
+      || !this._loadedEventRange;
     this._eventCacheGeneration += 1;
+    this._eventCacheLoadInFlight = false;
     this._eventFetchGeneration += 1;
     this._eventLoadingInvalidatedWhileDisconnected = true;
     this.clearEventRefreshWarningTimer();


### PR DESCRIPTION
### Motivation
- Fix a lifecycle race where Masonry/Sections dashboards could disconnect/reconnect the same card instance and leave it rendered with no events until the stale-refresh interval elapsed.
- The disconnect path increments generation counters, making in-flight cache/network results obsolete while `_lastFetch` could already be updated, preventing an immediate retry.

### Description
- Add a reconnect marker `_eventLoadingInvalidatedWhileDisconnected` and set it in `disconnectedCallback()` to record lifecycle invalidation while preserving existing generation protections. 
- On `connectedCallback()` clear the marker and promptly restart persistent cache hydration via `loadEventCacheForCurrentConfig()` and force `ensureEventsForCurrentRange({ force: true })` when `hass` is present. 
- Update `ensureEventsForCurrentRange()` so that when there is no `_loadedEventRange` and no per-calendar metadata the card immediately calls `updateEvents()` instead of returning due to a recent `_lastFetch`, while preserving throttled retry behavior for calendars with failure metadata. 
- Add focused unit tests in `skylight-calendar-card.test.js` that simulate delayed network requests and delayed cache reads across `disconnectedCallback()`/`connectedCallback()` and verify obsolete results are ignored, prompt reconnection recovery occurs, repeated reconnects coalesce replacement fetches, and unloaded-card-first-load behavior remains correct. 
- Regenerate the shipped bundle `skylight-calendar-card.js` from `src/skylight-calendar-card.js` so the artifact matches source changes.

### Testing
- Ran `npm test` (unit suite) and all tests passed: `406` tests green. 
- Ran `npm run test:visual` (Playwright visual tests) and all `46` visual tests passed. 
- Ran build and sanity checks: `npm run build`, `node --check src/skylight-calendar-card.js`, and `node --check skylight-calendar-card.js` all succeeded and the generated `skylight-calendar-card.js` is up-to-date. 
- Verified the new regression tests exercising disconnect/reconnect, cache hydration, stale-generation rejection, and immediate retry behavior pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a592298b848833184181cf11d837632)