### PR TITLE
Preserve fresh per-calendar data during reconnect hydration

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -12610,6 +12610,10 @@ class SkylightCalendarCard extends HTMLElement {
       const cachedRange = this.getValidRange(cachedMetadata.range?.startDate, cachedMetadata.range?.endDate);
       const cachedLastSuccessfulRefresh = cachedMetadata.lastSuccessfulRefresh;
       if (!cachedRange || !Number.isFinite(cachedLastSuccessfulRefresh)) return;
+      const existingRange = this.getValidRange(metadata.range?.startDate, metadata.range?.endDate);
+      if (existingRange
+        && Number.isFinite(metadata.lastSuccessfulRefresh)
+        && metadata.lastSuccessfulRefresh >= cachedLastSuccessfulRefresh) return;
       cacheEventsByCalendar[entityId] = snapshot.eventsByCalendar[entityId];
       cacheMetadataByCalendar[entityId] = {
         range: cachedRange,

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -4757,6 +4757,66 @@ test('reconnect preserves usable in-memory events instead of reloading an older 
   }
 });
 
+test('reconnect cache hydration preserves fresher per-calendar data after a partial fetch', () => {
+  const card = makeCard({ entities: ['calendar.a', 'calendar.b'] });
+  const restore = stubLifecycleEnvironment(card);
+  const range = { startDate: new Date('2026-07-01T00:00:00Z'), endDate: new Date('2026-08-01T00:00:00Z') };
+  const freshRefresh = Date.parse('2026-07-15T12:00:00Z');
+  const cachedRefresh = Date.parse('2026-07-10T12:00:00Z');
+  card._hass = { user: { id: 'user-1' }, states: {} };
+  card._eventsByCalendar = {
+    'calendar.a': [{ entityId: 'calendar.a', summary: 'fresh network a', start: { date: '2026-07-12' }, end: { date: '2026-07-13' } }]
+  };
+  card._calendarEventMetadata = {
+    'calendar.a': { range, lastSuccessfulRefresh: freshRefresh, lastNetworkSuccessRequest: 1 },
+    'calendar.b': { refreshFailed: true }
+  };
+  card.recomputeEventState();
+  assert.equal(card._loadedEventRange, null);
+
+  const snapshot = {
+    eventsByCalendar: {
+      'calendar.a': [{ entityId: 'calendar.a', summary: 'older cached a', start: { date: '2026-07-05' }, end: { date: '2026-07-06' } }],
+      'calendar.b': [{ entityId: 'calendar.b', summary: 'cached b', start: { date: '2026-07-07' }, end: { date: '2026-07-08' } }]
+    },
+    perCalendarMetadata: {
+      'calendar.a': { range, lastSuccessfulRefresh: cachedRefresh },
+      'calendar.b': { range, lastSuccessfulRefresh: cachedRefresh }
+    }
+  };
+  card.loadEventCacheForCurrentConfig = function() {
+    const hydratable = this.getHydratableEventCacheSnapshotData(snapshot, this._eventFetchGeneration);
+    this.applyEventsByCalendar(hydratable.eventsByCalendar, {
+      startDate: range.startDate,
+      endDate: range.endDate,
+      lastSuccessfulRefresh: cachedRefresh,
+      successfulEntityIds: hydratable.successfulEntityIds,
+      source: 'cache',
+      requestId: this._eventFetchGeneration,
+      perCalendarMetadata: hydratable.perCalendarMetadata
+    });
+  };
+  card.ensureEventsForCurrentRange = function() {
+    this.applyEventsByCalendar({}, {
+      successfulEntityIds: [],
+      failedEntityIds: ['calendar.a', 'calendar.b'],
+      source: 'network',
+      requestId: this._eventFetchGeneration
+    });
+  };
+
+  try {
+    card.disconnectedCallback();
+    card.connectedCallback();
+
+    assert.equal(card._eventsByCalendar['calendar.a'][0].summary, 'fresh network a');
+    assert.equal(card._eventsByCalendar['calendar.b'][0].summary, 'cached b');
+    assert.equal(card._lastEventRefreshFailed, true);
+  } finally {
+    restore();
+  }
+});
+
 test('day_badge CSS variables do not leak into non-badge selectors', () => {
   const card = makeCard({ entities: ['calendar.a'] });
   const styles = card.getStyles();

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -2119,6 +2119,10 @@ class SkylightCalendarCard extends HTMLElement {
       const cachedRange = this.getValidRange(cachedMetadata.range?.startDate, cachedMetadata.range?.endDate);
       const cachedLastSuccessfulRefresh = cachedMetadata.lastSuccessfulRefresh;
       if (!cachedRange || !Number.isFinite(cachedLastSuccessfulRefresh)) return;
+      const existingRange = this.getValidRange(metadata.range?.startDate, metadata.range?.endDate);
+      if (existingRange
+        && Number.isFinite(metadata.lastSuccessfulRefresh)
+        && metadata.lastSuccessfulRefresh >= cachedLastSuccessfulRefresh) return;
       cacheEventsByCalendar[entityId] = snapshot.eventsByCalendar[entityId];
       cacheMetadataByCalendar[entityId] = {
         range: cachedRange,


### PR DESCRIPTION
### Motivation
- A partial calendar fetch could leave one calendar with fresh in-memory events while another lacked coverage, making the aggregate `_loadedEventRange` null and allowing a reconnect cache hydration to overwrite fresher per-calendar data with older cached snapshots.
- The intent is to prevent stale cached data from replacing newer in-memory calendar data during reconnect cache hydration while still hydrating calendars that have no usable in-memory coverage.

### Description
- Add a per-calendar guard in `getHydratableEventCacheSnapshotData()` that compares the in-memory calendar `lastSuccessfulRefresh` and range against the cached per-calendar `lastSuccessfulRefresh`, and skips including the cached calendar when the in-memory data is at least as recent. 
- Preserve the existing request-generation protections (`lastNetworkSuccessRequest`/`requestId`) and leave calendars without usable in-memory coverage eligible for cache hydration. 
- Regenerate and commit the shipped root artifact `skylight-calendar-card.js` via the repository `npm run build` process so the runtime artifact matches the source change. 
- Add a focused regression test that simulates: Calendar A with fresh network events and valid metadata, Calendar B lacking coverage, a cache snapshot containing older Calendar A data, a reconnect that hydrates the cache, and a failing reconnect network refresh — asserting Calendar A’s fresh in-memory events are preserved while Calendar B may be hydrated from cache.

### Testing
- Ran `npm run build` and committed the regenerated `skylight-calendar-card.js`, and the build completed successfully. 
- Verified syntax with `node --check src/skylight-calendar-card.js` and `node --check skylight-calendar-card.js` which passed. 
- Ran the unit test suite with `npm test` and all tests passed (408 tests). 
- Verified `git diff --exit-code -- skylight-calendar-card.js` after the build to ensure the generated artifact was fresh and the working tree is clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a9a6ef8948331b92e7db4744ff6e8)