### PR TITLE
Fix recurring event weekday not checked and modal button overflow

### DIFF
--- a/playwright/visual.spec.js
+++ b/playwright/visual.spec.js
@@ -893,6 +893,14 @@ async function expectBoxWithin(inner, outer, tolerance = 2) {
   expect(innerBox.y + innerBox.height).toBeLessThanOrEqual(outerBox.y + outerBox.height + tolerance);
 }
 
+async function assertNoHorizontalOverflow(locator, tolerance = 1) {
+  const dimensions = await locator.evaluate((el) => ({
+    clientWidth: el.clientWidth,
+    scrollWidth: el.scrollWidth
+  }));
+  expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth + tolerance);
+}
+
 async function expectBoxWithinViewport(locator, viewport, tolerance = 2) {
   const box = await locator.boundingBox();
   expect(box).not.toBeNull();
@@ -1392,6 +1400,73 @@ test('regression issue 321: compact wrapped header rows stay centered at medium 
   await expect.poll(async () => headerGroupsShareRow(left, controls)).toBe(false);
   await expect.poll(async () => centerOffsetWithinTolerance(header, left)).toBe(true);
   await expect.poll(async () => centerOffsetWithinTolerance(header, controls)).toBe(true);
+});
+
+test('regression issue 496: modal action buttons wrap instead of overflowing on small screens', async ({ page }) => {
+  // 320px is the classic "small phone" width and the one most likely to
+  // reproduce #496 (long translated button labels forcing horizontal scroll).
+  await page.setViewportSize({ width: 320, height: 640 });
+  const fixtureUrl = `file://${path.join(process.cwd(), 'playwright', 'ha-fixture.html')}`;
+  await page.goto(fixtureUrl);
+  // Give the Coffee event a uid so the edit/delete buttons render (both are
+  // required to exercise the .modal-actions and .form-actions button rows).
+  const eventsWithEditableCoffee = {
+    ...baseEvents,
+    'calendar.family': baseEvents['calendar.family'].map((evt) =>
+      evt.summary === 'Coffee' ? { ...evt, uid: 'playwright-coffee-uid' } : evt)
+  };
+  await page.evaluate((params) => window.renderCalendarCard(params), {
+    config: { entities: ['calendar.family'], default_view: 'month', enable_event_management: true },
+    events: eventsWithEditableCoffee,
+    darkMode: false
+  });
+
+  const card = page.locator('skylight-calendar-card');
+  await expect(card).toBeVisible();
+  const coffeeEvent = card.locator('.event').filter({ hasText: 'Coffee' });
+  await expect(coffeeEvent).toBeVisible();
+  await coffeeEvent.click();
+
+  const modal = card.locator('#event-modal');
+  await expect(modal).toHaveClass(/show/);
+
+  // Simulate a translation whose button labels are long, unbroken compound
+  // words (the scenario #496 reports) instead of relying on any specific
+  // language actually shipping such a string today.
+  const LONG_LABEL = 'Antidisestablishmentarianismverylongunbrokenwordwithnobreakopportunities';
+  const modalContent = card.locator('#modal-content');
+  const modalActions = card.locator('.modal-actions');
+
+  await modalActions.locator('.btn').evaluateAll((buttons, label) => {
+    buttons.forEach((btn) => { btn.textContent = label; });
+  }, LONG_LABEL);
+
+  await assertNoHorizontalOverflow(modalContent);
+  await assertNoHorizontalOverflow(modalActions);
+  const detailButtons = await modalActions.locator('.btn').all();
+  for (const btn of detailButtons) {
+    await assertNoHorizontalOverflow(btn);
+  }
+
+  // Open the edit form and repeat for its Cancel/Save Changes button row.
+  await card.locator('#edit-event-btn').click();
+  const editForm = card.locator('#edit-event-form');
+  await expect(editForm).toBeVisible();
+
+  const formActions = card.locator('.form-actions');
+  await formActions.locator('.btn').evaluateAll((buttons, label) => {
+    buttons.forEach((btn) => { btn.textContent = label; });
+  }, LONG_LABEL);
+
+  await assertNoHorizontalOverflow(modalContent);
+  await assertNoHorizontalOverflow(formActions);
+  const formButtons = await formActions.locator('.btn').all();
+  for (const btn of formButtons) {
+    await assertNoHorizontalOverflow(btn);
+  }
+
+  // And confirm the page itself never grew a horizontal scrollbar.
+  await assertNoHorizontalOverflow(page.locator('body'));
 });
 
 test('regression issue 321: standard header stays single-row', async ({ page }) => {

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -5435,6 +5435,7 @@ function getCardStyles() {
         gap: 12px;
         justify-content: flex-end;
         margin-top: 6px;
+        max-width: 100%;
       }
 
       .btn {
@@ -5447,7 +5448,9 @@ function getCardStyles() {
         border: none;
         font-family: inherit;
         min-width: 0;
-        overflow-wrap: break-word;
+        max-width: 100%;
+        white-space: normal;
+        overflow-wrap: anywhere;
       }
 
       .btn-primary {
@@ -5498,18 +5501,21 @@ function getCardStyles() {
         justify-content: space-between;
         margin-top: 24px;
         align-items: center;
+        max-width: 100%;
       }
 
       .modal-actions-left {
         display: flex;
         flex-wrap: wrap;
         gap: 12px;
+        max-width: 100%;
       }
 
       .modal-actions-right {
         display: flex;
         flex-wrap: wrap;
         gap: 12px;
+        max-width: 100%;
       }
 
       .confirm-dialog {
@@ -16472,11 +16478,13 @@ class SkylightCalendarCard extends HTMLElement {
     });
 
     // WEEKLY rules may omit BYDAY, in which case the recurrence is implied
-    // by DTSTART's weekday (RFC 5545 §3.3.10).
+    // by DTSTART's weekday (RFC 5545 §3.3.10). Use the card's configured
+    // time_zone (via getDateParts) rather than the browser's local zone,
+    // since DTSTART's weekday can differ between the two.
     if (parsed.frequency === 'WEEKLY' && parsed.byDay.length === 0 &&
         fallbackStartDate instanceof Date && !Number.isNaN(fallbackStartDate.getTime())) {
       const weekdayCodes = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
-      parsed.byDay = [weekdayCodes[fallbackStartDate.getDay()]];
+      parsed.byDay = [weekdayCodes[this.getDateParts(fallbackStartDate).weekday]];
     }
 
     return parsed;

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -5013,9 +5013,11 @@ function getCardStyles() {
         padding: 24px;
         max-width: 500px;
         width: 90%;
+        box-sizing: border-box;
         max-height: 80vh;
         max-height: min(80vh, calc(100dvh - 32px));
         overflow-y: auto;
+        overflow-x: hidden;
         box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
       }
 
@@ -5026,6 +5028,7 @@ function getCardStyles() {
       }
 
       .modal-content.modal-size-medium {
+        box-sizing: border-box;
         max-width: 500px;
         width: 90%;
       }
@@ -5428,6 +5431,7 @@ function getCardStyles() {
 
       .form-actions {
         display: flex;
+        flex-wrap: wrap;
         gap: 12px;
         justify-content: flex-end;
         margin-top: 6px;
@@ -5442,6 +5446,8 @@ function getCardStyles() {
         transition: all 0.2s;
         border: none;
         font-family: inherit;
+        min-width: 0;
+        overflow-wrap: break-word;
       }
 
       .btn-primary {
@@ -5487,6 +5493,7 @@ function getCardStyles() {
 
       .modal-actions {
         display: flex;
+        flex-wrap: wrap;
         gap: 12px;
         justify-content: space-between;
         margin-top: 24px;
@@ -5495,11 +5502,13 @@ function getCardStyles() {
 
       .modal-actions-left {
         display: flex;
+        flex-wrap: wrap;
         gap: 12px;
       }
 
       .modal-actions-right {
         display: flex;
+        flex-wrap: wrap;
         gap: 12px;
       }
 
@@ -16421,7 +16430,7 @@ class SkylightCalendarCard extends HTMLElement {
     return buildRRuleFromInputs({ frequency, interval, untilDate, count, byDay });
   }
 
-  parseRRule(rrule = '') {
+  parseRRule(rrule = '', fallbackStartDate = null) {
     const parsed = {
       frequency: 'DAILY',
       interval: '1',
@@ -16461,6 +16470,14 @@ class SkylightCalendarCard extends HTMLElement {
         }
       }
     });
+
+    // WEEKLY rules may omit BYDAY, in which case the recurrence is implied
+    // by DTSTART's weekday (RFC 5545 §3.3.10).
+    if (parsed.frequency === 'WEEKLY' && parsed.byDay.length === 0 &&
+        fallbackStartDate instanceof Date && !Number.isNaN(fallbackStartDate.getTime())) {
+      const weekdayCodes = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
+      parsed.byDay = [weekdayCodes[fallbackStartDate.getDay()]];
+    }
 
     return parsed;
   }
@@ -16585,7 +16602,7 @@ class SkylightCalendarCard extends HTMLElement {
 
     // For all-day events, show same day to user (we'll add +1 when submitting)
     const endDate = prefill?.endDate ? new Date(prefill.endDate) : new Date(startDate);
-    const recurrenceData = this.parseRRule(prefill?.rrule || '');
+    const recurrenceData = this.parseRRule(prefill?.rrule || '', startDate);
     const isPrefilledRecurring = !!prefill?.rrule;
     const isPrefilledAllDay = !!prefill?.isAllDay;
 
@@ -16783,7 +16800,7 @@ class SkylightCalendarCard extends HTMLElement {
       : [];
     const visibleCalendarOptions = selectedCombinedCalendarIds.length > 0 ? selectedCombinedCalendarIds : writableCalendars;
 
-    const recurrenceData = this.parseRRule(event.rrule || '');
+    const recurrenceData = this.parseRRule(event.rrule || '', startDate);
     const isRecurring = !!event.rrule;
     const isSingleOccurrenceEdit = editScope === 'this' && isRecurring;
     const recurringSelectedByDefault = isRecurring && !isSingleOccurrenceEdit;

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -8971,6 +8971,48 @@ test('parseRRule does not infer byDay for non-WEEKLY frequencies', () => {
   assert.deepEqual(parsed.byDay, []);
 });
 
+test('parseRRule infers weekday using the configured time_zone, not the browser local zone', () => {
+  const originalTZ = process.env.TZ;
+  try {
+    // Simulate a browser whose local zone is Chicago.
+    process.env.TZ = 'America/Chicago';
+
+    // 2026-07-14T23:00:00Z is still Tuesday 18:00 in Chicago (UTC-5),
+    // but already Wednesday 11:00 in Auckland (UTC+12) — the two zones
+    // disagree on the calendar day, which is exactly what this guards.
+    const instant = new Date('2026-07-14T23:00:00Z');
+    assert.equal(instant.getDay(), 2, 'test setup: browser-local (Chicago) day must be Tuesday');
+
+    const card = makeCard({ entities: ['calendar.a'], time_zone: 'Pacific/Auckland' });
+    const parsed = card.parseRRule('FREQ=WEEKLY;INTERVAL=1', instant);
+
+    assert.deepEqual(parsed.byDay, ['WE'], 'should use the configured Auckland weekday, not the browser-local Tuesday');
+  } finally {
+    if (originalTZ === undefined) {
+      delete process.env.TZ;
+    } else {
+      process.env.TZ = originalTZ;
+    }
+  }
+});
+
+test('parseRRule falls back to the browser local weekday when no time_zone is configured', () => {
+  const originalTZ = process.env.TZ;
+  try {
+    process.env.TZ = 'America/Chicago';
+    const instant = new Date('2026-07-14T23:00:00Z');
+    const card = makeCard({ entities: ['calendar.a'] });
+    const parsed = card.parseRRule('FREQ=WEEKLY;INTERVAL=1', instant);
+    assert.deepEqual(parsed.byDay, ['TU']);
+  } finally {
+    if (originalTZ === undefined) {
+      delete process.env.TZ;
+    } else {
+      process.env.TZ = originalTZ;
+    }
+  }
+});
+
 test('showEditEventModal checks the correct weekday when the event rrule omits BYDAY', () => {
   const card = makeCard({ entities: ['calendar.family'], enable_event_management: true });
   card.getWritableCalendars = () => ['calendar.family'];

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -8949,3 +8949,72 @@ test('failed refresh preserves last-known-good events and stale warning timing',
   card._lastEventRefreshFailed = false;
   assert.equal(card.shouldShowEventRefreshWarning(Date.now() + 31 * 60 * 1000), false);
 });
+
+test('parseRRule infers weekday from start date when WEEKLY rule omits BYDAY', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const wednesday = new Date(2026, 6, 15); // 2026-07-15 is a Wednesday
+  const parsed = card.parseRRule('FREQ=WEEKLY;INTERVAL=1', wednesday);
+  assert.deepEqual(parsed.byDay, ['WE']);
+});
+
+test('parseRRule keeps explicit BYDAY when present, ignoring fallback start date', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const wednesday = new Date(2026, 6, 15);
+  const parsed = card.parseRRule('FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,FR', wednesday);
+  assert.deepEqual(parsed.byDay, ['MO', 'FR']);
+});
+
+test('parseRRule does not infer byDay for non-WEEKLY frequencies', () => {
+  const card = makeCard({ entities: ['calendar.a'] });
+  const wednesday = new Date(2026, 6, 15);
+  const parsed = card.parseRRule('FREQ=DAILY;INTERVAL=1', wednesday);
+  assert.deepEqual(parsed.byDay, []);
+});
+
+test('showEditEventModal checks the correct weekday when the event rrule omits BYDAY', () => {
+  const card = makeCard({ entities: ['calendar.family'], enable_event_management: true });
+  card.getWritableCalendars = () => ['calendar.family'];
+  card.getCalendarName = () => 'Family';
+  card.applyEventModalSizeClass = () => {};
+  card.syncRecurrenceEndInputs = () => {};
+  card.setupStartEndDurationSync = () => {};
+  const modal = { classList: createClassListHarness() };
+  const content = { innerHTML: '' };
+  const elements = {
+    'event-modal': modal,
+    'modal-content': content,
+    'edit-event-form': { addEventListener: () => {} },
+    'event-all-day': { checked: false, addEventListener: () => {} },
+    'event-recurring': { checked: true, addEventListener: () => {} },
+    'event-recurrence-frequency': { value: 'WEEKLY', addEventListener: () => {} },
+    'timed-event-fields': { style: {} },
+    'all-day-event-fields': { style: {} },
+    'recurring-event-fields': { style: {} },
+    'event-recurrence-weekdays-group': { style: {} },
+    'form-error': { textContent: '', style: {} },
+    'close-modal': { addEventListener: () => {} },
+    'cancel-btn': { addEventListener: () => {} }
+  };
+  card.getRootElementById = (id) => elements[id] || null;
+  card._root = {
+    querySelectorAll: () => [],
+    querySelector: () => null
+  };
+
+  const startDate = new Date('2026-07-15T09:00:00Z'); // a Wednesday
+  card.showEditEventModal(
+    { entityId: 'calendar.family', uid: 'evt-1', summary: 'Practice', rrule: 'FREQ=WEEKLY;INTERVAL=1', start: { dateTime: '2026-07-15T09:00:00Z' }, end: { dateTime: '2026-07-15T10:00:00Z' } },
+    startDate,
+    new Date('2026-07-15T10:00:00Z'),
+    false,
+    'all'
+  );
+
+  const weCheckboxMatch = content.innerHTML.match(/<input type="checkbox" class="form-checkbox event-recurrence-weekday" value="WE"[^>]*>/);
+  assert.ok(weCheckboxMatch, 'expected a WE weekday checkbox to be rendered');
+  assert.match(weCheckboxMatch[0], /checked/);
+
+  const moCheckboxMatch = content.innerHTML.match(/<input type="checkbox" class="form-checkbox event-recurrence-weekday" value="MO"[^>]*>/);
+  assert.ok(moCheckboxMatch, 'expected a MO weekday checkbox to be rendered');
+  assert.doesNotMatch(moCheckboxMatch[0], /checked/);
+});

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -5930,7 +5930,7 @@ class SkylightCalendarCard extends HTMLElement {
     return buildRRuleFromInputsHelper({ frequency, interval, untilDate, count, byDay });
   }
 
-  parseRRule(rrule = '') {
+  parseRRule(rrule = '', fallbackStartDate = null) {
     const parsed = {
       frequency: 'DAILY',
       interval: '1',
@@ -5970,6 +5970,14 @@ class SkylightCalendarCard extends HTMLElement {
         }
       }
     });
+
+    // WEEKLY rules may omit BYDAY, in which case the recurrence is implied
+    // by DTSTART's weekday (RFC 5545 §3.3.10).
+    if (parsed.frequency === 'WEEKLY' && parsed.byDay.length === 0 &&
+        fallbackStartDate instanceof Date && !Number.isNaN(fallbackStartDate.getTime())) {
+      const weekdayCodes = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
+      parsed.byDay = [weekdayCodes[fallbackStartDate.getDay()]];
+    }
 
     return parsed;
   }
@@ -6094,7 +6102,7 @@ class SkylightCalendarCard extends HTMLElement {
 
     // For all-day events, show same day to user (we'll add +1 when submitting)
     const endDate = prefill?.endDate ? new Date(prefill.endDate) : new Date(startDate);
-    const recurrenceData = this.parseRRule(prefill?.rrule || '');
+    const recurrenceData = this.parseRRule(prefill?.rrule || '', startDate);
     const isPrefilledRecurring = !!prefill?.rrule;
     const isPrefilledAllDay = !!prefill?.isAllDay;
 
@@ -6292,7 +6300,7 @@ class SkylightCalendarCard extends HTMLElement {
       : [];
     const visibleCalendarOptions = selectedCombinedCalendarIds.length > 0 ? selectedCombinedCalendarIds : writableCalendars;
 
-    const recurrenceData = this.parseRRule(event.rrule || '');
+    const recurrenceData = this.parseRRule(event.rrule || '', startDate);
     const isRecurring = !!event.rrule;
     const isSingleOccurrenceEdit = editScope === 'this' && isRecurring;
     const recurringSelectedByDefault = isRecurring && !isSingleOccurrenceEdit;

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -5972,11 +5972,13 @@ class SkylightCalendarCard extends HTMLElement {
     });
 
     // WEEKLY rules may omit BYDAY, in which case the recurrence is implied
-    // by DTSTART's weekday (RFC 5545 §3.3.10).
+    // by DTSTART's weekday (RFC 5545 §3.3.10). Use the card's configured
+    // time_zone (via getDateParts) rather than the browser's local zone,
+    // since DTSTART's weekday can differ between the two.
     if (parsed.frequency === 'WEEKLY' && parsed.byDay.length === 0 &&
         fallbackStartDate instanceof Date && !Number.isNaN(fallbackStartDate.getTime())) {
       const weekdayCodes = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
-      parsed.byDay = [weekdayCodes[fallbackStartDate.getDay()]];
+      parsed.byDay = [weekdayCodes[this.getDateParts(fallbackStartDate).weekday]];
     }
 
     return parsed;

--- a/src/styles/card-styles.js
+++ b/src/styles/card-styles.js
@@ -1821,9 +1821,11 @@ export function getCardStyles() {
         padding: 24px;
         max-width: 500px;
         width: 90%;
+        box-sizing: border-box;
         max-height: 80vh;
         max-height: min(80vh, calc(100dvh - 32px));
         overflow-y: auto;
+        overflow-x: hidden;
         box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
       }
 
@@ -1834,6 +1836,7 @@ export function getCardStyles() {
       }
 
       .modal-content.modal-size-medium {
+        box-sizing: border-box;
         max-width: 500px;
         width: 90%;
       }
@@ -2236,6 +2239,7 @@ export function getCardStyles() {
 
       .form-actions {
         display: flex;
+        flex-wrap: wrap;
         gap: 12px;
         justify-content: flex-end;
         margin-top: 6px;
@@ -2250,6 +2254,8 @@ export function getCardStyles() {
         transition: all 0.2s;
         border: none;
         font-family: inherit;
+        min-width: 0;
+        overflow-wrap: break-word;
       }
 
       .btn-primary {
@@ -2295,6 +2301,7 @@ export function getCardStyles() {
 
       .modal-actions {
         display: flex;
+        flex-wrap: wrap;
         gap: 12px;
         justify-content: space-between;
         margin-top: 24px;
@@ -2303,11 +2310,13 @@ export function getCardStyles() {
 
       .modal-actions-left {
         display: flex;
+        flex-wrap: wrap;
         gap: 12px;
       }
 
       .modal-actions-right {
         display: flex;
+        flex-wrap: wrap;
         gap: 12px;
       }
 

--- a/src/styles/card-styles.js
+++ b/src/styles/card-styles.js
@@ -2243,6 +2243,7 @@ export function getCardStyles() {
         gap: 12px;
         justify-content: flex-end;
         margin-top: 6px;
+        max-width: 100%;
       }
 
       .btn {
@@ -2255,7 +2256,9 @@ export function getCardStyles() {
         border: none;
         font-family: inherit;
         min-width: 0;
-        overflow-wrap: break-word;
+        max-width: 100%;
+        white-space: normal;
+        overflow-wrap: anywhere;
       }
 
       .btn-primary {
@@ -2306,18 +2309,21 @@ export function getCardStyles() {
         justify-content: space-between;
         margin-top: 24px;
         align-items: center;
+        max-width: 100%;
       }
 
       .modal-actions-left {
         display: flex;
         flex-wrap: wrap;
         gap: 12px;
+        max-width: 100%;
       }
 
       .modal-actions-right {
         display: flex;
         flex-wrap: wrap;
         gap: 12px;
+        max-width: 100%;
       }
 
       .confirm-dialog {


### PR DESCRIPTION
## Summary
- Fixes #509: `parseRRule()` only read `BYDAY` from the RRULE string, but a `WEEKLY` rule can legitimately omit `BYDAY` per RFC 5545 — the weekday is then implied by `DTSTART`. Many calendar backends (Google, CalDAV, Outlook, etc.) produce rules like this. This left every weekday checkbox unchecked when opening the edit modal for such events. `parseRRule` now falls back to deriving the weekday from the event's start date when `BYDAY` is absent, and both call sites (edit modal, forward-event prefill) pass the start date through.
- Fixes #496: long translated button labels (e.g. German/Dutch compound words) could overflow the edit/detail modal footer and cause horizontal scrolling on small screens, since the button rows used `flex-wrap: nowrap` with no `min-width: 0` on buttons. The earlier #495 fix only shortened specific translation strings, which didn't address the underlying layout issue. This adds `flex-wrap: wrap` to the button rows, `min-width: 0` + `overflow-wrap: break-word` to buttons, and `overflow-x: hidden` on the modal container as a backstop.

## Test plan
- [x] Added unit tests for `parseRRule` covering: inferring weekday when `BYDAY` is absent on a `WEEKLY` rule, preserving explicit `BYDAY` when present, and not inferring for non-`WEEKLY` frequencies.
- [x] Added an integration test that renders the actual edit-event modal HTML for a `WEEKLY` event with no `BYDAY` and asserts the correct weekday checkbox has the `checked` attribute.
- [x] Ran the full test suite (`npm test`) — no new failures introduced (verified against a clean checkout baseline).
- [x] `npm run build` succeeds and the generated bundle is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)