### PR TITLE
Fix empty header spacing for blank titles

### DIFF
--- a/docs/configuration/basic.mdx
+++ b/docs/configuration/basic.mdx
@@ -20,7 +20,7 @@ The Daylight Calendar Card requires only a list of calendar entities to get star
 </ParamField>
 
 <ParamField path="title" default="Family Calendar" type="string">
-  The title displayed in the card header.
+  The title displayed in the card header. Set `title: ""` to hide only the title while retaining any other configured header content, such as time, weather, custom header items, or controls.
 
   ```yaml
   title: My Calendar

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -3554,6 +3554,10 @@ function getCardStyles() {
         justify-content: flex-end;
       }
 
+      .header-controls-only {
+        margin-left: auto;
+      }
+
       .period-controls,
       .compact-period-controls {
         display: flex;
@@ -10155,7 +10159,7 @@ function renderStandardHeader({
           ${headerTitle}
         </div>` : ''}
         ${shouldShowControls ? `
-          <div class="header-controls">
+          <div class="header-controls${leftContent.trim() ? '' : ' header-controls-only'}">
             ${canAddEvents ? `<button class="add-event-button" id="add-event-btn"><span class="icon">+</span>${helpers.t('addEvent')}</button>` : ''}
             ${helpers.renderThemeToggle()}
             <div class="period-controls">
@@ -10192,7 +10196,7 @@ function renderCompactHeader({
           ${calendarBadges}
         </div>` : ''}
         ${shouldShowControls ? `
-          <div class="header-controls compact-header-controls">
+          <div class="header-controls compact-header-controls${leftContent.trim() ? '' : ' header-controls-only'}">
             <div class="compact-period-controls">
               ${helpers.renderPeriodNavigationButtons('previous')}
               <div class="month-year">${helpers.getPeriodLabel()}</div>

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -10142,12 +10142,18 @@ function renderStandardHeader({
   shouldShowControls,
   helpers
 }) {
+  const dashboardButton = helpers.renderDashboardNavButton();
+  const headerTitle = helpers.renderHeaderTitle();
+  const leftContent = `${dashboardButton}${headerTitle}`;
+
+  if (!leftContent.trim() && !shouldShowControls) return '';
+
   return `
       <div class="header">
-        <div class="header-left">
-          ${helpers.renderDashboardNavButton()}
-          ${helpers.renderHeaderTitle()}
-        </div>
+        ${leftContent.trim() ? `<div class="header-left">
+          ${dashboardButton}
+          ${headerTitle}
+        </div>` : ''}
         ${shouldShowControls ? `
           <div class="header-controls">
             ${canAddEvents ? `<button class="add-event-button" id="add-event-btn"><span class="icon">+</span>${helpers.t('addEvent')}</button>` : ''}
@@ -10171,13 +10177,20 @@ function renderCompactHeader({
   shouldShowControls,
   helpers
 }) {
+  const dashboardButton = helpers.renderDashboardNavButton();
+  const headerTitle = helpers.renderHeaderTitle();
+  const calendarBadges = shouldShowCalendars ? helpers.renderCalendarBadgesInline() : '';
+  const leftContent = `${dashboardButton}${headerTitle}${calendarBadges}`;
+
+  if (!leftContent.trim() && !shouldShowControls) return '';
+
   return `
       <div class="header header-compact">
-        <div class="compact-header-left">
-          ${helpers.renderDashboardNavButton()}
-          ${helpers.renderHeaderTitle()}
-          ${shouldShowCalendars ? helpers.renderCalendarBadgesInline() : ''}
-        </div>
+        ${leftContent.trim() ? `<div class="compact-header-left">
+          ${dashboardButton}
+          ${headerTitle}
+          ${calendarBadges}
+        </div>` : ''}
         ${shouldShowControls ? `
           <div class="header-controls compact-header-controls">
             <div class="compact-period-controls">
@@ -10202,9 +10215,12 @@ function renderHeaderTitle({
   headerItems = [],
   helpers
 }) {
+  const hasTitle = String(title ?? '').trim().length > 0;
+  if (!hasTitle && !headerTime && !headerWeather && headerItems.length === 0) return '';
+
   return `
       <div class="header-title-wrap">
-        <h2 class="header-title">${helpers.escapeHtml(title || '')}</h2>
+        ${hasTitle ? `<h2 class="header-title">${helpers.escapeHtml(title)}</h2>` : ''}
         ${headerTime ? `<span class="header-time">${helpers.escapeHtml(headerTime)}</span>` : ''}
         ${headerWeather ? `<span class="header-weather"><ha-icon icon="${helpers.escapeHtml(headerWeather.conditionIcon)}"></ha-icon>${helpers.escapeHtml(headerWeather.temperature)}</span>` : ''}
         ${headerItems.map((item) => `<span class="header-item">${item.icon ? `<ha-icon icon="${helpers.escapeHtmlAttribute(item.icon)}"></ha-icon>` : ''}<span class="header-item-value">${helpers.escapeHtml(item.value)}</span></span>`).join('')}

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -2629,6 +2629,90 @@ test('hide_header removes the header wrapper entirely', () => {
   assert.match(html, /class="calendar-body"/);
 });
 
+test('blank titles omit title markup and empty left containers while standard controls remain visible', () => {
+  for (const title of ['', '   \t']) {
+    const card = makeCard({ entities: ['calendar.family'], title });
+    const html = card.renderStandardHeader();
+
+    assert.doesNotMatch(html, /header-title(?:-wrap)?/);
+    assert.doesNotMatch(html, /class="header-left"/);
+    assert.match(html, /class="header-controls"/);
+  }
+});
+
+test('blank titles retain configured time weather and custom header items without an h2', () => {
+  const card = makeCard({
+    entities: ['calendar.family'],
+    title: '  ',
+    header_time_sensor: 'sensor.time',
+    header_weather_sensor: 'weather.home',
+    header_items: [{ icon: 'mdi:home', text: 'Family' }],
+    hide_controls: true
+  });
+  card._hass = { states: {
+    'sensor.time': { state: '2026-07-25T14:30:00Z', attributes: {} },
+    'weather.home': { state: 'sunny', attributes: { temperature: 21 } }
+  } };
+
+  const html = card.renderStandardHeader();
+  assert.doesNotMatch(html, /<h2 class="header-title">/);
+  assert.match(html, /class="header-title-wrap"/);
+  assert.match(html, /class="header-time"/);
+  assert.match(html, /class="header-weather"/);
+  assert.match(html, /class="header-item"/);
+  assert.match(html, /class="header-left"/);
+});
+
+test('fully empty standard and compact headers render no markup', () => {
+  const standard = makeCard({ entities: ['calendar.family'], title: '', hide_controls: true });
+  assert.equal(standard.renderHeaderTitle(), '');
+  assert.equal(standard.renderStandardHeader(), '');
+
+  const compact = makeCard({
+    entities: ['calendar.family'],
+    title: '\n ',
+    compact_header: true,
+    hide_controls: true,
+    hide_calendars: true
+  });
+  assert.equal(compact.renderHeaderTitle(), '');
+  assert.equal(compact.renderCompactHeader(), '');
+});
+
+test('compact headers omit an empty left container but retain controls or calendar badges', () => {
+  const controls = makeCard({
+    entities: ['calendar.family'],
+    title: '',
+    compact_header: true,
+    hide_calendars: true
+  });
+  const controlsHtml = controls.renderCompactHeader();
+  assert.doesNotMatch(controlsHtml, /class="compact-header-left"/);
+  assert.match(controlsHtml, /class="header-controls compact-header-controls"/);
+
+  const badges = makeCard({
+    entities: ['calendar.family'],
+    title: '',
+    compact_header: true,
+    hide_controls: true
+  });
+  const badgesHtml = badges.renderCompactHeader();
+  assert.match(badgesHtml, /class="compact-header-left"/);
+  assert.match(badgesHtml, /calendar-badge/);
+  assert.doesNotMatch(badgesHtml, /<h2 class="header-title">/);
+});
+
+test('normal titles retain title markup in standard and compact headers', () => {
+  const standard = makeCard({ entities: ['calendar.family'], title: 'Family Calendar' });
+  assert.match(standard.renderStandardHeader(), /<h2 class="header-title">Family Calendar<\/h2>/);
+
+  const compact = makeCard({ entities: ['calendar.family'], title: 'Family Calendar', compact_header: true });
+  assert.match(compact.renderCompactHeader(), /<h2 class="header-title">Family Calendar<\/h2>/);
+
+  const localizedDefault = makeCard({ entities: ['calendar.family'], language: 'da' });
+  assert.match(localizedDefault.renderStandardHeader(), /<h2 class="header-title">Familiekalender<\/h2>/);
+});
+
 
 
 test('renderEventDescription supports markdown formatting with safe links', () => {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -2636,7 +2636,7 @@ test('blank titles omit title markup and empty left containers while standard co
 
     assert.doesNotMatch(html, /header-title(?:-wrap)?/);
     assert.doesNotMatch(html, /class="header-left"/);
-    assert.match(html, /class="header-controls"/);
+    assert.match(html, /class="header-controls header-controls-only"/);
   }
 });
 
@@ -2688,7 +2688,7 @@ test('compact headers omit an empty left container but retain controls or calend
   });
   const controlsHtml = controls.renderCompactHeader();
   assert.doesNotMatch(controlsHtml, /class="compact-header-left"/);
-  assert.match(controlsHtml, /class="header-controls compact-header-controls"/);
+  assert.match(controlsHtml, /class="header-controls compact-header-controls header-controls-only"/);
 
   const badges = makeCard({
     entities: ['calendar.family'],
@@ -2704,10 +2704,14 @@ test('compact headers omit an empty left container but retain controls or calend
 
 test('normal titles retain title markup in standard and compact headers', () => {
   const standard = makeCard({ entities: ['calendar.family'], title: 'Family Calendar' });
-  assert.match(standard.renderStandardHeader(), /<h2 class="header-title">Family Calendar<\/h2>/);
+  const standardHtml = standard.renderStandardHeader();
+  assert.match(standardHtml, /<h2 class="header-title">Family Calendar<\/h2>/);
+  assert.doesNotMatch(standardHtml, /header-controls-only/);
 
   const compact = makeCard({ entities: ['calendar.family'], title: 'Family Calendar', compact_header: true });
-  assert.match(compact.renderCompactHeader(), /<h2 class="header-title">Family Calendar<\/h2>/);
+  const compactHtml = compact.renderCompactHeader();
+  assert.match(compactHtml, /<h2 class="header-title">Family Calendar<\/h2>/);
+  assert.doesNotMatch(compactHtml, /header-controls-only/);
 
   const localizedDefault = makeCard({ entities: ['calendar.family'], language: 'da' });
   assert.match(localizedDefault.renderStandardHeader(), /<h2 class="header-title">Familiekalender<\/h2>/);

--- a/src/renderers/header-renderer.js
+++ b/src/renderers/header-renderer.js
@@ -16,7 +16,7 @@ export function renderStandardHeader({
           ${headerTitle}
         </div>` : ''}
         ${shouldShowControls ? `
-          <div class="header-controls">
+          <div class="header-controls${leftContent.trim() ? '' : ' header-controls-only'}">
             ${canAddEvents ? `<button class="add-event-button" id="add-event-btn"><span class="icon">+</span>${helpers.t('addEvent')}</button>` : ''}
             ${helpers.renderThemeToggle()}
             <div class="period-controls">
@@ -53,7 +53,7 @@ export function renderCompactHeader({
           ${calendarBadges}
         </div>` : ''}
         ${shouldShowControls ? `
-          <div class="header-controls compact-header-controls">
+          <div class="header-controls compact-header-controls${leftContent.trim() ? '' : ' header-controls-only'}">
             <div class="compact-period-controls">
               ${helpers.renderPeriodNavigationButtons('previous')}
               <div class="month-year">${helpers.getPeriodLabel()}</div>

--- a/src/renderers/header-renderer.js
+++ b/src/renderers/header-renderer.js
@@ -3,12 +3,18 @@ export function renderStandardHeader({
   shouldShowControls,
   helpers
 }) {
+  const dashboardButton = helpers.renderDashboardNavButton();
+  const headerTitle = helpers.renderHeaderTitle();
+  const leftContent = `${dashboardButton}${headerTitle}`;
+
+  if (!leftContent.trim() && !shouldShowControls) return '';
+
   return `
       <div class="header">
-        <div class="header-left">
-          ${helpers.renderDashboardNavButton()}
-          ${helpers.renderHeaderTitle()}
-        </div>
+        ${leftContent.trim() ? `<div class="header-left">
+          ${dashboardButton}
+          ${headerTitle}
+        </div>` : ''}
         ${shouldShowControls ? `
           <div class="header-controls">
             ${canAddEvents ? `<button class="add-event-button" id="add-event-btn"><span class="icon">+</span>${helpers.t('addEvent')}</button>` : ''}
@@ -32,13 +38,20 @@ export function renderCompactHeader({
   shouldShowControls,
   helpers
 }) {
+  const dashboardButton = helpers.renderDashboardNavButton();
+  const headerTitle = helpers.renderHeaderTitle();
+  const calendarBadges = shouldShowCalendars ? helpers.renderCalendarBadgesInline() : '';
+  const leftContent = `${dashboardButton}${headerTitle}${calendarBadges}`;
+
+  if (!leftContent.trim() && !shouldShowControls) return '';
+
   return `
       <div class="header header-compact">
-        <div class="compact-header-left">
-          ${helpers.renderDashboardNavButton()}
-          ${helpers.renderHeaderTitle()}
-          ${shouldShowCalendars ? helpers.renderCalendarBadgesInline() : ''}
-        </div>
+        ${leftContent.trim() ? `<div class="compact-header-left">
+          ${dashboardButton}
+          ${headerTitle}
+          ${calendarBadges}
+        </div>` : ''}
         ${shouldShowControls ? `
           <div class="header-controls compact-header-controls">
             <div class="compact-period-controls">
@@ -63,9 +76,12 @@ export function renderHeaderTitle({
   headerItems = [],
   helpers
 }) {
+  const hasTitle = String(title ?? '').trim().length > 0;
+  if (!hasTitle && !headerTime && !headerWeather && headerItems.length === 0) return '';
+
   return `
       <div class="header-title-wrap">
-        <h2 class="header-title">${helpers.escapeHtml(title || '')}</h2>
+        ${hasTitle ? `<h2 class="header-title">${helpers.escapeHtml(title)}</h2>` : ''}
         ${headerTime ? `<span class="header-time">${helpers.escapeHtml(headerTime)}</span>` : ''}
         ${headerWeather ? `<span class="header-weather"><ha-icon icon="${helpers.escapeHtml(headerWeather.conditionIcon)}"></ha-icon>${helpers.escapeHtml(headerWeather.temperature)}</span>` : ''}
         ${headerItems.map((item) => `<span class="header-item">${item.icon ? `<ha-icon icon="${helpers.escapeHtmlAttribute(item.icon)}"></ha-icon>` : ''}<span class="header-item-value">${helpers.escapeHtml(item.value)}</span></span>`).join('')}

--- a/src/styles/card-styles.js
+++ b/src/styles/card-styles.js
@@ -362,6 +362,10 @@ export function getCardStyles() {
         justify-content: flex-end;
       }
 
+      .header-controls-only {
+        margin-left: auto;
+      }
+
       .period-controls,
       .compact-period-controls {
         display: flex;


### PR DESCRIPTION
### Motivation
- Blank or whitespace-only `title` values rendered an empty `<h2>` and left an unwanted header band (GitHub Discussion #520). 
- The goal is a narrow, backward-compatible layout fix: treat an explicit blank/whitespace `title` as a request to omit the title without adding a new config option and without removing other header content.

### Description
- Render `<h2 class="header-title">` only when the `title` is nonblank; `renderHeaderTitle()` now returns an empty string when there is no title, header time, header weather, or custom `header_items`.
- Standard and compact header renderers (`renderStandardHeader` / `renderCompactHeader`) avoid emitting an empty left-side container and return an empty string when the header has no visible left content and no controls, preventing an empty header band.
- Preserved existing behavior for default/localized titles, nonblank titles, controls, dashboard navigation, header sensors/items, calendar badges, and `hide_header` semantics.
- Added focused unit tests covering blank and whitespace-only titles, standard and compact headers, blank-title scenarios that still show time/weather/items or controls, fully empty headers, and unchanged normal-title behavior, and updated the docs to note that `title: ""` hides only the title while retaining other header content.
- Rebuilt the shipped root artifact (`skylight-calendar-card.js`) so the generated bundle is in sync with the source change.

### Testing
- Ran `npm test` — all tests passed (420 tests reported ok).
- Ran `npm run check:build` (build + `git diff --exit-code` check) — build succeeded and the generated artifact was recreated without unexpected diff.
- Ran `node --check` on `src/renderers/header-renderer.js`, `src/skylight-calendar-card.js`, and `skylight-calendar-card.js` — no syntax errors.
- Performed a Playwright fixture smoke check that verified a configuration with `title: ""` and no other header content emits no `.header` element, and captured a screenshot for verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64e54eb6588331a6a94b1a150efa0a)