### PR TITLE
Add workflow to open PR from `main` into `dev` after release

### DIFF
--- a/.github/workflows/sync-main-to-dev-after-release.yml
+++ b/.github/workflows/sync-main-to-dev-after-release.yml
@@ -23,6 +23,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+          GH_REPO_OWNER: ${{ github.repository_owner }}
         run: |
           set -euo pipefail
 
@@ -34,12 +35,10 @@ jobs:
           fi
 
           OPEN_PR_COUNT="$(
-            gh pr list \
-              --repo "$GH_REPO" \
-              --state open \
-              --head main \
-              --base dev \
-              --json number \
+            gh api --method GET "repos/$GH_REPO/pulls" \
+              -f state=open \
+              -f head="$GH_REPO_OWNER:main" \
+              -f base=dev \
               --jq 'length'
           )"
           if [ "$OPEN_PR_COUNT" -gt 0 ]; then
@@ -58,6 +57,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+          GH_REPO_OWNER: ${{ github.repository_owner }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
@@ -81,12 +81,10 @@ jobs:
           # A run outside the concurrency group could have created the same PR
           # after our check. Treat that duplicate race as a successful no-op.
           OPEN_PR_COUNT="$(
-            gh pr list \
-              --repo "$GH_REPO" \
-              --state open \
-              --head main \
-              --base dev \
-              --json number \
+            gh api --method GET "repos/$GH_REPO/pulls" \
+              -f state=open \
+              -f head="$GH_REPO_OWNER:main" \
+              -f base=dev \
               --jq 'length'
           )"
           if [ "$OPEN_PR_COUNT" -gt 0 ]; then

--- a/.github/workflows/sync-main-to-dev-after-release.yml
+++ b/.github/workflows/sync-main-to-dev-after-release.yml
@@ -1,0 +1,98 @@
+name: Sync Main Back Into Dev
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# Serialize release events so concurrent runs cannot race to open duplicate PRs.
+concurrency:
+  group: sync-main-back-into-dev
+  cancel-in-progress: false
+
+jobs:
+  open-sync-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check whether a sync pull request is needed
+        id: sync-check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          AHEAD_BY="$(gh api "repos/$GH_REPO/compare/dev...main" --jq '.ahead_by')"
+          if [ "$AHEAD_BY" -eq 0 ]; then
+            echo "main has no commits that are missing from dev; nothing to synchronize."
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          OPEN_PR_COUNT="$(
+            gh pr list \
+              --repo "$GH_REPO" \
+              --state open \
+              --head main \
+              --base dev \
+              --json number \
+              --jq 'length'
+          )"
+          if [ "$OPEN_PR_COUNT" -gt 0 ]; then
+            echo "An open main-to-dev pull request already exists; nothing to do."
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "main is $AHEAD_BY commit(s) ahead of dev and no sync pull request is open."
+          echo "needed=true" >> "$GITHUB_OUTPUT"
+
+      # A PR preserves branch protection, required checks, and review history;
+      # this workflow intentionally never pushes or merges directly into dev.
+      - name: Open main-to-dev sync pull request
+        if: steps.sync-check.outputs.needed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          BODY="$(cat <<'EOF'
+          This pull request was automatically created after publishing a GitHub release.
+
+          It synchronizes release-only changes from `main` back into the `dev` development branch.
+          EOF
+          )"
+
+          if gh pr create \
+            --repo "$GH_REPO" \
+            --head main \
+            --base dev \
+            --title "Sync main back into dev after $RELEASE_TAG" \
+            --body "$BODY"; then
+            exit 0
+          fi
+
+          # A run outside the concurrency group could have created the same PR
+          # after our check. Treat that duplicate race as a successful no-op.
+          OPEN_PR_COUNT="$(
+            gh pr list \
+              --repo "$GH_REPO" \
+              --state open \
+              --head main \
+              --base dev \
+              --json number \
+              --jq 'length'
+          )"
+          if [ "$OPEN_PR_COUNT" -gt 0 ]; then
+            echo "A main-to-dev pull request now exists; no duplicate was created."
+            exit 0
+          fi
+
+          echo "ERROR: Unable to create the main-to-dev pull request."
+          exit 1


### PR DESCRIPTION
### Motivation

- Ensure release-only commits on `main` are synchronized back into `dev` automatically after a GitHub release is published. 

### Description

- Add a new workflow file at `.github/workflows/sync-main-to-dev-after-release.yml` that triggers only on `release` events with `types: [published]` and uses only `contents: read` and `pull-requests: write` permissions. 
- Verify whether `main` contains commits not present in `dev` using `gh api "repos/$GH_REPO/compare/dev...main" --jq '.ahead_by'` and exit successfully if branches are already synchronized. 
- Check for an existing open `main`→`dev` PR using `gh pr list --head main --base dev` and exit successfully if one exists. 
- Create a normal (non-draft) PR with `gh pr create --head main --base dev --title "Sync main back into dev after $RELEASE_TAG" --body "$BODY"` that includes the release tag from `github.event.release.tag_name`, and deliberately never push or merge directly into `dev` to preserve branch protection and review history. 
- Protect against duplicate/parallel runs by using a `concurrency` group `sync-main-back-into-dev`, re-checking for an open PR if creation initially fails, and treating races as harmless no-ops; include concise inline comments explaining why a PR is used instead of direct updates. 

### Testing

- `ruby -e "require 'yaml'; YAML.parse_file('.github/workflows/sync-main-to-dev-after-release.yml')"` succeeded and confirmed valid YAML syntax. 
- Custom Python assertions validated the release-only trigger, minimal permissions, the `compare/dev...main` check, the open-PR duplicate check, `github.event.release.tag_name` usage, and non-draft PR creation, and all assertions passed. 
- `git diff --check` and repository status validations ran and reported no local issues. 
- `actionlint` installation failed in this environment due to restricted access to `proxy.golang.org`, so `actionlint` was not executed here (this is an environment limitation, not a workflow problem).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64fbfdb59c8331911b8cd88f9e481f)