### PR TITLE
Fix transparent surface alpha and add grid_color option

### DIFF
--- a/docs/configuration/appearance.mdx
+++ b/docs/configuration/appearance.mdx
@@ -94,6 +94,15 @@ The Daylight Calendar Card gives you extensive control over its visual presentat
   Legacy shortcut for a fully transparent card body. When `background_opacity` is not set, `true` is equivalent to `background_opacity: 100`.
 </ParamField>
 
+<ParamField path="grid_color" type="string">
+  The color used for Month and Week Compact grid lines, Schedule dividers and hour lines, and Agenda dividers. It accepts normal CSS color values, including hex colors and CSS variables. When omitted, the card keeps its light or dark default; transparent backgrounds use a readable translucent white.
+
+  ```yaml
+  background_opacity: 100
+  grid_color: "#ffffff"
+  ```
+</ParamField>
+
 <ParamField path="background_image_url" type="string">
   A URL pointing to an image to display behind the calendar grid. Local Home Assistant paths (e.g. `/local/calendar-bg.jpg`) and remote URLs are both supported.
 </ParamField>

--- a/playwright/visual.spec.js
+++ b/playwright/visual.spec.js
@@ -582,6 +582,31 @@ test('discussion 532: transparent surfaces and grid color contract across views'
     await expect(card.locator(selector).first()).toHaveCSS(property.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`), 'rgb(255, 255, 255)');
   }
 
+  await render({ default_view: 'week-compact', color_scheme: 'dark', grid_color: '#ffffff' });
+  await expect(card.locator('.week-day-column:not(.today) .week-day-header').first()).toHaveCSS('border-bottom-color', 'rgb(255, 255, 255)');
+  await expect(card.locator('.week-day-column.today .week-day-header')).toHaveCSS('border-bottom-color', 'rgb(59, 130, 246)');
+
+  await render({ default_view: 'week-standard', color_scheme: 'dark', grid_color: '#ffffff' });
+  await expect(card.locator('.calendar-badges')).toHaveCSS('border-bottom-color', 'rgb(255, 255, 255)');
+  await expect(card.locator('.week-standard-day-column').first()).toHaveCSS('border-color', 'rgb(255, 255, 255)');
+  await expect(card.locator('.week-standard-day-header').first()).toHaveCSS('border-bottom-color', 'rgb(255, 255, 255)');
+  await expect(card.locator('.all-day-events').first()).toHaveCSS('border-bottom-color', 'rgb(255, 255, 255)');
+  await expect(card.locator('.day-time-slot').first()).toHaveCSS('border-top-color', 'rgb(255, 255, 255)');
+
+  await render({ default_view: 'agenda', color_scheme: 'dark', grid_color: '#ffffff' });
+  await expect(card.locator('.agenda-day-row').first()).toHaveCSS('border-top-color', 'rgb(255, 255, 255)');
+  await expect(card.locator('.agenda-day-label').first()).toHaveCSS('border-bottom-color', 'rgb(255, 255, 255)');
+
+  await render({ default_view: 'week-compact', color_scheme: 'dark' });
+  await expect(card.locator('.week-day-column:not(.today) .week-day-header').first()).toHaveCSS('border-bottom-color', 'rgb(85, 96, 112)');
+  await render({ default_view: 'week-standard', color_scheme: 'dark' });
+  await expect(card.locator('.calendar-badges')).toHaveCSS('border-bottom-color', 'rgb(75, 85, 99)');
+  await expect(card.locator('.week-standard-day-column').first()).toHaveCSS('border-color', 'rgb(96, 107, 123)');
+  await expect(card.locator('.week-standard-day-header').first()).toHaveCSS('border-bottom-color', 'rgba(0, 0, 0, 0)');
+  await expect(card.locator('.day-time-slot').first()).toHaveCSS('border-top-color', 'rgb(85, 96, 112)');
+  await render({ default_view: 'agenda', color_scheme: 'dark' });
+  await expect(card.locator('.agenda-day-row').first()).toHaveCSS('border-top-color', 'rgb(91, 102, 118)');
+
   await render({ default_view: 'month' });
   await expect(card.locator('.calendar-grid')).toHaveCSS('background-color', 'rgb(229, 231, 235)');
   await expect(card.locator('.day-cell:not(.other-month)').first()).toHaveCSS('background-color', 'rgb(255, 255, 255)');

--- a/playwright/visual.spec.js
+++ b/playwright/visual.spec.js
@@ -539,6 +539,55 @@ test.beforeEach(async ({ page }) => {
   }, FIXED_NOW);
 });
 
+test('discussion 532: transparent surfaces and grid color contract across views', async ({ page }) => {
+  const fixtureUrl = `file://${path.join(process.cwd(), 'playwright', 'ha-fixture.html')}`;
+  await page.goto(fixtureUrl);
+
+  const render = (config) => page.evaluate((params) => window.renderCalendarCard(params), {
+    config: { entities: ['calendar.family'], ...config },
+    events: baseEvents
+  });
+  const card = page.locator('skylight-calendar-card');
+  const surfaceByView = {
+    month: '.day-cell:not(.day-style-has-background)',
+    'week-compact': '.week-day-column:not(.day-style-has-background)',
+    'week-standard': '.week-standard-day-column:not(.day-style-has-background)',
+    agenda: '.agenda-day-row:not(.day-style-has-background)'
+  };
+  const alpha = async (selector) => card.locator(selector).first().evaluate((element) => {
+    const value = getComputedStyle(element).backgroundColor;
+    const match = value.match(/rgba\([^,]+,[^,]+,[^,]+,\s*([\d.]+)\)/);
+    return match ? Number(match[1]) : 1;
+  });
+
+  for (const [view, selector] of Object.entries(surfaceByView)) {
+    await render({ default_view: view, background_opacity: 100 });
+    await expect(card.locator('.calendar-container')).toHaveCSS('--custom-surface-alpha', '0');
+    expect(await alpha(selector)).toBe(0);
+  }
+
+  await render({ default_view: 'month', background_transparent: true });
+  await expect(card.locator('.calendar-container')).toHaveCSS('--custom-surface-alpha', '0');
+  expect(await alpha('.day-cell:not(.day-style-has-background)')).toBe(0);
+  expect(await alpha('.day-cell.other-month')).toBe(0);
+
+  const whiteGridChecks = [
+    ['month', '.calendar-grid', 'backgroundColor'],
+    ['week-compact', '.week-compact-container', 'backgroundColor'],
+    ['week-standard', '.day-time-slot', 'borderTopColor'],
+    ['agenda', '.agenda-day-row', 'borderTopColor']
+  ];
+  for (const [view, selector, property] of whiteGridChecks) {
+    await render({ default_view: view, grid_color: '#ffffff' });
+    await expect(card.locator(selector).first()).toHaveCSS(property.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`), 'rgb(255, 255, 255)');
+  }
+
+  await render({ default_view: 'month' });
+  await expect(card.locator('.calendar-grid')).toHaveCSS('background-color', 'rgb(229, 231, 235)');
+  await expect(card.locator('.day-cell:not(.other-month)').first()).toHaveCSS('background-color', 'rgb(255, 255, 255)');
+  await expect(card.locator('.calendar-container')).toHaveCSS('--custom-surface-alpha', '1');
+});
+
 test('regression issue 212: inherited HA card theme styles and explicit background override', async ({ page }) => {
   const fixtureUrl = `file://${path.join(process.cwd(), 'playwright', 'ha-fixture.html')}`;
   await page.goto(fixtureUrl);

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -453,6 +453,7 @@ function createConfigNormalizationSchema({
       { key: 'show_current_time_bar', defaultValue: ({ rawConfig }) => rawConfig.show_current_time_bar || DEFAULT_CONFIG_VALUES.show_current_time_bar },
       { key: 'header_color', defaultValue: ({ derived }) => derived.normalizedHeaderColor !== undefined ? derived.normalizedHeaderColor : DEFAULT_CONFIG_VALUES.header_color },
       { key: 'header_text_color', defaultValue: ({ derived }) => derived.normalizedHeaderTextColor },
+      { key: 'grid_color', defaultValue: ({ derived }) => derived.normalizedGridColor, normalize: ({ derived }) => derived.normalizedGridColor },
       { key: 'header_background_transparent', defaultValue: ({ derived }) => derived.normalizedHeaderBackgroundOpacity >= DEFAULT_CONFIG_VALUES.background_opacity_transparent_threshold, normalize: ({ derived }) => derived.normalizedHeaderBackgroundOpacity >= DEFAULT_CONFIG_VALUES.background_opacity_transparent_threshold },
       { key: 'header_background_opacity', defaultValue: ({ derived }) => derived.normalizedHeaderBackgroundOpacity, normalize: ({ derived }) => derived.normalizedHeaderBackgroundOpacity },
       { key: 'background_transparent', defaultValue: ({ derived }) => derived.normalizedBackgroundOpacity >= DEFAULT_CONFIG_VALUES.background_opacity_transparent_threshold, normalize: ({ derived }) => derived.normalizedBackgroundOpacity >= DEFAULT_CONFIG_VALUES.background_opacity_transparent_threshold },
@@ -2178,6 +2179,13 @@ class SkylightCalendarCardEditor extends HTMLElement {
           <input data-field="header_text_color_text" data-type="header-text-color-text" type="text" value="${this.escapeHtml(this._config.header_text_color || '')}" placeholder="Auto contrast">
         </div>
       </div>
+      <div class="field">
+        <label for="grid_color">Grid and divider color</label>
+        <div class="field-row">
+          ${this.renderColorInputControl({ id: 'grid_color', field: 'grid_color', value: this._config.grid_color })}
+          <input data-field="grid_color_text" data-type="grid-color-text" type="text" value="${this.escapeHtml(this._config.grid_color || '')}" placeholder="Theme default">
+        </div>
+      </div>
       ${this.renderSubSection('Calendar colors', `<div class="map-grid">${this.renderMapRowInputs('colors', { label: 'calendar colors', inputType: 'color' })}</div>`)}
       ${this.renderSubSection('Event font colors', `<div class="map-grid">${this.renderMapRowInputs('event_font_colors', { label: 'event font colors', inputType: 'color' })}</div>`)}
       ${this.renderSubSection('Calendar display names', `<div class="map-grid">${this.renderMapRowInputs('calendar_names', { label: 'calendar names', placeholder: 'Display name' })}</div>`)}
@@ -2982,6 +2990,11 @@ class SkylightCalendarCardEditor extends HTMLElement {
       headerTextColorTextInput.value = this._config.header_text_color || '';
     }
 
+    const gridColorTextInput = this.querySelector('input[data-field="grid_color_text"]');
+    if (gridColorTextInput && document.activeElement !== gridColorTextInput) {
+      gridColorTextInput.value = this._config.grid_color || '';
+    }
+
     this.querySelectorAll('[data-map-field]').forEach((input) => {
       if (document.activeElement === input) return;
       const mapField = input.dataset.mapField;
@@ -3163,6 +3176,8 @@ class SkylightCalendarCardEditor extends HTMLElement {
       nextConfig.header_color = event.target.value;
     } else if (event.target.dataset.type === 'header-text-color-text') {
       nextConfig.header_text_color = event.target.value;
+    } else if (event.target.dataset.type === 'grid-color-text') {
+      nextConfig.grid_color = event.target.value;
     } else if (event.target.dataset.type === 'number') {
       if (event.target.value === '') {
         nextConfig[field] = this.getEditorDefaultValue(field);
@@ -3788,8 +3803,8 @@ function getCardStyles() {
         display: grid;
         grid-template-columns: repeat(7, 1fr);
         gap: 1px;
-        background: #e5e7eb;
-        border-top: 1px solid #e5e7eb;
+        background: var(--calendar-grid-color, #e5e7eb);
+        border-top: 1px solid var(--calendar-grid-color, #e5e7eb);
         flex: 1 1 auto;
         min-height: 0;
         overflow: auto;
@@ -4094,8 +4109,8 @@ function getCardStyles() {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
         gap: 1px;
-        background: #e5e7eb;
-        border-top: 1px solid #e5e7eb;
+        background: var(--calendar-grid-color, #e5e7eb);
+        border-top: 1px solid var(--calendar-grid-color, #e5e7eb);
         flex: 1 1 auto;
         min-height: 0;
         overflow: auto;
@@ -4116,7 +4131,7 @@ function getCardStyles() {
         text-align: center;
         margin-bottom: 12px;
         padding-bottom: 12px;
-        border-bottom: 2px solid #e5e7eb;
+        border-bottom: 2px solid var(--calendar-grid-color, #e5e7eb);
         display: flex;
         flex-direction: column;
         align-items: center;
@@ -4353,14 +4368,14 @@ function getCardStyles() {
         display: grid;
         grid-template-columns: 88px 1fr;
         gap: 12px;
-        border-top: 1px solid #e5e7eb;
+        border-top: 1px solid var(--calendar-grid-color, #e5e7eb);
         padding-top: 8px;
       }
 
       .agenda-month-banner {
         width: 100%;
-        border-top: 2px solid #d1d5db;
-        border-bottom: 1px solid #d1d5db;
+        border-top: 2px solid var(--calendar-grid-color, #d1d5db);
+        border-bottom: 1px solid var(--calendar-grid-color, #d1d5db);
         color: #4b5563;
         font-size: 24px;
         font-weight: 700;
@@ -4378,7 +4393,7 @@ function getCardStyles() {
         text-align: center;
         margin-bottom: 12px;
         padding-bottom: 12px;
-        border-bottom: 2px solid #e5e7eb;
+        border-bottom: 2px solid var(--calendar-grid-color, #e5e7eb);
       }
 
       .agenda-day-weekday {
@@ -4531,7 +4546,7 @@ function getCardStyles() {
         -webkit-overflow-scrolling: touch;
         scrollbar-width: thin;
         background: white;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--calendar-grid-color, #e5e7eb);
       }
 
       .calendar-badges-container.has-overflow::after,
@@ -4765,7 +4780,7 @@ function getCardStyles() {
       .week-standard-day-header {
         padding: 16px;
         text-align: center;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--calendar-grid-color, #e5e7eb);
         background: white;
         display: flex;
         flex-direction: column;
@@ -4812,7 +4827,7 @@ function getCardStyles() {
       .all-day-events {
         padding: var(--all-day-horizontal-padding);
         background: #f9fafb;
-        border-bottom: 2px solid #e5e7eb;
+        border-bottom: 2px solid var(--calendar-grid-color, #e5e7eb);
         display: flex;
         flex-direction: column;
         gap: 4px;
@@ -4901,7 +4916,7 @@ function getCardStyles() {
 
       .day-time-slot {
         height: 120px;
-        border-top: 1px solid var(--schedule-hour-line-color, #e5e7eb);
+        border-top: 1px solid var(--calendar-grid-color, var(--schedule-hour-line-color, #e5e7eb));
         position: relative;
         box-sizing: border-box;
         cursor: pointer;
@@ -6011,7 +6026,7 @@ function getCardStyles() {
       .calendar-container.custom-background .calendar-grid,
       .calendar-container.custom-background .week-compact-container,
       .calendar-container.custom-background .calendar-badges {
-        border-color: rgba(255, 255, 255, 0.35) !important;
+        border-color: var(--calendar-grid-color, rgba(255, 255, 255, 0.35)) !important;
       }
 
       .calendar-container.custom-background .week-standard-container {
@@ -6019,8 +6034,8 @@ function getCardStyles() {
       }
 
       .calendar-container.custom-background .calendar-grid {
-        background: rgba(var(--custom-surface-calendar-rgb, 249, 250, 251), var(--custom-surface-alpha, 0.55)) !important;
-        border-top-color: rgba(var(--custom-surface-column-rgb, 255, 255, 255), var(--custom-surface-alpha, 0.55)) !important;
+        background: var(--calendar-grid-color, rgba(255, 255, 255, 0.35)) !important;
+        border-top-color: var(--calendar-grid-color, rgba(255, 255, 255, 0.35)) !important;
       }
 
       .calendar-container.custom-background .day-header,
@@ -6034,8 +6049,8 @@ function getCardStyles() {
       }
 
       .calendar-container.custom-background .week-compact-container {
-        background: rgba(var(--custom-surface-calendar-rgb, 249, 250, 251), var(--custom-surface-alpha, 0.55)) !important;
-        border-top-color: rgba(var(--custom-surface-column-rgb, 255, 255, 255), var(--custom-surface-alpha, 0.55)) !important;
+        background: var(--calendar-grid-color, rgba(255, 255, 255, 0.35)) !important;
+        border-top-color: var(--calendar-grid-color, rgba(255, 255, 255, 0.35)) !important;
       }
 
       .calendar-container.custom-background .week-day-column {
@@ -6066,11 +6081,11 @@ function getCardStyles() {
 
       .calendar-container.dark-mode.custom-background .week-standard-day-header,
       .calendar-container.dark-mode.custom-background .all-day-events {
-        border-bottom-color: transparent !important;
+        border-bottom-color: var(--calendar-grid-color, rgba(255, 255, 255, 0.35)) !important;
       }
 
       .calendar-container.dark-mode.custom-background .week-standard-day-column {
-        border-color: transparent !important;
+        border-color: var(--calendar-grid-color, rgba(255, 255, 255, 0.35)) !important;
         box-shadow: none !important;
       }
 
@@ -6087,11 +6102,11 @@ function getCardStyles() {
 
 
       .calendar-container.custom-background .day-cell.other-month {
-        background: rgba(255, 255, 255, 0.12) !important;
+        background: rgba(255, 255, 255, calc(var(--custom-surface-alpha, 0.55) * 0.12)) !important;
       }
 
       .calendar-container.dark-mode.custom-background .day-cell.other-month {
-        background: rgba(0, 0, 0, 0.2) !important;
+        background: rgba(0, 0, 0, calc(var(--custom-surface-alpha, 0.55) * 0.2)) !important;
       }
 
       @media (max-width: 768px) {
@@ -11515,6 +11530,7 @@ class SkylightCalendarCard extends HTMLElement {
       normalizedDayBadges: this.normalizeDayBadges(rawConfig.day_badges || []),
       normalizedDayBadgeLayoutWeek: this.normalizeDayBadgeLayoutWeek(rawConfig.day_badge_layout_week),
       normalizedHeaderColor: this.normalizeSingleColor(rawConfig.header_color),
+      normalizedGridColor: this.normalizeSingleColor(rawConfig.grid_color),
       normalizedHeaderTextColor: this.normalizeSingleColor(rawConfig.header_text_color),
       normalizedHeaderBackgroundOpacity,
       normalizedBackgroundOpacity,
@@ -14124,7 +14140,7 @@ class SkylightCalendarCard extends HTMLElement {
     const normalizedReveal = Math.max(0, Math.min(1, normalizedBackgroundOpacity / 100));
     const scaledBackgroundImageAlpha = Math.max(0, Math.min(1, normalizedReveal * 0.75));
     const backgroundImageAlpha = safeBackgroundImageUrl ? scaledBackgroundImageAlpha : 0;
-    const customSurfaceAlpha = Math.max(0.2, 1 - (normalizedReveal * 0.75));
+    const customSurfaceAlpha = 1 - normalizedReveal;
     const customSurfacePalette = this._isDarkMode
       ? {
         calendar: '48, 54, 63',
@@ -14139,7 +14155,10 @@ class SkylightCalendarCard extends HTMLElement {
         slot: '255, 255, 255'
       };
     const forcedBackgroundStyle = forcedThemeBackground ? `--calendar-forced-background: ${forcedThemeBackground}; ` : '';
-    const backgroundStyle = `${forcedBackgroundStyle}--calendar-default-background: ${themeCardBackground}; --calendar-background-opacity: ${backgroundAlpha}; --calendar-background-image-opacity: ${backgroundImageAlpha}; --custom-surface-alpha: ${customSurfaceAlpha}; --custom-surface-calendar-rgb: ${customSurfacePalette.calendar}; --custom-surface-column-rgb: ${customSurfacePalette.column}; --custom-surface-all-day-rgb: ${customSurfacePalette.allDay}; --custom-surface-slot-rgb: ${customSurfacePalette.slot};`;
+    const configuredGridColor = this.normalizeSingleColor(this._config.grid_color);
+    const resolvedGridColor = configuredGridColor || (hasCustomBackground ? 'rgba(255, 255, 255, 0.35)' : null);
+    const gridColorStyle = resolvedGridColor ? `--calendar-grid-color: ${resolvedGridColor}; ` : '';
+    const backgroundStyle = `${forcedBackgroundStyle}--calendar-default-background: ${themeCardBackground}; --calendar-background-opacity: ${backgroundAlpha}; --calendar-background-image-opacity: ${backgroundImageAlpha}; --custom-surface-alpha: ${customSurfaceAlpha}; ${gridColorStyle}--custom-surface-calendar-rgb: ${customSurfacePalette.calendar}; --custom-surface-column-rgb: ${customSurfacePalette.column}; --custom-surface-all-day-rgb: ${customSurfacePalette.allDay}; --custom-surface-slot-rgb: ${customSurfacePalette.slot};`;
     const containerStyle = `${headerStyle} ${backgroundStyle} ${backgroundImageStyle}`.trim();
 
     this._root.innerHTML = `

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -5768,7 +5768,7 @@ function getCardStyles() {
       .calendar-container.dark-mode .week-standard-container,
       .calendar-container.dark-mode .calendar-badges {
         background: #30363f;
-        border-color: #4b5563;
+        border-color: var(--calendar-grid-color, #4b5563);
       }
 
       .calendar-container.dark-mode .calendar-badges-container.has-overflow::after {
@@ -5796,7 +5796,7 @@ function getCardStyles() {
       .calendar-container.dark-mode .empty-state {
         background: #353c45;
         color: #dde3ea;
-        border-color: #556070;
+        border-color: var(--calendar-grid-color, #556070);
       }
 
       .calendar-container.dark-mode .time-slot {
@@ -5807,7 +5807,7 @@ function getCardStyles() {
 
       .calendar-container.dark-mode .week-standard-day-header,
       .calendar-container.dark-mode .all-day-events {
-        border-bottom-color: transparent;
+        border-bottom-color: var(--calendar-grid-color, transparent);
       }
 
 	  .calendar-container.dark-mode .day-header,
@@ -5815,7 +5815,7 @@ function getCardStyles() {
       .calendar-container.dark-mode .month-week-number-cell {
         background: #353b42;
         color: #dde3ea;
-        border-color: #556070;
+        border-color: var(--calendar-grid-color, #556070);
       }
 
       .calendar-container.dark-mode .week-day-column.today .week-day-header {
@@ -5828,7 +5828,7 @@ function getCardStyles() {
       .calendar-container.dark-mode .week-day-date {
         background: #3b434d;
         color: #dde3ea;
-        border-color: #556070;
+        border-color: var(--calendar-grid-color, #556070);
       }
 
       .calendar-container.dark-mode .agenda-day-weekday,
@@ -5848,7 +5848,7 @@ function getCardStyles() {
       }
 
       .calendar-container.dark-mode .week-standard-day-column {
-        border: 1px solid #556070;
+        border: 1px solid var(--calendar-grid-color, #556070);
         box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
       }
 
@@ -5887,8 +5887,6 @@ function getCardStyles() {
         color: #c7d0db;
       }
 
-      .calendar-container.dark-mode .week-standard-day-column,
-      .calendar-container.dark-mode .week-day-column,
       .calendar-container.dark-mode .modal-content,
       .calendar-container.dark-mode .confirm-dialog,
       .calendar-container.dark-mode .form-input,
@@ -5900,6 +5898,14 @@ function getCardStyles() {
         background: #3b434d;
         color: #e2e8f0;
         border-color: #606b7b;
+        box-shadow: none;
+      }
+
+      .calendar-container.dark-mode .week-standard-day-column,
+      .calendar-container.dark-mode .week-day-column {
+        background: #3b434d;
+        color: #e2e8f0;
+        border-color: var(--calendar-grid-color, #606b7b);
         box-shadow: none;
       }
 
@@ -5988,16 +5994,16 @@ function getCardStyles() {
       }
 
       .calendar-container.dark-mode .agenda-day-row {
-        border-top-color: #5b6676;
+        border-top-color: var(--calendar-grid-color, #5b6676);
       }
 
       .calendar-container.dark-mode .agenda-day-label {
-        border-bottom-color: #5b6676;
+        border-bottom-color: var(--calendar-grid-color, #5b6676);
       }
 
       .calendar-container.dark-mode .agenda-month-banner {
-        border-top-color: #5b6676;
-        border-bottom-color: #5b6676;
+        border-top-color: var(--calendar-grid-color, #5b6676);
+        border-bottom-color: var(--calendar-grid-color, #5b6676);
         color: #c7d0db;
       }
 

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -138,6 +138,7 @@ const CONFIG_COVERAGE_INVENTORY = {
   show_current_time_bar: 'setConfig applies visual layout and styling options',
   header_color: 'setConfig applies visual layout and styling options',
   header_text_color: 'setConfig applies visual layout and styling options',
+  grid_color: 'setConfig applies visual layout and styling options',
   header_background_transparent: 'setConfig normalizes fallback values and aliases',
   header_background_opacity: 'setConfig applies visual layout and styling options',
   background_transparent: 'setConfig normalizes fallback values and aliases',
@@ -951,6 +952,7 @@ test('setConfig applies visual layout and styling options', () => {
     display_full_weekday_names: true,
     header_color: '#123456',
     header_text_color: '#ffffff',
+    grid_color: 'rgb(255, 255, 255)',
     header_background_opacity: 55,
     background_opacity: 35,
     background_image_url: 'https://example.com/bg.png',
@@ -1008,6 +1010,7 @@ test('setConfig applies visual layout and styling options', () => {
   assert.equal(card._config.day_badge_layout_week, 'stacked');
   assert.equal(card._config.header_color, '#123456');
   assert.equal(card._config.header_text_color, '#ffffff');
+  assert.equal(card._config.grid_color, 'rgb(255, 255, 255)');
   assert.equal(card._config.header_background_opacity, 55);
   assert.equal(card._config.background_opacity, 35);
   assert.equal(card._config.background_image_url, 'https://example.com/bg.png');

--- a/src/editor/daylight-calendar-card-editor.js
+++ b/src/editor/daylight-calendar-card-editor.js
@@ -900,6 +900,13 @@ export class SkylightCalendarCardEditor extends HTMLElement {
           <input data-field="header_text_color_text" data-type="header-text-color-text" type="text" value="${this.escapeHtml(this._config.header_text_color || '')}" placeholder="Auto contrast">
         </div>
       </div>
+      <div class="field">
+        <label for="grid_color">Grid and divider color</label>
+        <div class="field-row">
+          ${this.renderColorInputControl({ id: 'grid_color', field: 'grid_color', value: this._config.grid_color })}
+          <input data-field="grid_color_text" data-type="grid-color-text" type="text" value="${this.escapeHtml(this._config.grid_color || '')}" placeholder="Theme default">
+        </div>
+      </div>
       ${this.renderSubSection('Calendar colors', `<div class="map-grid">${this.renderMapRowInputs('colors', { label: 'calendar colors', inputType: 'color' })}</div>`)}
       ${this.renderSubSection('Event font colors', `<div class="map-grid">${this.renderMapRowInputs('event_font_colors', { label: 'event font colors', inputType: 'color' })}</div>`)}
       ${this.renderSubSection('Calendar display names', `<div class="map-grid">${this.renderMapRowInputs('calendar_names', { label: 'calendar names', placeholder: 'Display name' })}</div>`)}
@@ -1704,6 +1711,11 @@ export class SkylightCalendarCardEditor extends HTMLElement {
       headerTextColorTextInput.value = this._config.header_text_color || '';
     }
 
+    const gridColorTextInput = this.querySelector('input[data-field="grid_color_text"]');
+    if (gridColorTextInput && document.activeElement !== gridColorTextInput) {
+      gridColorTextInput.value = this._config.grid_color || '';
+    }
+
     this.querySelectorAll('[data-map-field]').forEach((input) => {
       if (document.activeElement === input) return;
       const mapField = input.dataset.mapField;
@@ -1885,6 +1897,8 @@ export class SkylightCalendarCardEditor extends HTMLElement {
       nextConfig.header_color = event.target.value;
     } else if (event.target.dataset.type === 'header-text-color-text') {
       nextConfig.header_text_color = event.target.value;
+    } else if (event.target.dataset.type === 'grid-color-text') {
+      nextConfig.grid_color = event.target.value;
     } else if (event.target.dataset.type === 'number') {
       if (event.target.value === '') {
         nextConfig[field] = this.getEditorDefaultValue(field);

--- a/src/editor/editor-schema.js
+++ b/src/editor/editor-schema.js
@@ -93,6 +93,7 @@ export function createConfigNormalizationSchema({
       { key: 'show_current_time_bar', defaultValue: ({ rawConfig }) => rawConfig.show_current_time_bar || DEFAULT_CONFIG_VALUES.show_current_time_bar },
       { key: 'header_color', defaultValue: ({ derived }) => derived.normalizedHeaderColor !== undefined ? derived.normalizedHeaderColor : DEFAULT_CONFIG_VALUES.header_color },
       { key: 'header_text_color', defaultValue: ({ derived }) => derived.normalizedHeaderTextColor },
+      { key: 'grid_color', defaultValue: ({ derived }) => derived.normalizedGridColor, normalize: ({ derived }) => derived.normalizedGridColor },
       { key: 'header_background_transparent', defaultValue: ({ derived }) => derived.normalizedHeaderBackgroundOpacity >= DEFAULT_CONFIG_VALUES.background_opacity_transparent_threshold, normalize: ({ derived }) => derived.normalizedHeaderBackgroundOpacity >= DEFAULT_CONFIG_VALUES.background_opacity_transparent_threshold },
       { key: 'header_background_opacity', defaultValue: ({ derived }) => derived.normalizedHeaderBackgroundOpacity, normalize: ({ derived }) => derived.normalizedHeaderBackgroundOpacity },
       { key: 'background_transparent', defaultValue: ({ derived }) => derived.normalizedBackgroundOpacity >= DEFAULT_CONFIG_VALUES.background_opacity_transparent_threshold, normalize: ({ derived }) => derived.normalizedBackgroundOpacity >= DEFAULT_CONFIG_VALUES.background_opacity_transparent_threshold },

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -938,6 +938,7 @@ class SkylightCalendarCard extends HTMLElement {
       normalizedDayBadges: this.normalizeDayBadges(rawConfig.day_badges || []),
       normalizedDayBadgeLayoutWeek: this.normalizeDayBadgeLayoutWeek(rawConfig.day_badge_layout_week),
       normalizedHeaderColor: this.normalizeSingleColor(rawConfig.header_color),
+      normalizedGridColor: this.normalizeSingleColor(rawConfig.grid_color),
       normalizedHeaderTextColor: this.normalizeSingleColor(rawConfig.header_text_color),
       normalizedHeaderBackgroundOpacity,
       normalizedBackgroundOpacity,
@@ -3547,7 +3548,7 @@ class SkylightCalendarCard extends HTMLElement {
     const normalizedReveal = Math.max(0, Math.min(1, normalizedBackgroundOpacity / 100));
     const scaledBackgroundImageAlpha = Math.max(0, Math.min(1, normalizedReveal * 0.75));
     const backgroundImageAlpha = safeBackgroundImageUrl ? scaledBackgroundImageAlpha : 0;
-    const customSurfaceAlpha = Math.max(0.2, 1 - (normalizedReveal * 0.75));
+    const customSurfaceAlpha = 1 - normalizedReveal;
     const customSurfacePalette = this._isDarkMode
       ? {
         calendar: '48, 54, 63',
@@ -3562,7 +3563,10 @@ class SkylightCalendarCard extends HTMLElement {
         slot: '255, 255, 255'
       };
     const forcedBackgroundStyle = forcedThemeBackground ? `--calendar-forced-background: ${forcedThemeBackground}; ` : '';
-    const backgroundStyle = `${forcedBackgroundStyle}--calendar-default-background: ${themeCardBackground}; --calendar-background-opacity: ${backgroundAlpha}; --calendar-background-image-opacity: ${backgroundImageAlpha}; --custom-surface-alpha: ${customSurfaceAlpha}; --custom-surface-calendar-rgb: ${customSurfacePalette.calendar}; --custom-surface-column-rgb: ${customSurfacePalette.column}; --custom-surface-all-day-rgb: ${customSurfacePalette.allDay}; --custom-surface-slot-rgb: ${customSurfacePalette.slot};`;
+    const configuredGridColor = this.normalizeSingleColor(this._config.grid_color);
+    const resolvedGridColor = configuredGridColor || (hasCustomBackground ? 'rgba(255, 255, 255, 0.35)' : null);
+    const gridColorStyle = resolvedGridColor ? `--calendar-grid-color: ${resolvedGridColor}; ` : '';
+    const backgroundStyle = `${forcedBackgroundStyle}--calendar-default-background: ${themeCardBackground}; --calendar-background-opacity: ${backgroundAlpha}; --calendar-background-image-opacity: ${backgroundImageAlpha}; --custom-surface-alpha: ${customSurfaceAlpha}; ${gridColorStyle}--custom-surface-calendar-rgb: ${customSurfacePalette.calendar}; --custom-surface-column-rgb: ${customSurfacePalette.column}; --custom-surface-all-day-rgb: ${customSurfacePalette.allDay}; --custom-surface-slot-rgb: ${customSurfacePalette.slot};`;
     const containerStyle = `${headerStyle} ${backgroundStyle} ${backgroundImageStyle}`.trim();
 
     this._root.innerHTML = `

--- a/src/styles/card-styles.js
+++ b/src/styles/card-styles.js
@@ -554,8 +554,8 @@ export function getCardStyles() {
         display: grid;
         grid-template-columns: repeat(7, 1fr);
         gap: 1px;
-        background: #e5e7eb;
-        border-top: 1px solid #e5e7eb;
+        background: var(--calendar-grid-color, #e5e7eb);
+        border-top: 1px solid var(--calendar-grid-color, #e5e7eb);
         flex: 1 1 auto;
         min-height: 0;
         overflow: auto;
@@ -860,8 +860,8 @@ export function getCardStyles() {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
         gap: 1px;
-        background: #e5e7eb;
-        border-top: 1px solid #e5e7eb;
+        background: var(--calendar-grid-color, #e5e7eb);
+        border-top: 1px solid var(--calendar-grid-color, #e5e7eb);
         flex: 1 1 auto;
         min-height: 0;
         overflow: auto;
@@ -882,7 +882,7 @@ export function getCardStyles() {
         text-align: center;
         margin-bottom: 12px;
         padding-bottom: 12px;
-        border-bottom: 2px solid #e5e7eb;
+        border-bottom: 2px solid var(--calendar-grid-color, #e5e7eb);
         display: flex;
         flex-direction: column;
         align-items: center;
@@ -1119,14 +1119,14 @@ export function getCardStyles() {
         display: grid;
         grid-template-columns: 88px 1fr;
         gap: 12px;
-        border-top: 1px solid #e5e7eb;
+        border-top: 1px solid var(--calendar-grid-color, #e5e7eb);
         padding-top: 8px;
       }
 
       .agenda-month-banner {
         width: 100%;
-        border-top: 2px solid #d1d5db;
-        border-bottom: 1px solid #d1d5db;
+        border-top: 2px solid var(--calendar-grid-color, #d1d5db);
+        border-bottom: 1px solid var(--calendar-grid-color, #d1d5db);
         color: #4b5563;
         font-size: 24px;
         font-weight: 700;
@@ -1144,7 +1144,7 @@ export function getCardStyles() {
         text-align: center;
         margin-bottom: 12px;
         padding-bottom: 12px;
-        border-bottom: 2px solid #e5e7eb;
+        border-bottom: 2px solid var(--calendar-grid-color, #e5e7eb);
       }
 
       .agenda-day-weekday {
@@ -1297,7 +1297,7 @@ export function getCardStyles() {
         -webkit-overflow-scrolling: touch;
         scrollbar-width: thin;
         background: white;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--calendar-grid-color, #e5e7eb);
       }
 
       .calendar-badges-container.has-overflow::after,
@@ -1531,7 +1531,7 @@ export function getCardStyles() {
       .week-standard-day-header {
         padding: 16px;
         text-align: center;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--calendar-grid-color, #e5e7eb);
         background: white;
         display: flex;
         flex-direction: column;
@@ -1578,7 +1578,7 @@ export function getCardStyles() {
       .all-day-events {
         padding: var(--all-day-horizontal-padding);
         background: #f9fafb;
-        border-bottom: 2px solid #e5e7eb;
+        border-bottom: 2px solid var(--calendar-grid-color, #e5e7eb);
         display: flex;
         flex-direction: column;
         gap: 4px;
@@ -1667,7 +1667,7 @@ export function getCardStyles() {
 
       .day-time-slot {
         height: 120px;
-        border-top: 1px solid var(--schedule-hour-line-color, #e5e7eb);
+        border-top: 1px solid var(--calendar-grid-color, var(--schedule-hour-line-color, #e5e7eb));
         position: relative;
         box-sizing: border-box;
         cursor: pointer;
@@ -2777,7 +2777,7 @@ export function getCardStyles() {
       .calendar-container.custom-background .calendar-grid,
       .calendar-container.custom-background .week-compact-container,
       .calendar-container.custom-background .calendar-badges {
-        border-color: rgba(255, 255, 255, 0.35) !important;
+        border-color: var(--calendar-grid-color, rgba(255, 255, 255, 0.35)) !important;
       }
 
       .calendar-container.custom-background .week-standard-container {
@@ -2785,8 +2785,8 @@ export function getCardStyles() {
       }
 
       .calendar-container.custom-background .calendar-grid {
-        background: rgba(var(--custom-surface-calendar-rgb, 249, 250, 251), var(--custom-surface-alpha, 0.55)) !important;
-        border-top-color: rgba(var(--custom-surface-column-rgb, 255, 255, 255), var(--custom-surface-alpha, 0.55)) !important;
+        background: var(--calendar-grid-color, rgba(255, 255, 255, 0.35)) !important;
+        border-top-color: var(--calendar-grid-color, rgba(255, 255, 255, 0.35)) !important;
       }
 
       .calendar-container.custom-background .day-header,
@@ -2800,8 +2800,8 @@ export function getCardStyles() {
       }
 
       .calendar-container.custom-background .week-compact-container {
-        background: rgba(var(--custom-surface-calendar-rgb, 249, 250, 251), var(--custom-surface-alpha, 0.55)) !important;
-        border-top-color: rgba(var(--custom-surface-column-rgb, 255, 255, 255), var(--custom-surface-alpha, 0.55)) !important;
+        background: var(--calendar-grid-color, rgba(255, 255, 255, 0.35)) !important;
+        border-top-color: var(--calendar-grid-color, rgba(255, 255, 255, 0.35)) !important;
       }
 
       .calendar-container.custom-background .week-day-column {
@@ -2832,11 +2832,11 @@ export function getCardStyles() {
 
       .calendar-container.dark-mode.custom-background .week-standard-day-header,
       .calendar-container.dark-mode.custom-background .all-day-events {
-        border-bottom-color: transparent !important;
+        border-bottom-color: var(--calendar-grid-color, rgba(255, 255, 255, 0.35)) !important;
       }
 
       .calendar-container.dark-mode.custom-background .week-standard-day-column {
-        border-color: transparent !important;
+        border-color: var(--calendar-grid-color, rgba(255, 255, 255, 0.35)) !important;
         box-shadow: none !important;
       }
 
@@ -2853,11 +2853,11 @@ export function getCardStyles() {
 
 
       .calendar-container.custom-background .day-cell.other-month {
-        background: rgba(255, 255, 255, 0.12) !important;
+        background: rgba(255, 255, 255, calc(var(--custom-surface-alpha, 0.55) * 0.12)) !important;
       }
 
       .calendar-container.dark-mode.custom-background .day-cell.other-month {
-        background: rgba(0, 0, 0, 0.2) !important;
+        background: rgba(0, 0, 0, calc(var(--custom-surface-alpha, 0.55) * 0.2)) !important;
       }
 
       @media (max-width: 768px) {

--- a/src/styles/card-styles.js
+++ b/src/styles/card-styles.js
@@ -2519,7 +2519,7 @@ export function getCardStyles() {
       .calendar-container.dark-mode .week-standard-container,
       .calendar-container.dark-mode .calendar-badges {
         background: #30363f;
-        border-color: #4b5563;
+        border-color: var(--calendar-grid-color, #4b5563);
       }
 
       .calendar-container.dark-mode .calendar-badges-container.has-overflow::after {
@@ -2547,7 +2547,7 @@ export function getCardStyles() {
       .calendar-container.dark-mode .empty-state {
         background: #353c45;
         color: #dde3ea;
-        border-color: #556070;
+        border-color: var(--calendar-grid-color, #556070);
       }
 
       .calendar-container.dark-mode .time-slot {
@@ -2558,7 +2558,7 @@ export function getCardStyles() {
 
       .calendar-container.dark-mode .week-standard-day-header,
       .calendar-container.dark-mode .all-day-events {
-        border-bottom-color: transparent;
+        border-bottom-color: var(--calendar-grid-color, transparent);
       }
 
 	  .calendar-container.dark-mode .day-header,
@@ -2566,7 +2566,7 @@ export function getCardStyles() {
       .calendar-container.dark-mode .month-week-number-cell {
         background: #353b42;
         color: #dde3ea;
-        border-color: #556070;
+        border-color: var(--calendar-grid-color, #556070);
       }
 
       .calendar-container.dark-mode .week-day-column.today .week-day-header {
@@ -2579,7 +2579,7 @@ export function getCardStyles() {
       .calendar-container.dark-mode .week-day-date {
         background: #3b434d;
         color: #dde3ea;
-        border-color: #556070;
+        border-color: var(--calendar-grid-color, #556070);
       }
 
       .calendar-container.dark-mode .agenda-day-weekday,
@@ -2599,7 +2599,7 @@ export function getCardStyles() {
       }
 
       .calendar-container.dark-mode .week-standard-day-column {
-        border: 1px solid #556070;
+        border: 1px solid var(--calendar-grid-color, #556070);
         box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
       }
 
@@ -2638,8 +2638,6 @@ export function getCardStyles() {
         color: #c7d0db;
       }
 
-      .calendar-container.dark-mode .week-standard-day-column,
-      .calendar-container.dark-mode .week-day-column,
       .calendar-container.dark-mode .modal-content,
       .calendar-container.dark-mode .confirm-dialog,
       .calendar-container.dark-mode .form-input,
@@ -2651,6 +2649,14 @@ export function getCardStyles() {
         background: #3b434d;
         color: #e2e8f0;
         border-color: #606b7b;
+        box-shadow: none;
+      }
+
+      .calendar-container.dark-mode .week-standard-day-column,
+      .calendar-container.dark-mode .week-day-column {
+        background: #3b434d;
+        color: #e2e8f0;
+        border-color: var(--calendar-grid-color, #606b7b);
         box-shadow: none;
       }
 
@@ -2739,16 +2745,16 @@ export function getCardStyles() {
       }
 
       .calendar-container.dark-mode .agenda-day-row {
-        border-top-color: #5b6676;
+        border-top-color: var(--calendar-grid-color, #5b6676);
       }
 
       .calendar-container.dark-mode .agenda-day-label {
-        border-bottom-color: #5b6676;
+        border-bottom-color: var(--calendar-grid-color, #5b6676);
       }
 
       .calendar-container.dark-mode .agenda-month-banner {
-        border-top-color: #5b6676;
-        border-bottom-color: #5b6676;
+        border-top-color: var(--calendar-grid-color, #5b6676);
+        border-bottom-color: var(--calendar-grid-color, #5b6676);
         color: #c7d0db;
       }
 


### PR DESCRIPTION
### Motivation
- Ensure `background_opacity: 100` and legacy `background_transparent: true` make the calendar body and all internal view surfaces fully transparent while header transparency remains independently controlled. 
- Remove the residual 25% overlay at full transparency caused by the previous `customSurfaceAlpha` clamp and make surface alpha linear from 0–100. 
- Provide user control for grid/divider color across views with a backward-compatible `grid_color` option and a stable `--calendar-grid-color` CSS variable.

### Description
- Surface alpha: changed surface alpha math so surface opacity scales linearly using `customSurfaceAlpha = 1 - normalizedReveal` (was clamped to a 0.2 minimum), so `background_opacity: 100` yields zero surface fill; header behavior remains unchanged and independent. (primary change in `src/skylight-calendar-card.js`).
- Other-month & custom-background overlays: scaled fixed overlay fills by the surface alpha so `other-month` and similar overlays no longer leave a residual tint at full transparency (updates in `src/styles/card-styles.js`).
- Grid color option: added `grid_color` normalization and editor wiring (`src/skylight-calendar-card.js`, `src/editor/editor-schema.js`, `src/editor/daylight-calendar-card-editor.js`) and introduced `--calendar-grid-color` CSS variable used for Month/Week-Compact grid gaps/backgrounds, Schedule dividers/hour lines, and Agenda separators (changes in `src/styles/card-styles.js`).
- Visual editor and docs: added the `grid_color` control to the visual editor using existing color-control patterns and documented the option in `docs/configuration/appearance.mdx` with an example YAML snippet.
- Tests: added Playwright regression coverage that verifies (a) computed surface alpha reaches zero at `background_opacity: 100`, (b) `background_transparent: true` behaves equivalently, (c) representative surfaces in Month/Week-Compact/Week-Standard/Agenda reach zero fill, and (d) `grid_color: "#ffffff"` affects view separators (`playwright/visual.spec.js`).
- Artifact: regenerated the shipped root artifact via the normal build so the committed `skylight-calendar-card.js` matches the source changes.

### Testing
- Ran `npm test` — all unit tests passed (422 tests passed).
- Ran `npm run build` and validated the generated `skylight-calendar-card.js` artifact was produced and consistent with the source build rules (`node --check` ran on changed files successfully).
- Ran `npm run test:visual` — Playwright suite passed including the new regression (91 visual tests passed).
- Performed JavaScript syntax checks with `node --check` on modified files and confirmed no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69783e93ac83319b8b68c8e10ba7d8)