### PR TITLE
docs: clarify daily weather forecast behavior and header-only mode

### DIFF
--- a/docs/configuration/weather.mdx
+++ b/docs/configuration/weather.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Weather"
 description: "Add weather forecasts and a live clock to your Daylight Calendar Card header using Home Assistant weather and time sensor entities."
 ---
 
-The Daylight Calendar Card can pull current conditions and a daily forecast from any Home Assistant `weather.*` entity and display them alongside your events. Current conditions and today's temperature appear in the card header, and per-day forecast icons appear in Month day cells and in the Agenda view.
+The Daylight Calendar Card can pull current conditions and, when available, a daily forecast from a Home Assistant `weather.*` entity. Current conditions and today's temperature appear in the card header. Per-day forecast icons can appear in Month, Week Compact, Week Standard/Schedule, and Agenda views.
 
 ## Weather Forecast
 
@@ -26,7 +26,9 @@ The Daylight Calendar Card can pull current conditions and a daily forecast from
 To display weather data you need:
 
 1. A weather integration installed and configured in Home Assistant — for example, [Met.no](https://www.home-assistant.io/integrations/met/), [OpenWeatherMap](https://www.home-assistant.io/integrations/openweathermap/), or [AccuWeather](https://www.home-assistant.io/integrations/accuweather/).
-2. The `weather.*` entity must support the **daily forecast** type. Home Assistant exposes this as the `FORECAST_DAILY` feature on the entity. Most modern HA weather integrations support daily forecasts out of the box, but a few (especially radar-only or current-conditions-only integrations) do not.
+2. When `show_daily_weather_forecast` is enabled, the `weather.*` entity must support the **daily forecast** type. Home Assistant exposes this as the `FORECAST_DAILY` feature on the entity. Most modern HA weather integrations support daily forecasts out of the box, but a few (especially radar-only or current-conditions-only integrations) do not.
+
+With `show_daily_weather_forecast: false`, the card can still show current conditions in the header from a `weather.*` entity that does not provide daily forecasts.
 
 ### Example
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -195,7 +195,7 @@ The Daylight Calendar Card is a custom Lovelace card for Home Assistant that bri
     header_weather_sensor: weather.home
     ```
 
-    The card subscribes to Home Assistant's daily forecast API and displays weather icons both in the card header and in individual day cells. Make sure your weather integration provides a **daily forecast** — hourly-only integrations will not populate the day icons.
+    The card displays current conditions in the header. Daily forecasts are enabled by default and appear in calendar views when the entity supports them. Set `show_daily_weather_forecast: false` to keep the header conditions without requesting or displaying per-day forecasts; in this mode, the entity does not need to support daily forecasts.
 
     <Tip>
       Not sure what your weather entity is called? Open **Developer Tools → States** in Home Assistant and filter by `weather.` to see all available weather entities.


### PR DESCRIPTION
### Motivation

- Update the documentation for PR #546 so the `show_daily_weather_forecast` behavior is described accurately and consistently across the weather docs and FAQ.
- Clarify that per-day forecasts may appear in additional calendar views and that header conditions can be shown even when the weather entity does not provide daily forecasts.

### Description

- Updated the weather introduction to note that per-day forecast icons can appear in Month, Week Compact, Week Standard/Schedule, and Agenda views, and to indicate forecasts are shown “when available”.
- Clarified in `docs/configuration/weather.mdx` that the `weather.*` entity must support daily forecasts only when `show_daily_weather_forecast` is enabled, and added an explicit note that with `show_daily_weather_forecast: false` the card can still show current header conditions from a non-forecast `weather.*` entity.
- Updated the FAQ entry in `docs/faq.mdx` to remove the implication that configuring `header_weather_sensor` always shows per-day forecasts and to state that per-day forecasts are enabled by default but may be disabled with `show_daily_weather_forecast: false`.
- Changes are documentation-only and preserve existing Mintlify formatting and YAML examples.

### Testing

- Ran `git diff --check` to ensure no whitespace or diff-check issues and it completed without errors.
- Attempted to run the docs link checker with `npx --yes mint broken-links`, but the run failed due to npm registry access (HTTP 403), so link-checking could not be completed in this environment.
- No other dedicated docs/lint tool was available or executed in this environment; the edits were limited to two MDX files only (`docs/configuration/weather.mdx`, `docs/faq.mdx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a780d1880288331afe3fa3f78cb624b)