### PR TITLE
Normalize object recurrence_id values and fix recurring occurrence identities (fix #551)

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -936,9 +936,9 @@ function shouldRefreshEvents({ lastFetch, now = Date.now(), maxAge = 60000 } = {
   return !lastFetch || (now - lastFetch > maxAge);
 }
 
-const EVENT_CACHE_SCHEMA_VERSION = 2;
+const EVENT_CACHE_SCHEMA_VERSION = 3;
 const DB_NAME = 'daylight-calendar-card-events';
-const DB_VERSION = 1;
+const EVENT_CACHE_DB_VERSION = 2;
 const STORE_NAME = 'eventSnapshots';
 const MAX_CACHE_ENTRIES = 12;
 let eventCacheMutationQueue = Promise.resolve();
@@ -965,7 +965,7 @@ const openEventCacheDb = () => new Promise((resolve, reject) => {
     resolve(null);
     return;
   }
-  const request = indexedDBRef.open(DB_NAME, DB_VERSION);
+  const request = indexedDBRef.open(DB_NAME, EVENT_CACHE_DB_VERSION);
   request.onupgradeneeded = () => {
     const db = request.result;
     if (!db.objectStoreNames.contains(STORE_NAME)) {
@@ -7945,9 +7945,29 @@ function escapeHtmlAttribute(text) {
   return String(text ?? '').replace(/[&<>"']/g, (char) => replacements[char]);
 }
 
+const serializeRecurrenceValue = (value, seen = new WeakSet()) => {
+  if (value === null) return 'null';
+  if (typeof value !== 'object') return JSON.stringify(value);
+  if (seen.has(value)) return '"[Circular]"';
+  seen.add(value);
+  const serialized = Array.isArray(value)
+    ? `[${value.map(item => serializeRecurrenceValue(item, seen)).join(',')}]`
+    : `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${serializeRecurrenceValue(value[key], seen)}`).join(',')}}`;
+  seen.delete(value);
+  return serialized;
+};
+
+const normalizeRecurrenceId = (value) => {
+  if (value === undefined || value === null) return '';
+  if (typeof value !== 'object') return String(value);
+  if (value.dateTime !== undefined && value.dateTime !== null) return normalizeRecurrenceId(value.dateTime);
+  if (value.date !== undefined && value.date !== null) return normalizeRecurrenceId(value.date);
+  return serializeRecurrenceValue(value);
+};
+
 const getEventIdentityKey = (entityId, event) => {
   const uid = event?.uid;
-  const recurrenceId = event?.recurrence_id || event?.recurring_event_id;
+  const recurrenceId = normalizeRecurrenceId(event?.recurrence_id || event?.recurring_event_id);
   const start = event?.start?.dateTime || event?.start?.date || event?.start || '';
   const end = event?.end?.dateTime || event?.end?.date || event?.end || '';
   if (uid && recurrenceId) return `${entityId}|${uid}|${recurrenceId}`;
@@ -8899,7 +8919,7 @@ const getRecurringUpdateControls = (originalEvent, eventData, editScope = 'this'
   const isRecurringUpdate = !!eventData.rrule || !!originalEvent.rrule;
   return {
     isRecurringUpdate,
-    recurrenceId: (isRecurringUpdate && editScope !== 'all') ? originalEvent.recurrence_id : null,
+    recurrenceId: (isRecurringUpdate && editScope !== 'all') ? normalizeRecurrenceId(originalEvent.recurrence_id) : null,
     recurrenceRange: (isRecurringUpdate && editScope === 'future' && originalEvent.recurrence_id) ? 'THISANDFUTURE' : null
   };
 };
@@ -8910,8 +8930,9 @@ const buildUpdateEventServiceData = (originalEvent, eventData, recurrenceId = nu
     uid: originalEvent.uid
   };
 
-  if (recurrenceId) {
-    serviceData.recurrence_id = recurrenceId;
+  const normalizedRecurrenceId = normalizeRecurrenceId(recurrenceId);
+  if (normalizedRecurrenceId) {
+    serviceData.recurrence_id = normalizedRecurrenceId;
   }
 
   if (recurrenceRange) {
@@ -8950,8 +8971,9 @@ const buildUpdateEventWebSocketPayload = (originalEvent, eventData, recurrenceId
     event: eventPayload
   };
 
-  if (recurrenceId) {
-    wsPayload.recurrence_id = recurrenceId;
+  const normalizedRecurrenceId = normalizeRecurrenceId(recurrenceId);
+  if (normalizedRecurrenceId) {
+    wsPayload.recurrence_id = normalizedRecurrenceId;
   }
 
   if (recurrenceRange) {
@@ -8967,8 +8989,9 @@ const buildDeleteEventPayload = (calendarId, uid, recurrenceId = null, recurrenc
     uid: uid
   };
 
-  if (recurrenceId) {
-    payload.recurrence_id = recurrenceId;
+  const normalizedRecurrenceId = normalizeRecurrenceId(recurrenceId);
+  if (normalizedRecurrenceId) {
+    payload.recurrence_id = normalizedRecurrenceId;
   }
 
   if (recurrenceRange) {
@@ -9692,7 +9715,7 @@ function stablePart(value) {
 }
 
 function getOccurrenceStartToken(event) {
-  return stablePart(event?.recurrence_id) || stablePart(event?.start?.dateTime) || stablePart(event?.start?.date) || stablePart(event?.start);
+  return normalizeRecurrenceId(event?.recurrence_id) || stablePart(event?.start?.dateTime) || stablePart(event?.start?.date) || stablePart(event?.start);
 }
 
 function getCustomEventColorKeys(event, { getEventIdentityKey } = {}) {
@@ -9704,7 +9727,7 @@ function getCustomEventColorKeys(event, { getEventIdentityKey } = {}) {
   const isRecurring = !!(event.recurrence_id || recurringId || rrule);
   const seriesIdentity = recurringId || (isRecurring ? uid : '');
   const seriesKey = entityId && seriesIdentity ? `${entityId}|series|${seriesIdentity}` : null;
-  const occurrenceToken = stablePart(event.recurrence_id) || getOccurrenceStartToken(event);
+  const occurrenceToken = normalizeRecurrenceId(event.recurrence_id) || getOccurrenceStartToken(event);
   let occurrenceKey = null;
   if (seriesKey && occurrenceToken) {
     occurrenceKey = `${seriesKey}|occurrence|${occurrenceToken}`;
@@ -12731,7 +12754,7 @@ class SkylightCalendarCard extends HTMLElement {
 
   getStableEventIdentityKey(entityId, event) {
     if (!event?.uid) return null;
-    const recurrenceId = event.recurrence_id || event.recurring_event_id;
+    const recurrenceId = normalizeRecurrenceId(event.recurrence_id || event.recurring_event_id);
     if (recurrenceId) return `${entityId}|${event.uid}|${recurrenceId}`;
     return null;
   }

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -8305,6 +8305,67 @@ test('event identity is HA recurrence-aware across merge and chunk deduplication
   assert.deepEqual(result.events.map(event => event.summary), ['first', 'second']);
 });
 
+test('object recurrence IDs are normalized across identity, fetch, reconciliation, and custom colors', async () => {
+  const { fetchEventsForCalendar } = await import('./src/events/event-fetcher.js');
+  const { getEventIdentityKey, normalizeCalendarEvent, normalizeRecurrenceId } = await import('./src/events/event-normalizer.js');
+  const { applyCustomEventColor, createEmptyCustomEventColors, resolveCustomEventColor } = await import('./src/events/custom-event-colors.js');
+  const dateTimeA = { uid: 'series', recurrence_id: { dateTime: '2026-01-01T10:00:00Z', rrule: null }, summary: 'first', start: { dateTime: '2026-01-01T10:00:00Z' }, end: { dateTime: '2026-01-01T11:00:00Z' } };
+  const dateTimeB = { uid: 'series', recurrence_id: { dateTime: '2026-01-08T10:00:00Z', rrule: null }, summary: 'second', start: { dateTime: '2026-01-08T10:00:00Z' }, end: { dateTime: '2026-01-08T11:00:00Z' } };
+  const dateA = { uid: 'all-day-series', recurrence_id: { date: '2026-01-02' }, start: { date: '2026-01-02' }, end: { date: '2026-01-03' } };
+  const dateB = { uid: 'all-day-series', recurrence_id: { date: '2026-01-09' }, start: { date: '2026-01-09' }, end: { date: '2026-01-10' } };
+
+  assert.equal(normalizeRecurrenceId({ dateTime: 'preferred', date: 'ignored' }), 'preferred');
+  assert.equal(normalizeRecurrenceId('legacy-id'), 'legacy-id');
+  assert.equal(normalizeRecurrenceId({ z: 1, a: 2 }), '{"a":2,"z":1}');
+  assert.notEqual(getEventIdentityKey('calendar.a', dateTimeA), getEventIdentityKey('calendar.a', dateTimeB));
+  assert.notEqual(getEventIdentityKey('calendar.a', dateA), getEventIdentityKey('calendar.a', dateB));
+  assert.equal(getEventIdentityKey('calendar.a', { uid: 'legacy', recurrence_id: 'legacy-id' }), 'calendar.a|legacy|legacy-id');
+
+  const result = await fetchEventsForCalendar({
+    hass: { callWS: async () => [dateTimeA, dateTimeB], callApi: async () => [] },
+    entityId: 'calendar.a',
+    chunks: [{ startDate: new Date('2026-01-01'), endDate: new Date('2026-01-10') }, { startDate: new Date('2026-01-08'), endDate: new Date('2026-01-15') }],
+    formatLocalDate: date => date.toISOString().slice(0, 10),
+    getCalendarColor: () => '#123456',
+    getEventIdentityKey,
+    normalizeCalendarEvent
+  });
+  assert.deepEqual(result.events.map(event => event.summary), ['first', 'second']);
+
+  const card = makeCard({ entities: ['calendar.a'] });
+  const reconciled = card.reconcileEventsForFetchedRange([
+    { ...dateTimeA, entityId: 'calendar.a', summary: 'stale first' },
+    { ...dateTimeB, entityId: 'calendar.a' }
+  ], [{ ...dateTimeA, entityId: 'calendar.a', summary: 'fresh first' }], {
+    startDate: new Date('2026-01-01T00:00:00Z'), endDate: new Date('2026-01-02T00:00:00Z')
+  });
+  assert.deepEqual(reconciled.map(event => event.summary), ['fresh first', 'second']);
+
+  let colors = createEmptyCustomEventColors();
+  colors = applyCustomEventColor(colors, { ...dateTimeA, entityId: 'calendar.a' }, 'this', '#112233', { getEventIdentityKey });
+  colors = applyCustomEventColor(colors, { ...dateTimeB, entityId: 'calendar.a' }, 'this', '#445566', { getEventIdentityKey });
+  assert.equal(resolveCustomEventColor({ ...dateTimeA, entityId: 'calendar.a' }, colors, { getEventIdentityKey }), '#112233');
+  assert.equal(resolveCustomEventColor({ ...dateTimeB, entityId: 'calendar.a' }, colors, { getEventIdentityKey }), '#445566');
+});
+
+test('recurring update and delete payloads normalize object recurrence IDs', async () => {
+  const { buildDeleteEventPayload, buildUpdateEventServiceData, buildUpdateEventWebSocketPayload, getRecurringUpdateControls } = await import('./src/events/event-service.js');
+  const originalEvent = { entityId: 'calendar.a', uid: 'series', rrule: 'FREQ=WEEKLY', recurrence_id: { dateTime: '2026-01-01T10:00:00Z', rrule: null } };
+  const eventData = { summary: 'Updated', rrule: 'FREQ=WEEKLY', start: { dateTime: '2026-01-01T12:00:00Z' }, end: { dateTime: '2026-01-01T13:00:00Z' } };
+  const controls = getRecurringUpdateControls(originalEvent, eventData, 'future');
+  assert.equal(controls.recurrenceId, '2026-01-01T10:00:00Z');
+  assert.equal(buildUpdateEventServiceData(originalEvent, eventData, originalEvent.recurrence_id).recurrence_id, '2026-01-01T10:00:00Z');
+  assert.equal(buildUpdateEventWebSocketPayload(originalEvent, eventData, originalEvent.recurrence_id).recurrence_id, '2026-01-01T10:00:00Z');
+  assert.equal(buildDeleteEventPayload('calendar.a', 'series', { date: '2026-01-01' }).recurrence_id, '2026-01-01');
+});
+
+test('recurrence identity cache schema bump invalidates prior snapshots', async () => {
+  const { EVENT_CACHE_DB_VERSION, EVENT_CACHE_SCHEMA_VERSION, normalizeEventCacheSnapshot } = await import('./src/events/event-cache.js');
+  assert.equal(EVENT_CACHE_DB_VERSION, 2);
+  assert.equal(EVENT_CACHE_SCHEMA_VERSION, 3);
+  assert.equal(normalizeEventCacheSnapshot({ schemaVersion: 2 }), null);
+});
+
 test('UID-only occurrences use start and end for fetch and merge identity', async () => {
   const { fetchEventsForCalendar, mergeEvents } = await import('./src/events/event-fetcher.js');
   const { getEventIdentityKey, normalizeCalendarEvent } = await import('./src/events/event-normalizer.js');

--- a/src/events/custom-event-colors.js
+++ b/src/events/custom-event-colors.js
@@ -1,3 +1,5 @@
+import { normalizeRecurrenceId } from './event-normalizer.js';
+
 export const CUSTOM_EVENT_COLORS_VERSION = 1;
 
 export function createEmptyCustomEventColors() {
@@ -18,7 +20,7 @@ function stablePart(value) {
 }
 
 export function getOccurrenceStartToken(event) {
-  return stablePart(event?.recurrence_id) || stablePart(event?.start?.dateTime) || stablePart(event?.start?.date) || stablePart(event?.start);
+  return normalizeRecurrenceId(event?.recurrence_id) || stablePart(event?.start?.dateTime) || stablePart(event?.start?.date) || stablePart(event?.start);
 }
 
 export function getCustomEventColorKeys(event, { getEventIdentityKey } = {}) {
@@ -30,7 +32,7 @@ export function getCustomEventColorKeys(event, { getEventIdentityKey } = {}) {
   const isRecurring = !!(event.recurrence_id || recurringId || rrule);
   const seriesIdentity = recurringId || (isRecurring ? uid : '');
   const seriesKey = entityId && seriesIdentity ? `${entityId}|series|${seriesIdentity}` : null;
-  const occurrenceToken = stablePart(event.recurrence_id) || getOccurrenceStartToken(event);
+  const occurrenceToken = normalizeRecurrenceId(event.recurrence_id) || getOccurrenceStartToken(event);
   let occurrenceKey = null;
   if (seriesKey && occurrenceToken) {
     occurrenceKey = `${seriesKey}|occurrence|${occurrenceToken}`;

--- a/src/events/event-cache.js
+++ b/src/events/event-cache.js
@@ -1,8 +1,8 @@
 import { toStableString } from './event-fetcher.js';
 
-export const EVENT_CACHE_SCHEMA_VERSION = 2;
+export const EVENT_CACHE_SCHEMA_VERSION = 3;
 const DB_NAME = 'daylight-calendar-card-events';
-const DB_VERSION = 1;
+export const EVENT_CACHE_DB_VERSION = 2;
 const STORE_NAME = 'eventSnapshots';
 const MAX_CACHE_ENTRIES = 12;
 let eventCacheMutationQueue = Promise.resolve();
@@ -29,7 +29,7 @@ const openEventCacheDb = () => new Promise((resolve, reject) => {
     resolve(null);
     return;
   }
-  const request = indexedDBRef.open(DB_NAME, DB_VERSION);
+  const request = indexedDBRef.open(DB_NAME, EVENT_CACHE_DB_VERSION);
   request.onupgradeneeded = () => {
     const db = request.result;
     if (!db.objectStoreNames.contains(STORE_NAME)) {

--- a/src/events/event-normalizer.js
+++ b/src/events/event-normalizer.js
@@ -1,6 +1,26 @@
+const serializeRecurrenceValue = (value, seen = new WeakSet()) => {
+  if (value === null) return 'null';
+  if (typeof value !== 'object') return JSON.stringify(value);
+  if (seen.has(value)) return '"[Circular]"';
+  seen.add(value);
+  const serialized = Array.isArray(value)
+    ? `[${value.map(item => serializeRecurrenceValue(item, seen)).join(',')}]`
+    : `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${serializeRecurrenceValue(value[key], seen)}`).join(',')}}`;
+  seen.delete(value);
+  return serialized;
+};
+
+export const normalizeRecurrenceId = (value) => {
+  if (value === undefined || value === null) return '';
+  if (typeof value !== 'object') return String(value);
+  if (value.dateTime !== undefined && value.dateTime !== null) return normalizeRecurrenceId(value.dateTime);
+  if (value.date !== undefined && value.date !== null) return normalizeRecurrenceId(value.date);
+  return serializeRecurrenceValue(value);
+};
+
 export const getEventIdentityKey = (entityId, event) => {
   const uid = event?.uid;
-  const recurrenceId = event?.recurrence_id || event?.recurring_event_id;
+  const recurrenceId = normalizeRecurrenceId(event?.recurrence_id || event?.recurring_event_id);
   const start = event?.start?.dateTime || event?.start?.date || event?.start || '';
   const end = event?.end?.dateTime || event?.end?.date || event?.end || '';
   if (uid && recurrenceId) return `${entityId}|${uid}|${recurrenceId}`;

--- a/src/events/event-service.js
+++ b/src/events/event-service.js
@@ -1,3 +1,5 @@
+import { normalizeRecurrenceId } from './event-normalizer.js';
+
 export const buildEventServiceData = (calendarId, eventData) => {
   const baseData = {
     entity_id: calendarId,
@@ -44,7 +46,7 @@ export const getRecurringUpdateControls = (originalEvent, eventData, editScope =
   const isRecurringUpdate = !!eventData.rrule || !!originalEvent.rrule;
   return {
     isRecurringUpdate,
-    recurrenceId: (isRecurringUpdate && editScope !== 'all') ? originalEvent.recurrence_id : null,
+    recurrenceId: (isRecurringUpdate && editScope !== 'all') ? normalizeRecurrenceId(originalEvent.recurrence_id) : null,
     recurrenceRange: (isRecurringUpdate && editScope === 'future' && originalEvent.recurrence_id) ? 'THISANDFUTURE' : null
   };
 };
@@ -55,8 +57,9 @@ export const buildUpdateEventServiceData = (originalEvent, eventData, recurrence
     uid: originalEvent.uid
   };
 
-  if (recurrenceId) {
-    serviceData.recurrence_id = recurrenceId;
+  const normalizedRecurrenceId = normalizeRecurrenceId(recurrenceId);
+  if (normalizedRecurrenceId) {
+    serviceData.recurrence_id = normalizedRecurrenceId;
   }
 
   if (recurrenceRange) {
@@ -95,8 +98,9 @@ export const buildUpdateEventWebSocketPayload = (originalEvent, eventData, recur
     event: eventPayload
   };
 
-  if (recurrenceId) {
-    wsPayload.recurrence_id = recurrenceId;
+  const normalizedRecurrenceId = normalizeRecurrenceId(recurrenceId);
+  if (normalizedRecurrenceId) {
+    wsPayload.recurrence_id = normalizedRecurrenceId;
   }
 
   if (recurrenceRange) {
@@ -112,8 +116,9 @@ export const buildDeleteEventPayload = (calendarId, uid, recurrenceId = null, re
     uid: uid
   };
 
-  if (recurrenceId) {
-    payload.recurrence_id = recurrenceId;
+  const normalizedRecurrenceId = normalizeRecurrenceId(recurrenceId);
+  if (normalizedRecurrenceId) {
+    payload.recurrence_id = normalizedRecurrenceId;
   }
 
   if (recurrenceRange) {

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -82,7 +82,8 @@ import {
   getEventDateTimeInfo as getNormalizedEventDateTimeInfo,
   getEventIdentityKey as getNormalizedEventIdentityKey,
   getEventStartDate as getNormalizedEventStartDate,
-  normalizeCalendarEvent
+  normalizeCalendarEvent,
+  normalizeRecurrenceId
 } from './events/event-normalizer.js';
 import {
   dateMatchesDayCondition as matchDateDayCondition,
@@ -2003,7 +2004,7 @@ class SkylightCalendarCard extends HTMLElement {
 
   getStableEventIdentityKey(entityId, event) {
     if (!event?.uid) return null;
-    const recurrenceId = event.recurrence_id || event.recurring_event_id;
+    const recurrenceId = normalizeRecurrenceId(event.recurrence_id || event.recurring_event_id);
     if (recurrenceId) return `${entityId}|${event.uid}|${recurrenceId}`;
     return null;
   }


### PR DESCRIPTION
### Motivation

- Home Assistant can return `recurrence_id` as objects (e.g. `{ dateTime: "...", rrule: null }` or `{ date: "..."}`) which were being implicitly stringified to `[object Object]`, collapsing distinct recurring occurrences that share a UID and causing de-duplication, reconciliation, and custom-color collisions.
- The change introduces a single, deterministic normalization strategy so identity, caching, color keys, and update/delete payloads use the same canonical recurrence ID.

### Description

- Add a shared recurrence-ID normalizer `normalizeRecurrenceId` with deterministic serialization and `dateTime`/`date` preference, and use it everywhere identity/reconciliation depends on `recurrence_id` (new helper in `src/events/event-normalizer.js`).
- Replace object-stringification usage with the normalizer in event identity generation using `getEventIdentityKey` and stable identity paths (`getStableEventIdentityKey`) so occurrences are distinct when appropriate (changes in `src/events/event-normalizer.js` and `src/skylight-calendar-card.js`).
- Update custom event color occurrence keys to use the normalized recurrence token so per-occurrence custom colors no longer collide (`src/events/custom-event-colors.js`).
- Ensure recurring update/delete service and WebSocket payload builders send the canonical normalized `recurrence_id` strings instead of objects (`src/events/event-service.js`).
- Bump persisted event cache schema and IndexedDB DB version to invalidate previously corrupted/collapsed snapshots (`src/events/event-cache.js`): `EVENT_CACHE_SCHEMA_VERSION` -> `3` and DB version exported as `EVENT_CACHE_DB_VERSION = 2`.
- Add regression tests covering object `{dateTime}` and `{date}` recurrence IDs, legacy string IDs, chunk deduplication, reconciliation, custom-color keys, update/delete payload normalization, and cache-schema invalidation (`skylight-calendar-card.test.js`).
- Regenerated the shipped artifact `skylight-calendar-card.js` from `src/` and committed the updated files.

### Testing

- Ran the unit test suite with `npm test`, and all tests passed (437 tests, all OK).
- Ran build and static checks: `npm run build`, `git diff --exit-code -- skylight-calendar-card.js`, and `node --check` on modified files and the generated artifact, all of which succeeded.
- Verified new tests exercise: distinct identities for `{dateTime}` vs `{date}`, existing string IDs still work, overlapping chunk de-duplication, reconciliation behavior, per-occurrence custom colors, normalized update/delete payloads, and cache schema invalidation (all assertions passed in automated tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a951e1dcc833194a9febc9afcefd2)