### PR TITLE
Keep event cache IndexedDB at version 1 and strengthen cache schema regression test

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -938,7 +938,6 @@ function shouldRefreshEvents({ lastFetch, now = Date.now(), maxAge = 60000 } = {
 
 const EVENT_CACHE_SCHEMA_VERSION = 3;
 const DB_NAME = 'daylight-calendar-card-events';
-const EVENT_CACHE_DB_VERSION = 2;
 const STORE_NAME = 'eventSnapshots';
 const MAX_CACHE_ENTRIES = 12;
 let eventCacheMutationQueue = Promise.resolve();
@@ -965,7 +964,7 @@ const openEventCacheDb = () => new Promise((resolve, reject) => {
     resolve(null);
     return;
   }
-  const request = indexedDBRef.open(DB_NAME, EVENT_CACHE_DB_VERSION);
+  const request = indexedDBRef.open(DB_NAME, 1);
   request.onupgradeneeded = () => {
     const db = request.result;
     if (!db.objectStoreNames.contains(STORE_NAME)) {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -8360,10 +8360,25 @@ test('recurring update and delete payloads normalize object recurrence IDs', asy
 });
 
 test('recurrence identity cache schema bump invalidates prior snapshots', async () => {
-  const { EVENT_CACHE_DB_VERSION, EVENT_CACHE_SCHEMA_VERSION, normalizeEventCacheSnapshot } = await import('./src/events/event-cache.js');
-  assert.equal(EVENT_CACHE_DB_VERSION, 2);
+  const { EVENT_CACHE_SCHEMA_VERSION, normalizeEventCacheSnapshot } = await import('./src/events/event-cache.js');
+  const validSnapshot = {
+    schemaVersion: EVENT_CACHE_SCHEMA_VERSION,
+    configSignature: 'recurrence-identity',
+    coveredRange: { start: '2026-01-01T00:00:00Z', end: '2026-02-01T00:00:00Z' },
+    lastSuccessfulRefresh: 1,
+    eventsByCalendar: {
+      'calendar.a': [{
+        entityId: 'calendar.a',
+        uid: 'series',
+        recurrence_id: { dateTime: '2026-01-01T10:00:00Z' },
+        start: { dateTime: '2026-01-01T10:00:00Z' },
+        end: { dateTime: '2026-01-01T11:00:00Z' }
+      }]
+    }
+  };
   assert.equal(EVENT_CACHE_SCHEMA_VERSION, 3);
-  assert.equal(normalizeEventCacheSnapshot({ schemaVersion: 2 }), null);
+  assert.equal(normalizeEventCacheSnapshot({ ...validSnapshot, schemaVersion: 2 }), null);
+  assert.notEqual(normalizeEventCacheSnapshot(validSnapshot), null);
 });
 
 test('UID-only occurrences use start and end for fetch and merge identity', async () => {

--- a/src/events/event-cache.js
+++ b/src/events/event-cache.js
@@ -2,7 +2,6 @@ import { toStableString } from './event-fetcher.js';
 
 export const EVENT_CACHE_SCHEMA_VERSION = 3;
 const DB_NAME = 'daylight-calendar-card-events';
-export const EVENT_CACHE_DB_VERSION = 2;
 const STORE_NAME = 'eventSnapshots';
 const MAX_CACHE_ENTRIES = 12;
 let eventCacheMutationQueue = Promise.resolve();
@@ -29,7 +28,7 @@ const openEventCacheDb = () => new Promise((resolve, reject) => {
     resolve(null);
     return;
   }
-  const request = indexedDBRef.open(DB_NAME, EVENT_CACHE_DB_VERSION);
+  const request = indexedDBRef.open(DB_NAME, 1);
   request.onupgradeneeded = () => {
     const db = request.result;
     if (!db.objectStoreNames.contains(STORE_NAME)) {


### PR DESCRIPTION
### Motivation
- Revert an unnecessary IndexedDB database-version bump while retaining the snapshot schema bump to invalidate corrupt/collapsed cache data. 
- Make the cache-invalidation regression test more robust by validating that an otherwise-valid older snapshot is rejected solely because its `schemaVersion` is outdated.

### Description
- Restored the IndexedDB open call to use database version `1` and removed the exported `EVENT_CACHE_DB_VERSION` since the DB version is intentionally not bumped; only the snapshot schema is bumped. (`src/events/event-cache.js`, `skylight-calendar-card.js`).
- Kept `EVENT_CACHE_SCHEMA_VERSION` at `3` so snapshot normalization invalidates older schema snapshots. (`src/events/event-cache.js`).
- Strengthened the test `recurrence identity cache schema bump invalidates prior snapshots` by constructing an otherwise-valid version-2 snapshot and asserting `normalizeEventCacheSnapshot()` returns `null` for the outdated schema, and that the equivalent valid version-3 snapshot is accepted. (`skylight-calendar-card.test.js`).
- Regenerated the bundled artifact `skylight-calendar-card.js` to reflect the source changes and kept the generated artifact current with the source.

### Testing
- Ran `npm run build` to regenerate `skylight-calendar-card.js`, which completed successfully. 
- Ran `npm run check:build` and `node --check` on `src/skylight-calendar-card.js`, `skylight-calendar-card.js`, and `src/events/event-cache.js`, all of which passed without syntax errors. 
- Ran the unit test suite with `npm test` and observed all tests passing (`437` tests passed). 
- Verified bundle freshness with `npm run check:build` after regenerating the artifact and ensured no other code-format or build checks failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a9ceda8888331b3485c709d76759b)