### PR TITLE
Clarify advanced text matcher documentation

### DIFF
--- a/docs/advanced/day-badges.mdx
+++ b/docs/advanced/day-badges.mdx
@@ -82,7 +82,7 @@ The `conditions` object matches against events on each day. All specified keys m
   When `true`, the badge appears on days where at least one event is in the past. When `false`, only days with non-past events match.
 </ParamField>
 
-Text conditions accept a plain string or a matcher object, but operators such as `contains` accept one string, not an array. To match multiple values, use separate conditions under `match.any`. See [Text matching](/advanced/event-styles#text-matching) for the shared syntax and examples.
+Text conditions accept a plain string or a matcher object, but operators such as `contains` accept one string, not an array. In `day_badges`, bare event conditions are supported under `match.any`, so use a separate condition for each value. See [Text matching](/advanced/event-styles#text-matching) for the shared text operators; other rule types may require explicit event scoping.
 
 ### Day-scoped badges
 

--- a/docs/advanced/day-badges.mdx
+++ b/docs/advanced/day-badges.mdx
@@ -54,19 +54,23 @@ Each entry in `day_badges` supports the following fields:
 
 The `conditions` object matches against events on each day. All specified keys must match at least one event on that day for the badge to appear. The following fields are supported:
 
-<ParamField path="conditions.calendar" type="string">
+<ParamField path="conditions.calendar" type="string | object">
   A Home Assistant calendar entity ID (or virtual calendar ID). The badge appears on days where at least one event belongs to that calendar.
 </ParamField>
 
-<ParamField path="conditions.title" type="string">
+<ParamField path="conditions.title" type="string | object">
   A substring to match against event titles on a given day. The badge appears on days that have at least one event whose title contains this string. Prefix with `exact:` for an exact match or `regex:` for a regular expression.
 </ParamField>
 
-<ParamField path="conditions.description" type="string">
+<ParamField path="conditions.summary" type="string | object">
+  Alias for `conditions.title`. Both names match the event summary field.
+</ParamField>
+
+<ParamField path="conditions.description" type="string | object">
   A substring to match against the event description field. Supports the same `exact:` and `regex:` prefixes as `title`.
 </ParamField>
 
-<ParamField path="conditions.location" type="string">
+<ParamField path="conditions.location" type="string | object">
   A substring to match against the event location field. Supports the same `exact:` and `regex:` prefixes as `title`.
 </ParamField>
 
@@ -77,6 +81,8 @@ The `conditions` object matches against events on each day. All specified keys m
 <ParamField path="conditions.past" type="boolean">
   When `true`, the badge appears on days where at least one event is in the past. When `false`, only days with non-past events match.
 </ParamField>
+
+Text conditions accept a plain string or a matcher object, but operators such as `contains` accept one string, not an array. To match multiple values, use separate conditions under `match.any`. See [Text matching](/advanced/event-styles#text-matching) for the shared syntax and examples.
 
 ### Day-scoped badges
 

--- a/docs/advanced/day-styles.mdx
+++ b/docs/advanced/day-styles.mdx
@@ -135,7 +135,7 @@ day_styles:
 
 When `condition` is `has_event`, you must also provide a `calendar` sibling key containing the entity ID (or virtual calendar ID) to watch. The rule only applies to days where that specific calendar has at least one event. A legacy `has_event` rule without `calendar` (or `title_match`) is ignored — use the advanced `match.day.has_event: true` form instead if you want to match any event.
 
-You can optionally narrow the rule further by adding a `title_match` sibling key. When set, the rule only matches days where the named calendar has at least one event whose title contains the given string. `title_match` uses the same single-string matching syntax as `event_styles` and `day_badges` — prefix the value with `exact:` for an exact match or `regex:` for a regular expression. It does not accept an array; use the advanced `match.any` form for multiple titles. See [Text matching](/advanced/event-styles#text-matching).
+You can optionally narrow the rule further by adding a `title_match` sibling key. When set, the rule only matches days where the named calendar has at least one event whose title contains the given string. `title_match` uses the same single-string matching syntax as `event_styles` and `day_badges` — prefix the value with `exact:` for an exact match or `regex:` for a regular expression. It does not accept an array; use the event-scoped `match.any` form shown above for multiple titles. See [Text matching](/advanced/event-styles#text-matching).
 
 ```yaml
 # Any event on calendar.work makes the day match

--- a/docs/advanced/day-styles.mdx
+++ b/docs/advanced/day-styles.mdx
@@ -52,7 +52,7 @@ Use one or more of the following fields inside `match.day` to filter by date pro
   Inverse of `has_event`. When `true`, matches days with no events. When set to an object, matches days where **no** event satisfies that sub-match.
 </ParamField>
 
-You can also nest event-scoped conditions under `match.event` and combine blocks with `match.any`, `match.all`, `match.and`, and `match.not` — see the [shared advanced match schema](/advanced/event-styles#advanced-match-schema).
+You can also nest event-scoped conditions under `match.event` and combine blocks with `match.any`, `match.all`, `match.and`, and `match.not` — see the [shared advanced match schema](/advanced/event-styles#advanced-match-schema). Text fields accept a plain string or a matcher object, but each text operator takes one string. Use logical operators such as `any` to match multiple values; do not pass an array to `contains`. See [Text matching](/advanced/event-styles#text-matching) for syntax and examples.
 
 ### Example: only weekdays in the future
 
@@ -126,7 +126,7 @@ day_styles:
 
 When `condition` is `has_event`, you must also provide a `calendar` sibling key containing the entity ID (or virtual calendar ID) to watch. The rule only applies to days where that specific calendar has at least one event. A legacy `has_event` rule without `calendar` (or `title_match`) is ignored — use the advanced `match.day.has_event: true` form instead if you want to match any event.
 
-You can optionally narrow the rule further by adding a `title_match` sibling key. When set, the rule only matches days where the named calendar has at least one event whose title contains the given string. `title_match` uses the same matching syntax as `event_styles` and `day_badges` — prefix the value with `exact:` for an exact match or `regex:` for a regular expression.
+You can optionally narrow the rule further by adding a `title_match` sibling key. When set, the rule only matches days where the named calendar has at least one event whose title contains the given string. `title_match` uses the same single-string matching syntax as `event_styles` and `day_badges` — prefix the value with `exact:` for an exact match or `regex:` for a regular expression. It does not accept an array; use the advanced `match.any` form for multiple titles. See [Text matching](/advanced/event-styles#text-matching).
 
 ```yaml
 # Any event on calendar.work makes the day match

--- a/docs/advanced/day-styles.mdx
+++ b/docs/advanced/day-styles.mdx
@@ -52,7 +52,16 @@ Use one or more of the following fields inside `match.day` to filter by date pro
   Inverse of `has_event`. When `true`, matches days with no events. When set to an object, matches days where **no** event satisfies that sub-match.
 </ParamField>
 
-You can also nest event-scoped conditions under `match.event` and combine blocks with `match.any`, `match.all`, `match.and`, and `match.not` — see the [shared advanced match schema](/advanced/event-styles#advanced-match-schema). Text fields accept a plain string or a matcher object, but each text operator takes one string. Use logical operators such as `any` to match multiple values; do not pass an array to `contains`. See [Text matching](/advanced/event-styles#text-matching) for syntax and examples.
+You can also nest event-scoped conditions under `match.event` and combine blocks with `match.any`, `match.all`, `match.and`, and `match.not` — see the [shared advanced match schema](/advanced/event-styles#advanced-match-schema). Text fields accept a plain string or a matcher object, but each text operator takes one string. To match multiple event text values in `day_styles`, put each alternative in an explicit `event` block under `match.any`; do not copy the event-style shorthand or pass an array to `contains`. See [Text matching](/advanced/event-styles#text-matching) for the shared text operators.
+
+```yaml
+match:
+  any:
+    - event:
+        title: "Dentist"
+    - event:
+        title: "Annual Leave"
+```
 
 ### Example: only weekdays in the future
 

--- a/docs/advanced/event-styles.mdx
+++ b/docs/advanced/event-styles.mdx
@@ -79,7 +79,7 @@ Use one or more of the following fields inside `match` (or `match.event`) to fil
 
 ## Text matching
 
-Plain strings for `title`, `summary`, `description`, and `location` use case-insensitive substring matching by default. Use this simple form for most rules:
+Plain strings for `title`, `summary`, `description`, `location`, and `calendar` use case-insensitive substring matching by default. Use this simple form for most rules:
 
 ```yaml
 match:
@@ -109,11 +109,11 @@ match:
     - title: "Annual Leave"
 ```
 
-Arrays belong to logical operators such as `any` and `all`, not text operators such as `contains`. The same text matching rules apply to `calendar` and to event conditions nested in `day_styles` or `day_badges`.
+Arrays belong to logical operators such as `any` and `all`, not text operators such as `contains`. Event conditions nested in `day_styles` or `day_badges` use the same text matching rules, but follow each rule type's scoping syntax.
 
 ## Logical Operators
 
-For compound rules, `match` accepts four logical operator keys. Each operator takes either a single sub-condition object or an array of sub-condition objects, and sub-conditions use the same match-field syntax as a top-level `match` block — including nested operators.
+For compound rules, `match.any`, `match.all`, and `match.and` accept arrays of sub-condition objects. `match.not` accepts either one sub-condition object or an array of them. Sub-conditions use the same match-field syntax as a top-level `match` block, including nested operators.
 
 <ParamField path="match.any" type="array">
   OR logic. The rule matches when **at least one** of the listed sub-conditions matches.

--- a/docs/advanced/event-styles.mdx
+++ b/docs/advanced/event-styles.mdx
@@ -50,7 +50,7 @@ event_styles:
 Use one or more of the following fields inside `match` (or `match.event`) to filter by event properties. By default, an event must satisfy **all** specified fields to be considered a match. For OR / NOT logic, use the [logical operators](#logical-operators) below.
 
 <ParamField path="match.calendar" type="string | object">
-  The entity ID of a specific Home Assistant calendar. Only events from that calendar entity will match. Aliases: `calendar_entity`, `entity_id`, `entity`.
+  A calendar entity ID or substring to match against an event's calendar identifiers. Plain strings use case-insensitive substring matching. Use an `exact` matcher object when an exact value is required. Aliases: `calendar_entity`, `entity_id`, `entity`.
 </ParamField>
 
 <ParamField path="match.title" type="string | object">
@@ -113,17 +113,17 @@ Arrays belong to logical operators such as `any` and `all`, not text operators s
 
 ## Logical Operators
 
-For compound rules, `match.any`, `match.all`, and `match.and` accept arrays of sub-condition objects. `match.not` accepts either one sub-condition object or an array of them. Sub-conditions use the same match-field syntax as a top-level `match` block, including nested operators.
+For compound rules, `match` supports four logical operator keys. `any`, `all`, `and`, and `not` each accept either a single sub-condition object or an array of sub-condition objects. Arrays are typically used when combining multiple conditions. Sub-conditions use the same match-field syntax as a top-level `match` block, including nested operators.
 
-<ParamField path="match.any" type="array">
+<ParamField path="match.any" type="object | array">
   OR logic. The rule matches when **at least one** of the listed sub-conditions matches.
 </ParamField>
 
-<ParamField path="match.all" type="array">
+<ParamField path="match.all" type="object | array">
   AND logic. The rule matches when **all** listed sub-conditions match. Same as combining fields at the top level, but useful when nesting inside `any` or `not`.
 </ParamField>
 
-<ParamField path="match.and" type="array">
+<ParamField path="match.and" type="object | array">
   Alias for `match.all`.
 </ParamField>
 

--- a/docs/advanced/event-styles.mdx
+++ b/docs/advanced/event-styles.mdx
@@ -128,7 +128,7 @@ For compound rules, `match` supports four logical operator keys. `any`, `all`, `
 </ParamField>
 
 <ParamField path="match.not" type="object | array">
-  NOT logic. The rule matches when the listed sub-condition (or none of the listed sub-conditions) matches.
+  NOT logic. The rule matches when the sub-condition does not match. When given an array, the rule matches only when none of the listed sub-conditions match.
 </ParamField>
 
 ### Example: events on the work OR personal calendar

--- a/docs/advanced/event-styles.mdx
+++ b/docs/advanced/event-styles.mdx
@@ -49,23 +49,23 @@ event_styles:
 
 Use one or more of the following fields inside `match` (or `match.event`) to filter by event properties. By default, an event must satisfy **all** specified fields to be considered a match. For OR / NOT logic, use the [logical operators](#logical-operators) below.
 
-<ParamField path="match.calendar" type="string">
+<ParamField path="match.calendar" type="string | object">
   The entity ID of a specific Home Assistant calendar. Only events from that calendar entity will match. Aliases: `calendar_entity`, `entity_id`, `entity`.
 </ParamField>
 
-<ParamField path="match.title" type="string">
+<ParamField path="match.title" type="string | object">
   A substring to look for in the event title. The match is case-insensitive. You can also pass a regex pattern wrapped in forward slashes, e.g. `/standup/i`. Alias: `title_contains: foo` is equivalent to `title: 'contains:foo'`.
 </ParamField>
 
-<ParamField path="match.summary" type="string">
+<ParamField path="match.summary" type="string | object">
   Alias for `match.title`. Both names map to the event summary field. Use whichever feels more natural. Alias: `summary_contains`.
 </ParamField>
 
-<ParamField path="match.description" type="string">
+<ParamField path="match.description" type="string | object">
   A substring to look for in the event description field. Alias: `description_contains`.
 </ParamField>
 
-<ParamField path="match.location" type="string">
+<ParamField path="match.location" type="string | object">
   A substring to look for in the event location field. Alias: `location_contains`.
 </ParamField>
 
@@ -77,9 +77,43 @@ Use one or more of the following fields inside `match` (or `match.event`) to fil
   When `true`, only matches events whose end time is in the past. When `false`, only matches events that are not yet past.
 </ParamField>
 
+## Text matching
+
+Plain strings for `title`, `summary`, `description`, and `location` use case-insensitive substring matching by default. Use this simple form for most rules:
+
+```yaml
+match:
+  title: "Dentist"
+```
+
+For explicit matching, these fields also accept an object with one of the following operators:
+
+- `title: { exact: "Dentist" }` matches the complete value.
+- `title: { contains: "Dentist" }` uses substring matching.
+- `title: { substring: "Dentist" }` is equivalent to `contains`.
+- `title: { regex: "^Dentist appointment$" }` uses a regular expression.
+
+Each text operator accepts a **single string**, not a YAML array. For example, this is invalid:
+
+```yaml
+title:
+  contains: ["Dentist"] # Invalid
+```
+
+To match multiple possible values, put separate conditions in `match.any`:
+
+```yaml
+match:
+  any:
+    - title: "Dentist"
+    - title: "Annual Leave"
+```
+
+Arrays belong to logical operators such as `any` and `all`, not text operators such as `contains`. The same text matching rules apply to `calendar` and to event conditions nested in `day_styles` or `day_badges`.
+
 ## Logical Operators
 
-For compound rules, `match` accepts three logical operator keys. Each operator takes either a single sub-condition object or an array of sub-condition objects, and sub-conditions use the same match-field syntax as a top-level `match` block — including nested operators.
+For compound rules, `match` accepts four logical operator keys. Each operator takes either a single sub-condition object or an array of sub-condition objects, and sub-conditions use the same match-field syntax as a top-level `match` block — including nested operators.
 
 <ParamField path="match.any" type="array">
   OR logic. The rule matches when **at least one** of the listed sub-conditions matches.


### PR DESCRIPTION
### Motivation

- Users were confused by matcher examples and the GitHub issue identified that text operators were sometimes assumed to accept YAML arrays, which the implementation does not support. 
- The docs needed a concise, authoritative example of the default behavior (case-insensitive substring) plus the supported object matcher forms and their single-string requirement. 

### Description

- Added a focused **Text matching** section to `docs/advanced/event-styles.mdx` documenting the default case-insensitive substring behavior, the recommended simple syntax (`match:\n  title: "Dentist"`), and the supported object operators `exact`, `contains`, `substring`, and `regex`. 
- Explicitly documented that text operators accept a **single string** (not a YAML array) and added an invalid example (`contains: ["Dentist"]`), and showed the correct approach to match multiple values using `match.any`. 
- Updated `ParamField` types to reflect matcher-capable fields (`match.calendar`, `match.title`, `match.summary`, `match.description`, `match.location`, and the corresponding `conditions.*` fields in `docs/advanced/day-badges.mdx`) to `string | object` so the docs match the implementation. 
- Added brief, cross-referenced clarifications to `docs/advanced/day-styles.mdx` and `docs/advanced/day-badges.mdx` explaining that arrays belong to logical operators such as `any`/`all` and that `title_match`/text conditions accept a single string or matcher object and not arrays. 

### Testing

- Ran `npm test` and all tests passed (`437` tests passed). 
- Ran `git diff --check` and `git status` to confirm repository consistency and no lint errors from the edits. 
- Attempted `mint broken-links` but the Mintlify CLI is not installed in the environment, so link-checking was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b87d59ce08331b3e862f2872fdae9)