### PR TITLE
Fix AI-generated HACS release notes

### DIFF
--- a/.github/workflows/publish-hacs-release.yml
+++ b/.github/workflows/publish-hacs-release.yml
@@ -22,6 +22,8 @@ jobs:
           ref: main
 
       - uses: actions/setup-node@v6
+        with:
+          node-version: 24
 
       - name: Install Copilot CLI
         run: npm install -g @github/copilot

--- a/.github/workflows/publish-hacs-release.yml
+++ b/.github/workflows/publish-hacs-release.yml
@@ -10,16 +10,21 @@ on:
 
 permissions:
   contents: write
-  models: read
+  copilot-requests: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: main
+
+      - uses: actions/setup-node@v6
+
+      - name: Install Copilot CLI
+        run: npm install -g @github/copilot
 
       - name: Read card version
         id: version
@@ -94,11 +99,12 @@ jobs:
 
       - name: Spiffy release notes with AI
         id: ai_notes
-        uses: actions/ai-inference@v1
+        uses: actions/ai-inference@v3
         with:
-          model: openai/gpt-4o
+          model: gpt-4.1
           prompt-file: ai-release-prompt.md
-          max-completion-tokens: 2000
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Save AI release notes
         run: |


### PR DESCRIPTION
Updates the HACS release workflow to use GitHub Copilot instead of the retired GitHub Models inference endpoint.

Changes:
- replace `models: read` with `copilot-requests: write`
- upgrade checkout to `actions/checkout@v6`
- add `actions/setup-node@v6` and install `@github/copilot`
- upgrade `actions/ai-inference` to `@v3`
- switch the model to `gpt-4.1`
- remove the obsolete `max-completion-tokens` input
- preserve the existing generated-notes and draft-release flow

The workflow still checks out `main` when it runs, so this PR targets `dev`; after it is merged and synced to `main`, the release workflow can be rerun there.