### PR TITLE
Use Copilot CLI directly for HACS release notes

### DIFF
--- a/.github/workflows/publish-hacs-release.yml
+++ b/.github/workflows/publish-hacs-release.yml
@@ -99,18 +99,19 @@ jobs:
 
           cat generated-release-notes.md >> ai-release-prompt.md
 
-      - name: Spiffy release notes with AI
-        id: ai_notes
-        uses: actions/ai-inference@v3
-        with:
-          model: gpt-4.1
-          prompt-file: ai-release-prompt.md
+      - name: Spiffy release notes with Copilot
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: Save AI release notes
+          COPILOT_GITHUB_TOKEN: ${{ github.token }}
         run: |
-          cat "${{ steps.ai_notes.outputs.response-file }}" > RELEASE_NOTES.md
+          copilot \
+            -p "$(cat ai-release-prompt.md)" \
+            -s \
+            --no-ask-user \
+            --model gpt-4.1 \
+            > RELEASE_NOTES.md
+
+      - name: Finish release notes
+        run: |
           echo "" >> RELEASE_NOTES.md
           echo "---" >> RELEASE_NOTES.md
           echo "" >> RELEASE_NOTES.md


### PR DESCRIPTION
Replaces `actions/ai-inference@v3` with a direct GitHub Copilot CLI invocation for release-note rewriting.

Why:
- the wrapper currently hides Copilot CLI stderr unless step debugging is enabled
- direct invocation keeps the same prompt/model behavior while surfacing the real CLI error if authentication/model access fails again
- preserves the existing Node 24 setup, generated release notes, and draft GitHub release flow

This PR also uses `COPILOT_GITHUB_TOKEN: ${{ github.token }}` explicitly for CLI authentication.