### PR TITLE
Make HACS release notes resilient to Copilot failures

### DIFF
--- a/.github/workflows/publish-hacs-release.yml
+++ b/.github/workflows/publish-hacs-release.yml
@@ -26,6 +26,8 @@ jobs:
           node-version: 24
 
       - name: Install Copilot CLI
+        id: install_copilot
+        continue-on-error: true
         run: npm install -g @github/copilot
 
       - name: Read card version
@@ -99,7 +101,13 @@ jobs:
 
           cat generated-release-notes.md >> ai-release-prompt.md
 
+      - name: Start with generated release notes
+        run: cp generated-release-notes.md RELEASE_NOTES.md
+
       - name: Spiffy release notes with Copilot
+        id: copilot_notes
+        if: steps.install_copilot.outcome == 'success'
+        continue-on-error: true
         env:
           COPILOT_GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -107,8 +115,22 @@ jobs:
             -p "$(cat ai-release-prompt.md)" \
             -s \
             --no-ask-user \
-            --model gpt-4.1 \
-            > RELEASE_NOTES.md
+            > RELEASE_NOTES.ai.md
+
+          if [ ! -s RELEASE_NOTES.ai.md ]; then
+            echo "Copilot returned an empty response"
+            exit 1
+          fi
+
+          mv RELEASE_NOTES.ai.md RELEASE_NOTES.md
+
+      - name: Report release-note source
+        run: |
+          if [ "${{ steps.copilot_notes.outcome }}" = "success" ]; then
+            echo "Using Copilot-polished release notes."
+          else
+            echo "Copilot polishing unavailable or failed; using GitHub-generated release notes instead."
+          fi
 
       - name: Finish release notes
         run: |


### PR DESCRIPTION
Fixes the release workflow so Copilot can no longer block publishing.

Changes:
- removes the unavailable hard-coded `gpt-4.1` model and lets Copilot choose an available default
- makes Copilot CLI installation non-fatal
- starts from GitHub-generated release notes as the guaranteed fallback
- makes the Copilot polishing step non-fatal and only replaces the fallback when it returns a non-empty response
- logs whether the draft is using Copilot-polished or plain GitHub-generated notes

The draft release will now still be created even if Copilot installation, authentication, entitlement, or model selection fails.