### PR TITLE
Fix header layout flash after controls rerender

### DIFF
--- a/playwright/visual.spec.js
+++ b/playwright/visual.spec.js
@@ -1777,6 +1777,52 @@ test('regression issue 572: wrapped compact header stays wrapped during a calend
   expect(wrapStateImmediatelyAfterRender).toBe(true);
 });
 
+test('regression issue 572: hidden header does not commit a zero-width wrapped state', async ({ page }) => {
+  await page.setViewportSize({ width: 1360, height: 820 });
+  const fixtureUrl = `file://${path.join(process.cwd(), 'playwright', 'ha-fixture.html')}`;
+  await page.goto(fixtureUrl);
+  await page.evaluate(() => {
+    document.getElementById('app').style.display = 'none';
+  });
+  await page.evaluate((params) => window.renderCalendarCard(params), {
+    config: {
+      entities: ['calendar.family', 'calendar.work'],
+      title: 'Issue 572 Hidden Header',
+      default_view: 'week-compact',
+      compact_header: true,
+      hide_dark_mode_toggle: true
+    },
+    events: baseEvents,
+    darkMode: false
+  });
+
+  // Wait beyond the two deferred animation frames used by the wrap measurement.
+  await page.evaluate(() => new Promise((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+  }));
+
+  const card = page.locator('skylight-calendar-card');
+  const hiddenState = await card.evaluate((element) => {
+    const header = element.querySelector('.header-compact');
+    return {
+      contentWidth: header?.clientWidth ?? -1,
+      wrapped: header?.classList.contains('is-wrapped') ?? false
+    };
+  });
+  expect(hiddenState.contentWidth).toBe(0);
+  expect(hiddenState.wrapped).toBe(false);
+
+  await page.evaluate(() => {
+    document.getElementById('app').style.display = '';
+  });
+
+  const header = card.locator('.header-compact');
+  const left = card.locator('.compact-header-left').first();
+  const controls = card.locator('.compact-header-controls').first();
+  await expect.poll(async () => headerGroupsShareRow(left, controls)).toBe(true);
+  await expect(header).not.toHaveClass(/is-wrapped/);
+});
+
 test('regression issue 496: modal action buttons wrap instead of overflowing on small screens', async ({ page }) => {
   // 320px is the classic "small phone" width and the one most likely to
   // reproduce #496 (long translated button labels forcing horizontal scroll).

--- a/playwright/visual.spec.js
+++ b/playwright/visual.spec.js
@@ -1743,6 +1743,40 @@ test('regression issue 321: compact wrapped header rows stay centered at medium 
   await expect.poll(async () => centerOffsetWithinTolerance(header, controls)).toBe(true);
 });
 
+test('regression issue 572: wrapped compact header stays wrapped during a calendar toggle rerender', async ({ page }) => {
+  await page.setViewportSize({ width: 980, height: 820 });
+  const fixtureUrl = `file://${path.join(process.cwd(), 'playwright', 'ha-fixture.html')}`;
+  await page.goto(fixtureUrl);
+  await page.evaluate((params) => window.renderCalendarCard(params), {
+    config: {
+      entities: ['calendar.family', 'calendar.work'],
+      title: 'Issue 572 Compact Wrapped Header',
+      default_view: 'week-compact',
+      compact_header: true,
+      hide_dark_mode_toggle: true,
+      show_dashboard_nav_button: true,
+      header_weather_sensor: 'weather.mock',
+      enable_event_management: true,
+      hide_view_selector: false
+    },
+    events: baseEvents,
+    weather: { 'weather.mock': { temperature: 72, condition: 'sunny' } },
+    darkMode: false
+  });
+
+  const card = page.locator('skylight-calendar-card');
+  await expect.poll(async () =>
+    card.locator('.header-compact').evaluate((header) => header.classList.contains('is-wrapped'))
+  ).toBe(true);
+
+  const wrapStateImmediatelyAfterRender = await card.evaluate((element) => {
+    element.querySelector('.calendar-badge-inline')?.click();
+    return element.querySelector('.header-compact')?.classList.contains('is-wrapped') ?? false;
+  });
+
+  expect(wrapStateImmediatelyAfterRender).toBe(true);
+});
+
 test('regression issue 496: modal action buttons wrap instead of overflowing on small screens', async ({ page }) => {
   // 320px is the classic "small phone" width and the one most likely to
   // reproduce #496 (long translated button labels forcing horizontal scroll).

--- a/playwright/visual.spec.js
+++ b/playwright/visual.spec.js
@@ -1781,9 +1781,6 @@ test('regression issue 572: hidden header does not commit a zero-width wrapped s
   await page.setViewportSize({ width: 1360, height: 820 });
   const fixtureUrl = `file://${path.join(process.cwd(), 'playwright', 'ha-fixture.html')}`;
   await page.goto(fixtureUrl);
-  await page.evaluate(() => {
-    document.getElementById('app').style.display = 'none';
-  });
   await page.evaluate((params) => window.renderCalendarCard(params), {
     config: {
       entities: ['calendar.family', 'calendar.work'],
@@ -1793,7 +1790,8 @@ test('regression issue 572: hidden header does not commit a zero-width wrapped s
       hide_dark_mode_toggle: true
     },
     events: baseEvents,
-    darkMode: false
+    darkMode: false,
+    parentStyle: 'display: none;'
   });
 
   // Wait beyond the two deferred animation frames used by the wrap measurement.

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -14369,6 +14369,10 @@ class SkylightCalendarCard extends HTMLElement {
 
     this.observeHostAndParentResize();
     this.attachEventListeners();
+    // render() replaces the header DOM, including its responsive wrap classes.
+    // Restore them synchronously so an unwrapped header is never painted, then
+    // keep the deferred measurement for late layout changes (fonts/icons).
+    this.measureAndApplyHeaderWrapState();
     this.updateCompactHeaderWrapState();
     this.updateCalendarBadgesScrollState();
     this.updateWeekStandardFixedOffsetHeightFromDom();

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -11576,6 +11576,11 @@ class SkylightCalendarCard extends HTMLElement {
     const badges = this._root.querySelector('.calendar-badges-inline');
 
     if (header) {
+      // Hidden dashboard views have no usable layout width. Measuring them
+      // would count the configured gap against zero-width groups and falsely
+      // mark the header as wrapped.
+      if (this.getElementContentWidth(header) <= 0) return;
+
       const liveLeftGroup = this._config.compact_header
         ? header.querySelector('.compact-header-left')
         : header.querySelector('.header-left');

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -3620,6 +3620,10 @@ class SkylightCalendarCard extends HTMLElement {
 
     this.observeHostAndParentResize();
     this.attachEventListeners();
+    // render() replaces the header DOM, including its responsive wrap classes.
+    // Restore them synchronously so an unwrapped header is never painted, then
+    // keep the deferred measurement for late layout changes (fonts/icons).
+    this.measureAndApplyHeaderWrapState();
     this.updateCompactHeaderWrapState();
     this.updateCalendarBadgesScrollState();
     this.updateWeekStandardFixedOffsetHeightFromDom();

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -827,6 +827,11 @@ class SkylightCalendarCard extends HTMLElement {
     const badges = this._root.querySelector('.calendar-badges-inline');
 
     if (header) {
+      // Hidden dashboard views have no usable layout width. Measuring them
+      // would count the configured gap against zero-width groups and falsely
+      // mark the header as wrapped.
+      if (this.getElementContentWidth(header) <= 0) return;
+
       const liveLeftGroup = this._config.compact_header
         ? header.querySelector('.compact-header-left')
         : header.querySelector('.header-left');


### PR DESCRIPTION
Fixes #572.

## What changed

- Reapply responsive header wrap classes synchronously after the card DOM is rebuilt.
- Keep the existing deferred two-frame measurement so late font/icon sizing and resize behavior remain accurate.
- Add a Playwright regression test that toggles an inline calendar badge and checks the replacement header is already wrapped in the same JavaScript task.
- Update the generated card bundle.

## Root cause

Header actions trigger a full card render. Replacing the DOM removed the measured `is-wrapped` state, and the state was restored only after two `requestAnimationFrame` callbacks. The browser could therefore paint the temporary unwrapped layout, causing the visible leftward jump and snap-back.

## Validation

- Confirmed the source and generated bundle contain the same synchronous wrap-state call.
- Added targeted Playwright coverage for the pre-paint rerender state.
- GitHub Actions will run the full repository checks on this draft PR.