### PR TITLE
Wrap long Week Compact event titles

### DIFF
--- a/playwright/visual.spec.js
+++ b/playwright/visual.spec.js
@@ -658,6 +658,58 @@ test('week compact event titles wrap inside their padded event boundary', async 
   expect(geometry.renderedTextRight).toBeLessThanOrEqual(geometry.contentRight + 1);
 });
 
+test('week compact friendly-name prefixes reserve space for wrapped titles', async ({ page }) => {
+  await page.setViewportSize({ width: 432, height: 900 });
+  const fixtureUrl = `file://${path.join(process.cwd(), 'playwright', 'ha-fixture.html')}`;
+  await page.goto(fixtureUrl);
+
+  await page.evaluate((params) => window.renderCalendarCard(params), {
+    config: {
+      entities: ['calendar.family'],
+      calendar_names: { 'calendar.family': 'Extremely Long Family Activities Calendar Name' },
+      default_view: 'week-compact',
+      event_title_prefix: 'friendly_name',
+      hide_header: true,
+      event_font_size: 14
+    },
+    events: {
+      'calendar.family': [{
+        summary: 'Zoe’s orientation/meet the teacher',
+        start: '2026-03-18T08:30:00Z',
+        end: '2026-03-18T10:00:00Z'
+      }]
+    }
+  });
+
+  const card = page.locator('skylight-calendar-card');
+  const event = card.locator('.week-compact-event').filter({ hasText: 'orientation/meet' });
+  const title = event.locator('.week-compact-event-title');
+  await expect(title).toBeVisible();
+
+  const geometry = await title.evaluate((titleElement) => {
+    const wrapper = titleElement.querySelector('.event-title-with-prefix');
+    const prefix = titleElement.querySelector('.event-title-prefix-friendly-name');
+    const titleNode = [...wrapper.childNodes].find((node) =>
+      node.nodeType === Node.TEXT_NODE && node.textContent.includes('orientation/meet')
+    );
+    const titleRange = document.createRange();
+    titleRange.selectNodeContents(titleNode);
+    const wrapperRect = wrapper.getBoundingClientRect();
+    const prefixRect = prefix.getBoundingClientRect();
+    return {
+      prefixWidth: prefixRect.width,
+      wrapperWidth: wrapperRect.width,
+      titleLineCount: titleRange.getClientRects().length,
+      titleScrollWidth: titleElement.scrollWidth,
+      titleClientWidth: titleElement.clientWidth
+    };
+  });
+
+  expect(geometry.prefixWidth).toBeLessThanOrEqual(geometry.wrapperWidth * 0.45 + 1);
+  expect(geometry.titleLineCount).toBeLessThanOrEqual(8);
+  expect(geometry.titleScrollWidth).toBeLessThanOrEqual(geometry.titleClientWidth + 1);
+});
+
 test('discussion 532: transparent surfaces and grid color contract across views', async ({ page }) => {
   const fixtureUrl = `file://${path.join(process.cwd(), 'playwright', 'ha-fixture.html')}`;
   await page.goto(fixtureUrl);

--- a/playwright/visual.spec.js
+++ b/playwright/visual.spec.js
@@ -613,6 +613,51 @@ test('regression 543: agenda events expand for wrapped content while compact eve
   expect(compactGeometry.height).toBeLessThan(compactGeometry.baseline);
 });
 
+test('week compact event titles wrap inside their padded event boundary', async ({ page }) => {
+  await page.setViewportSize({ width: 432, height: 900 });
+  const fixtureUrl = `file://${path.join(process.cwd(), 'playwright', 'ha-fixture.html')}`;
+  await page.goto(fixtureUrl);
+
+  await page.evaluate((params) => window.renderCalendarCard(params), {
+    config: {
+      entities: ['calendar.family'],
+      default_view: 'week-compact',
+      hide_header: true,
+      event_font_size: 14
+    },
+    events: {
+      'calendar.family': [{
+        summary: 'Zoe’s orientation/meet the teacher',
+        start: '2026-03-18T08:30:00Z',
+        end: '2026-03-18T10:00:00Z'
+      }]
+    }
+  });
+
+  const card = page.locator('skylight-calendar-card');
+  const event = card.locator('.week-compact-event').filter({ hasText: 'orientation/meet' });
+  const title = event.locator('.week-compact-event-title');
+  await expect(title).toBeVisible();
+
+  const geometry = await event.evaluate((eventElement) => {
+    const titleElement = eventElement.querySelector('.week-compact-event-title');
+    const eventRect = eventElement.getBoundingClientRect();
+    const eventStyle = getComputedStyle(eventElement);
+    const titleRange = document.createRange();
+    titleRange.selectNodeContents(titleElement);
+    const renderedTextRect = titleRange.getBoundingClientRect();
+    return {
+      contentRight: eventRect.right - Number.parseFloat(eventStyle.paddingRight),
+      renderedTextRight: renderedTextRect.right,
+      titleClientWidth: titleElement.clientWidth,
+      titleScrollWidth: titleElement.scrollWidth
+    };
+  });
+
+  expect(geometry.titleScrollWidth).toBeLessThanOrEqual(geometry.titleClientWidth + 1);
+  expect(geometry.renderedTextRight).toBeLessThanOrEqual(geometry.contentRight + 1);
+});
+
 test('discussion 532: transparent surfaces and grid color contract across views', async ({ page }) => {
   const fixtureUrl = `file://${path.join(process.cwd(), 'playwright', 'ha-fixture.html')}`;
   await page.goto(fixtureUrl);

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -4363,6 +4363,11 @@ function getCardStyles() {
         font-size: 1em;
         font-weight: 500;
         line-height: 1.3;
+        min-width: 0;
+        max-width: 100%;
+        white-space: normal;
+        overflow-wrap: anywhere;
+        word-break: break-word;
       }
 
       .event-title-with-prefix {
@@ -4370,6 +4375,7 @@ function getCardStyles() {
         align-items: center;
         gap: clamp(4px, calc(var(--event-bubble-font-size, 11px) * 0.3), 7px);
         min-width: 0;
+        max-width: 100%;
       }
 
       .event-style-icon {

--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -4375,7 +4375,18 @@ function getCardStyles() {
         align-items: center;
         gap: clamp(4px, calc(var(--event-bubble-font-size, 11px) * 0.3), 7px);
         min-width: 0;
+      }
+
+      .week-compact-event-title > .event-title-with-prefix {
         max-width: 100%;
+      }
+
+      .week-compact-event-title .event-title-prefix-friendly-name {
+        flex: 0 1 45%;
+        min-width: 0;
+        max-width: 45%;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
 
       .event-style-icon {

--- a/src/styles/card-styles.js
+++ b/src/styles/card-styles.js
@@ -1009,6 +1009,11 @@ export function getCardStyles() {
         font-size: 1em;
         font-weight: 500;
         line-height: 1.3;
+        min-width: 0;
+        max-width: 100%;
+        white-space: normal;
+        overflow-wrap: anywhere;
+        word-break: break-word;
       }
 
       .event-title-with-prefix {
@@ -1016,6 +1021,7 @@ export function getCardStyles() {
         align-items: center;
         gap: clamp(4px, calc(var(--event-bubble-font-size, 11px) * 0.3), 7px);
         min-width: 0;
+        max-width: 100%;
       }
 
       .event-style-icon {

--- a/src/styles/card-styles.js
+++ b/src/styles/card-styles.js
@@ -1021,7 +1021,18 @@ export function getCardStyles() {
         align-items: center;
         gap: clamp(4px, calc(var(--event-bubble-font-size, 11px) * 0.3), 7px);
         min-width: 0;
+      }
+
+      .week-compact-event-title > .event-title-with-prefix {
         max-width: 100%;
+      }
+
+      .week-compact-event-title .event-title-prefix-friendly-name {
+        flex: 0 1 45%;
+        min-width: 0;
+        max-width: 45%;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
 
       .event-style-icon {


### PR DESCRIPTION
## Summary
- allow Week Compact event titles to wrap long slash-separated or otherwise unbroken text inside the event's padded content area
- constrain the shared title-prefix wrapper so optional icons and calendar prefixes cannot expand past the title container
- add a mobile-width Playwright regression using `Zoe’s orientation/meet the teacher` and assert both layout width and rendered text stay within the event padding
- regenerate the committed HACS/manual-install artifact

## Root cause
Week Compact titles relied only on normal line-breaking opportunities. A token such as `orientation/meet` could be wider than the available content width, so the browser painted it through the event's right padding and beyond the bubble. The title and optional prefix wrapper also lacked explicit maximum-width constraints.

## User impact
Long event titles now wrap within the event bubble instead of clipping or painting into the neighboring area. Normal titles retain their existing typography and line wrapping.

## Validation
- Rollup build completed successfully and regenerated `skylight-calendar-card.js`
- `node --check` passed for the authored styles, Playwright spec, source entry point, and generated artifact
- `git diff --check` passed
- Added a Playwright regression that measures the actual rendered text range against the event's padded boundary
- Local Playwright execution was blocked because this runtime could not download the Chromium archive; GitHub Actions should execute the browser test
- The Node suite was run; 422/437 tests passed under the runtime's UTC environment, with the remaining existing date/time and clipboard-sensitive tests failing independently of this CSS-only change