### PR TITLE
Fix swipe navigation when starting inside horizontally scrollable badge row

### DIFF
--- a/skylight-calendar-card.js
+++ b/skylight-calendar-card.js
@@ -9975,7 +9975,7 @@ function renderCalendarBadges({ badgeItems, hideCalendarNames = false, helpers }
 
   return `
       <div class="calendar-badges-container">
-        <div class="calendar-badges">
+        <div class="calendar-badges" data-swipe-navigation-exempt>
           ${badgeItems.map((badgeItem) => renderCalendarBadge({
             badgeItem,
             hideCalendarNames,
@@ -16665,6 +16665,28 @@ class SkylightCalendarCard extends HTMLElement {
     return !this._config.disable_swipe_controls && this._viewMode !== 'agenda';
   }
 
+  isSwipeNavigationExcludedTarget(target) {
+    if (typeof Element === 'undefined' || !(target instanceof Element)) {
+      return false;
+    }
+
+    if (target.closest('button, select, input, textarea, .event, .week-compact-event, .week-standard-event, .all-day-event, .day-badge-action, [data-day-badge-action-id], [data-swipe-navigation-exempt]')) {
+      return true;
+    }
+
+    const cardContainer = this._root?.querySelector('.calendar-container') || null;
+    let element = target;
+    while (element && element !== cardContainer) {
+      const maxHorizontalScroll = Math.max(0, (element.scrollWidth || 0) - (element.clientWidth || 0));
+      if (maxHorizontalScroll > 1 && element.closest?.('.week-standard-container') !== element) {
+        return true;
+      }
+      element = element.parentElement;
+    }
+
+    return false;
+  }
+
   canTriggerSwipePeriodNavigation(deltaX) {
     if (this._viewMode !== 'week-standard') {
       return true;
@@ -16708,8 +16730,7 @@ class SkylightCalendarCard extends HTMLElement {
       this._swipeStartX = touch.clientX;
       this._swipeStartY = touch.clientY;
       this._swipeTracking = true;
-      const eventTarget = event.target instanceof Element ? event.target : null;
-      this._swipeStartedOnInteractive = !!eventTarget?.closest('button, select, input, textarea, .event, .week-compact-event, .week-standard-event, .all-day-event, .day-badge-action, [data-day-badge-action-id]');
+      this._swipeStartedOnInteractive = this.isSwipeNavigationExcludedTarget(event.target);
     }, { passive: true });
 
     container.addEventListener('touchend', (event) => {

--- a/skylight-calendar-card.test.js
+++ b/skylight-calendar-card.test.js
@@ -4241,6 +4241,121 @@ test('day badge actions are treated as interactive swipe targets', () => {
   }
 });
 
+
+test('touch swipes that start in horizontal scroll regions do not navigate periods', () => {
+  const OriginalElement = global.Element;
+  class FakeElement {
+    constructor({ matchingSelectors = [], scrollWidth = 0, clientWidth = 0, parentElement = null } = {}) {
+      this.matchingSelectors = matchingSelectors;
+      this.scrollWidth = scrollWidth;
+      this.clientWidth = clientWidth;
+      this.parentElement = parentElement;
+    }
+    closest(selector) {
+      const selectors = selector.split(',').map((part) => part.trim());
+      return this.matchingSelectors.some((matchingSelector) => selectors.includes(matchingSelector)) ? this : null;
+    }
+  }
+  global.Element = FakeElement;
+
+  try {
+    const card = makeCard({ entities: ['calendar.family'] });
+    const handlers = {};
+    const container = new FakeElement({ matchingSelectors: ['.calendar-container'], scrollWidth: 320, clientWidth: 320 });
+    container.addEventListener = (eventName, callback) => { handlers[eventName] = callback; };
+    const badgeScroller = new FakeElement({ scrollWidth: 600, clientWidth: 280, parentElement: container });
+    const badge = new FakeElement({ parentElement: badgeScroller });
+    card._root = {
+      querySelector: (selector) => selector === '.calendar-container' ? container : null
+    };
+    card.shouldEnableSwipeControls = () => true;
+    card.canTriggerSwipePeriodNavigation = () => true;
+    card.canNavigateToPreviousPeriod = () => true;
+    let nextCalls = 0;
+    let previousCalls = 0;
+    card.navigateToNextPeriod = () => { nextCalls += 1; };
+    card.navigateToPreviousPeriod = () => { previousCalls += 1; };
+
+    card.attachSwipeControls();
+    handlers.touchstart({
+      target: badge,
+      touches: [{ clientX: 100, clientY: 20 }]
+    });
+    assert.equal(card._swipeStartedOnInteractive, true);
+
+    handlers.touchend({
+      changedTouches: [{ clientX: 20, clientY: 22 }]
+    });
+
+    assert.equal(nextCalls, 0);
+    assert.equal(previousCalls, 0);
+    assert.equal(card._swipeStartedOnInteractive, false);
+    assert.equal(card._swipeTracking, false);
+  } finally {
+    if (OriginalElement === undefined) {
+      delete global.Element;
+    } else {
+      global.Element = OriginalElement;
+    }
+  }
+});
+
+test('touch swipes outside excluded regions still navigate periods', () => {
+  const OriginalElement = global.Element;
+  class FakeElement {
+    constructor({ matchingSelectors = [], scrollWidth = 0, clientWidth = 0, parentElement = null } = {}) {
+      this.matchingSelectors = matchingSelectors;
+      this.scrollWidth = scrollWidth;
+      this.clientWidth = clientWidth;
+      this.parentElement = parentElement;
+    }
+    closest(selector) {
+      const selectors = selector.split(',').map((part) => part.trim());
+      return this.matchingSelectors.some((matchingSelector) => selectors.includes(matchingSelector)) ? this : null;
+    }
+  }
+  global.Element = FakeElement;
+
+  try {
+    const card = makeCard({ entities: ['calendar.family'] });
+    const handlers = {};
+    const container = new FakeElement({ matchingSelectors: ['.calendar-container'], scrollWidth: 320, clientWidth: 320 });
+    container.addEventListener = (eventName, callback) => { handlers[eventName] = callback; };
+    const dayCell = new FakeElement({ parentElement: container });
+    card._root = {
+      querySelector: (selector) => selector === '.calendar-container' ? container : null
+    };
+    card.shouldEnableSwipeControls = () => true;
+    card.canTriggerSwipePeriodNavigation = () => true;
+    card.canNavigateToPreviousPeriod = () => true;
+    let nextCalls = 0;
+    let previousCalls = 0;
+    card.navigateToNextPeriod = () => { nextCalls += 1; };
+    card.navigateToPreviousPeriod = () => { previousCalls += 1; };
+
+    card.attachSwipeControls();
+    handlers.touchstart({
+      target: dayCell,
+      touches: [{ clientX: 100, clientY: 20 }]
+    });
+    assert.equal(card._swipeStartedOnInteractive, false);
+
+    handlers.touchend({
+      changedTouches: [{ clientX: 20, clientY: 22 }]
+    });
+
+    assert.equal(nextCalls, 1);
+    assert.equal(previousCalls, 0);
+    assert.equal(card._swipeTracking, false);
+  } finally {
+    if (OriginalElement === undefined) {
+      delete global.Element;
+    } else {
+      global.Element = OriginalElement;
+    }
+  }
+});
+
 test('day badge helper module delegates preserve normalization and resolution behavior', () => {
   const card = makeCard({ entities: ['calendar.a'] });
   const block = card.normalizeDayBadgeBlock({

--- a/src/renderers/calendar-badge-renderer.js
+++ b/src/renderers/calendar-badge-renderer.js
@@ -3,7 +3,7 @@ export function renderCalendarBadges({ badgeItems, hideCalendarNames = false, he
 
   return `
       <div class="calendar-badges-container">
-        <div class="calendar-badges">
+        <div class="calendar-badges" data-swipe-navigation-exempt>
           ${badgeItems.map((badgeItem) => renderCalendarBadge({
             badgeItem,
             hideCalendarNames,

--- a/src/skylight-calendar-card.js
+++ b/src/skylight-calendar-card.js
@@ -5899,6 +5899,28 @@ class SkylightCalendarCard extends HTMLElement {
     return !this._config.disable_swipe_controls && this._viewMode !== 'agenda';
   }
 
+  isSwipeNavigationExcludedTarget(target) {
+    if (typeof Element === 'undefined' || !(target instanceof Element)) {
+      return false;
+    }
+
+    if (target.closest('button, select, input, textarea, .event, .week-compact-event, .week-standard-event, .all-day-event, .day-badge-action, [data-day-badge-action-id], [data-swipe-navigation-exempt]')) {
+      return true;
+    }
+
+    const cardContainer = this._root?.querySelector('.calendar-container') || null;
+    let element = target;
+    while (element && element !== cardContainer) {
+      const maxHorizontalScroll = Math.max(0, (element.scrollWidth || 0) - (element.clientWidth || 0));
+      if (maxHorizontalScroll > 1 && element.closest?.('.week-standard-container') !== element) {
+        return true;
+      }
+      element = element.parentElement;
+    }
+
+    return false;
+  }
+
   canTriggerSwipePeriodNavigation(deltaX) {
     if (this._viewMode !== 'week-standard') {
       return true;
@@ -5942,8 +5964,7 @@ class SkylightCalendarCard extends HTMLElement {
       this._swipeStartX = touch.clientX;
       this._swipeStartY = touch.clientY;
       this._swipeTracking = true;
-      const eventTarget = event.target instanceof Element ? event.target : null;
-      this._swipeStartedOnInteractive = !!eventTarget?.closest('button, select, input, textarea, .event, .week-compact-event, .week-standard-event, .all-day-event, .day-badge-action, [data-day-badge-action-id]');
+      this._swipeStartedOnInteractive = this.isSwipeNavigationExcludedTarget(event.target);
     }, { passive: true });
 
     container.addEventListener('touchend', (event) => {


### PR DESCRIPTION
### Motivation
- Root cause: the card-level touch swipe handler treated any single-finger `touchstart` as a potential navigation unless it started on a small set of interactive selectors, so swipes beginning inside the horizontally scrollable badge strip were incorrectly interpreted as month/week navigation on iOS rather than badge scrolling.
- The fix needs to exclude gestures that originate inside horizontally scrollable regions or explicitly marked exempt regions while preserving existing swipe navigation everywhere else and leaving desktop/mouse behavior unchanged.
- Regression risk is low because the change only adjusts the swipe-start exclusion logic; manual touch verification on iOS/Android is recommended (see test plan below).

### Description
- Added a reusable helper `isSwipeNavigationExcludedTarget(target)` that returns true when the `target` is an interactive element, is inside an ancestor marked with `data-swipe-navigation-exempt`, or has a horizontally scrollable ancestor (`scrollWidth > clientWidth`) (the week-standard schedule container is still handled by its existing edge-aware logic).
- Replaced the inline interactive-selector check in `attachSwipeControls()` with the new `isSwipeNavigationExcludedTarget` helper so swipe tracking is vetoed for exempt/scrollable targets on `touchstart`.
- Marked the main calendar badge scroller with a `data-swipe-navigation-exempt` attribute in `renderCalendarBadges` so the current badge row is explicitly opted-out and serves as the forward-compatible pattern for other horizontal scrollers.
- Added unit tests that assert: swipes that start inside a horizontal scroll region do not trigger period navigation, and swipes outside excluded regions still trigger navigation.

### Testing
- Built artifacts with `npm run build` and verified the generated artifact was updated successfully.
- Static checks `node --check src/skylight-calendar-card.js`, `node --check src/renderers/calendar-badge-renderer.js`, and `node --check skylight-calendar-card.js` all succeeded.
- Ran the full unit test suite with `npm test` and all tests passed (including new swipe tests). 
- Ran focused tests with `node --test --test-name-pattern "swipes|interactive swipe" skylight-calendar-card.test.js` and the new swipe-related tests passed.
- No visual/browser tests were modified; recommend manual verification on touch devices per the manual test plan: swipe the overflowing badge row (should scroll, not navigate), swipe elsewhere on the month/week views (should navigate), and verify week-standard schedule edge behavior remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8e1d262d008331934df2707c195eaf)